### PR TITLE
Update master refs to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,7 +14,7 @@ assignees: ''
 * Please respect and fill out the issue template
 * Before you report, please make sure you tested on a physical device
 * For build issues: Can you reproduce it on a clean install of the example app? Please include full steps to reproduce from `react-native init`
-* Please include standalone code sample - a single component with one MapView in it. Use [one of our example](https://github.com/rnmapbox/maps/blob/master/example/src/examples/PointInMapView.js) screens as a starging point.
+* Please include standalone code sample - a single component with one MapView in it. Use [one of our example](https://github.com/rnmapbox/maps/blob/main/example/src/examples/PointInMapView.js) screens as a starging point.
 * Use [discussions](https://github.com/rnmapbox/maps/discussions) or gitter and/or stack overflow for questions.
 
 If you want others to spend time on your issue, please make sure to first spend some time on the ticket. 
@@ -35,7 +35,7 @@ A clear and concise description of what the bug is.
 Steps to reproduce the behavior. 
 
 Please include a single standalone React Native component.  
-Use [our BugReportTemplate](https://github.com/rnmapbox/maps/blob/master/example/src/examples/BugReportTemplate.js) screens as a starting point.
+Use [our BugReportTemplate](https://github.com/rnmapbox/maps/blob/main/example/src/examples/BugReportTemplate.js) screens as a starting point.
 Please simplify the example as much as possible!
 
 Chances that a bug report will be investiagete and worked on are exponetially higher with a complete and _working_ repro BugTemplate!

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ Once you verified, that `master` isn't broken, go on and increase the `version` 
 
 ## Update the CHANGELOG accordingly
 
-Our [`CHANGELOG.md`](https://github.com/rnmapbox/maps/blob/master/CHANGELOG.md) should be updated whenever a PR is merged/ noteworthy changes are commited to `master`.  
+Our [`CHANGELOG.md`](https://github.com/rnmapbox/maps/blob/main/CHANGELOG.md) should be updated whenever a PR is merged/ noteworthy changes are commited to `master`.  
 Prior to a release, the changes should be documented under the `UNRELEASED` section.  
 Once it's clear, that a release is about to be published, move the items under `UNRELEASED` to _this_ releases sections.  
 Let your actions be guided by the previous release entries.

--- a/android/install.md
+++ b/android/install.md
@@ -132,7 +132,7 @@ allprojects {
 }
 ```
 
-Feel free to check out the `/example` projects [`android/build.gradle`](https://github.com/rnmapbox/maps/blob/master/example/android/build.gradle) for inspiration!
+Feel free to check out the `/example` projects [`android/build.gradle`](https://github.com/rnmapbox/maps/blob/main/example/android/build.gradle) for inspiration!
 
 <br>
 

--- a/example/README.md
+++ b/example/README.md
@@ -1,18 +1,18 @@
 
 <p align="center">
-  <a href="https://github.com/rnmapbox/maps/blob/master/example/src/examples/ChoroplethLayerByZoomLevel.js">
+  <a href="https://github.com/rnmapbox/maps/blob/main/example/src/examples/ChoroplethLayerByZoomLevel.js">
     <img  src="readme_assets/example_choropleth_layer.png"  width="175"/>
   </a>
-  <a href="https://github.com/rnmapbox/maps/blob/master/example/src/examples/EarthQuakes.js">
+  <a href="https://github.com/rnmapbox/maps/blob/main/example/src/examples/EarthQuakes.js">
     <img  src="readme_assets/example_clustering_earthquakes.png" width="175"/>
   </a>
-  <a href="https://github.com/rnmapbox/maps/blob/master/example/src/examples/Annotations/CustomCallout.tsx">
+  <a href="https://github.com/rnmapbox/maps/blob/main/example/src/examples/Annotations/CustomCallout.tsx">
     <img  src="readme_assets/example_custom_callout.png" width="175"/>
   </a>
-  <a href="https://github.com/rnmapbox/maps/blob/master/example/src/examples/DataDrivenCircleColors.js">
+  <a href="https://github.com/rnmapbox/maps/blob/main/example/src/examples/DataDrivenCircleColors.js">
     <img  src="readme_assets/example_data_driven_circle_colors.png" width="175"/>
   </a>
-  <a href="https://github.com/rnmapbox/maps/blob/master/example/src/examples/ImageOverlay.js">
+  <a href="https://github.com/rnmapbox/maps/blob/main/example/src/examples/ImageOverlay.js">
     <img  src="readme_assets/example_image_overlay.png" width="175"/>
   </a>
 </p>

--- a/example/README.md
+++ b/example/README.md
@@ -1,18 +1,18 @@
 
 <p align="center">
-  <a href="https://github.com/rnmapbox/maps/blob/main/example/src/examples/ChoroplethLayerByZoomLevel.js">
+  <a href="https://github.com/rnmapbox/maps/blob/main/example/src/examples/FillRasterLayer/ChoroplethLayerByZoomLevel.js">
     <img  src="readme_assets/example_choropleth_layer.png"  width="175"/>
   </a>
-  <a href="https://github.com/rnmapbox/maps/blob/main/example/src/examples/EarthQuakes.js">
+  <a href="https://github.com/rnmapbox/maps/blob/main/example/src/examples/SymbolCircleLayer/EarthQuakes.js">
     <img  src="readme_assets/example_clustering_earthquakes.png" width="175"/>
   </a>
   <a href="https://github.com/rnmapbox/maps/blob/main/example/src/examples/Annotations/CustomCallout.tsx">
     <img  src="readme_assets/example_custom_callout.png" width="175"/>
   </a>
-  <a href="https://github.com/rnmapbox/maps/blob/main/example/src/examples/DataDrivenCircleColors.js">
+  <a href="https://github.com/rnmapbox/maps/blob/main/example/src/examples/SymbolCircleLayer/DataDrivenCircleColors.js">
     <img  src="readme_assets/example_data_driven_circle_colors.png" width="175"/>
   </a>
-  <a href="https://github.com/rnmapbox/maps/blob/main/example/src/examples/ImageOverlay.js">
+  <a href="https://github.com/rnmapbox/maps/blob/main/example/src/examples/FillRasterLayer/ImageOverlay.js">
     <img  src="readme_assets/example_image_overlay.png" width="175"/>
   </a>
 </p>

--- a/plugin/src/withMapbox.ts
+++ b/plugin/src/withMapbox.ts
@@ -28,7 +28,7 @@ type InstallerBlockName = 'pre' | 'post';
  * Dangerously adds the custom installer hooks to the Podfile.
  * In the future this should be removed in favor of some custom hooks provided by Expo autolinking.
  *
- * https://github.com/rnmapbox/maps/blob/master/ios/install.md#react-native--0600
+ * https://github.com/rnmapbox/maps/blob/main/ios/install.md#react-native--0600
  * @param config
  * @returns
  */


### PR DESCRIPTION
## Description

Changes references from `master` to `main` fixing broken links, also fixes example screenshot links to code

## Checklist

<!-- Check completed item: [X] -->

- [ ] I have tested this on a device/simulator for each compatible OS
- [ ] I formatted JS and TS files with running `yarn lint:fix` in the root folder
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typings files (`index.d.ts`)
- [ ] I added/ updated a sample (`/example`)
