### PR TITLE
Fix MapLibre with mapbox maps

### DIFF
--- a/android/rctmgl/src/main/java-maplibre/com/mapbox/rctmgl/impl/InstanceManagerImpl.java
+++ b/android/rctmgl/src/main/java-maplibre/com/mapbox/rctmgl/impl/InstanceManagerImpl.java
@@ -2,10 +2,11 @@ package com.mapbox.rctmgl.impl;
 
 import android.content.Context;
 import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.WellKnownTileServer;
 
 public class InstanceManagerImpl {
   public static void getInstance(Context context, String accessToken) {
-    Mapbox.getInstance(context);
+    Mapbox.getInstance(context, accessToken, WellKnownTileServer.Mapbox);
   }
 
   public static String getAccessToken() {


### PR DESCRIPTION
## Description

Without this change the build in mapbox styles don't work anymore with a valid mapbox key.

Tested the example app with a valid access key and a custom titleserver without a custom key both work now.

Only getAccessToken will not work on MapLibre, i don't know how to fix that. 

## Checklist

- [x ] I have tested this on a device/simulator for each compatible OS
