### PR TITLE
fix(ts): error in TS defs due to invalid use of generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ Please add unreleased changes in the following style:
 PR Title ([#123](link to my pr))
 ```
 
+fix: error in TS defs due to invalid use of generic ([#1744](https://github.com/react-native-mapbox-gl/maps/pull/1744))
 fix: add TypeScript type for MapViews's preferredFramesPerSecond prop ([#1717](https://github.com/react-native-mapbox-gl/maps/pull/1717))
 fix(example): update `/example` project (iOS only) to work with ARM-based Macs ([#1703](https://github.com/react-native-mapbox-gl/maps/pull/1703))
 
-fix(iOS): correct import of UIView+React.h header ([#1672](https://github.com/react-native-mapbox-gl/maps/pull/1672))
----
+## fix(iOS): correct import of UIView+React.h header ([#1672](https://github.com/react-native-mapbox-gl/maps/pull/1672))
 
 ## 8.5.0
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -164,8 +164,8 @@ declare namespace MapboxGL {
 
    class AnimatedPoint {
     constructor(point?: GeoJSON.Point);
-    longitude: ReactNative.Animated.Value<number>;
-    latitude: ReactNative.Animated.Value<number>;
+    longitude: ReactNative.Animated.Value;
+    latitude: ReactNative.Animated.Value;
     setValue: (point: GeoJSON.Point) => void;
     setOffset: (point: GeoJSON.Point) => void;
     flattenOffset: () => void;


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes issue with TS definitions caused by use of a generic on a non-generic type (ReactNative.Animated.Value, see [here](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-native/v0.63/index.d.ts#L8652) and [here](https://github.com/facebook/react-native/blob/8bd3edec88148d0ab1f225d2119435681fbbba33/Libraries/Animated/nodes/AnimatedValue.js#L90))

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I formatted JS and TS files with running `yarn lint:fix` in the root folder
- [x] I updated the documentation with running `yarn generate` in the root folder
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typings files (`index.d.ts`)
- [ ] I added/ updated a sample (`/example`)
