### PR TITLE
Fix kotlin error with - (1.6.* or 1.5.3*)

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -16,6 +16,7 @@ buildscript {
             RNMapboxMapsImpl = "maplibre"
         } else if (System.getenv('CI_MAP_IMPL').equals('mapbox')) {
             RNMapboxMapsImpl = "mapbox"
+            kotlinVersion = '1.5.21'
         } else if (System.getenv('CI_MAP_IMPL').equals('mapbox-gl')) {
             RNMapboxMapsImpl = "mapbox-gl"
         }


### PR DESCRIPTION
Try to fix build error on CI

```
> Task :rctmgl:compileDebugKotlin FAILED
[180](https://github.com/rnmapbox/maps/runs/5573673396?check_suite_focus=true#step:8:180)
    class com.mapbox.rctmgl.components.mapview.RCTMGLMapView, unresolved supertypes: MapView, OnMapClickListener, OnMapLongClickListener, OnCameraIsChangingListener, OnCameraDidChangeListener, OnDidFailLoadingMapListener, OnDidFinishLoadingMapListener, OnWillStartRenderingFrameListener, OnDidFinishRenderingFrameListener, OnWillStartRenderingMapListener, OnDidFinishRenderingMapListener, OnDidFinishLoadingStyleListener, OnStyleImageMissingListener
[181](https://github.com/rnmapbox/maps/runs/5573673396?check_suite_focus=true#step:8:181)
    class com.mapbox.rctmgl.components.annotation.MarkerViewManager, unresolved supertypes: MarkerViewManager
[182](https://github.com/rnmapbox/maps/runs/5573673396?check_suite_focus=true#step:8:182)

[183](https://github.com/rnmapbox/maps/runs/5573673396?check_suite_focus=true#step:8:183)
e: /home/runner/work/maps/maps/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/styles/terrain/RCTMGLTerrain.kt: (43, 35): Cannot access 'MapView' which is a supertype of 'com.mapbox.rctmgl.components.mapview.RCTMGLMapView'. Check your module classpath for missing or conflicting dependencies
[184](https://github.com/rnmapbox/maps/runs/5573673396?check_suite_focus=true#step:8:184)
e: /home/runner/work/maps/maps/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/styles/terrain/RCTMGLTerrain.kt: (43, 35): Cannot access 'MapboxMap.OnMapClickListener' which is a supertype of 'com.mapbox.rctmgl.components.mapview.RCTMGLMapView'. Check your module classpath for missing or conflicting dependencies
```
