### PR TITLE
Expo/ios RNMapboxMapsDownloadToken support

### DIFF
--- a/plugin/build/withMapbox.d.ts
+++ b/plugin/build/withMapbox.d.ts
@@ -4,8 +4,8 @@ export declare type MapboxPlugProps = {
     RNMapboxMapsImpl?: string;
     RNMapboxMapsDownloadToken?: string;
 };
-export declare function applyCocoaPodsModifications(contents: string, { RNMapboxMapsImpl }: MapboxPlugProps): string;
-export declare function addConstantBlock(src: string, RNMapboxMapsImpl?: string): string;
+export declare function applyCocoaPodsModifications(contents: string, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken }: MapboxPlugProps): string;
+export declare function addConstantBlock(src: string, RNMapboxMapsImpl?: string, RNMapboxMapsDownloadToken?: string): string;
 export declare function addInstallerBlock(src: string, blockName: InstallerBlockName): string;
 export declare function addMapboxInstallerBlock(src: string, blockName: InstallerBlockName): string;
 /**

--- a/plugin/install.md
+++ b/plugin/install.md
@@ -2,7 +2,7 @@
 
 > This package cannot be used in the "Expo Go" app because [it requires custom native code](https://docs.expo.io/workflow/customizing/).
 
-First install the package with yarn, npm, or [`expo install`](https://docs.expo.io/workflow/expo-cli/#expo-install).
+First install the package with yarn, npm, or [`expo install rnmapbox/maps#main`](https://docs.expo.io/workflow/expo-cli/#expo-install).
 
 ```sh
 expo install @rnmapbox/maps
@@ -27,9 +27,23 @@ After installing this npm package, add the [config plugin](https://docs.expo.io/
 
 Next, rebuild your app as described in the ["Adding custom native code"](https://docs.expo.io/workflow/customizing/) guide.
 
-## API
+For `mapbox` or `mapbox-gl` you'll need to provide `RNMapboxMapsDownloadToken` as well.
 
-This plugin doesn't currently provide any additional properties for customization. The plugin simply generates the pre-install block in the `ios/Podfile` (the post-install block is not required for Expo support). No additional changes are done on Android.
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "@rnmapbox/maps",
+        {
+          "RNMapboxMapsImpl": "maplibre",
+          "RNMapboxMapsDownloadToken": "sk.ey...qg"
+        }
+      ]
+    ]
+  }
+}
+```
 
 ## Manual Setup
 


### PR DESCRIPTION
Normally credentials are configured via `.netrc` for downloading Mapbox. But with expo `eas` this is not possible. 

We now support `RNMapboxMapsDownloadToken` plugin config on both iOS and android for expo builds.