### PR TITLE
v10 iOS: Wait for style load before adding layers, show/hide layer implemented

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLCamera.swift
+++ b/ios/RCTMGL-v10/RCTMGLCamera.swift
@@ -3,8 +3,10 @@ import MapboxMaps
 import Turf
 
 protocol RCTMGLMapComponent {
-  func addToMap(_ map: RCTMGLMapView)
+  func addToMap(_ map: RCTMGLMapView, style: Style)
   func removeFromMap(_ map: RCTMGLMapView)
+  
+  func waitForStyleLoad() -> Bool
 }
 
 
@@ -85,7 +87,13 @@ open class RCTMGLMapComponentBase : UIView, RCTMGLMapComponent {
     }
   }
   
-  func addToMap(_ map: RCTMGLMapView) {
+  // MARK: - RCTMGLMapComponent
+
+  func waitForStyleLoad() -> Bool {
+    return false
+  }
+  
+  func addToMap(_ map: RCTMGLMapView, style: Style) {
     _mapCallbacks.forEach { callback in
         callback(map)
     }
@@ -273,8 +281,8 @@ class RCTMGLCamera : RCTMGLMapComponentBase, LocationConsumer {
     _updateCamera()
   }
   
-  override func addToMap(_ map: RCTMGLMapView) {
-    super.addToMap(map)
+  override func addToMap(_ map: RCTMGLMapView, style: Style) {
+    super.addToMap(map, style: style)
     map.reactCamera = self
   }
   

--- a/ios/RCTMGL-v10/RCTMGLFillLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLFillLayer.swift
@@ -26,9 +26,8 @@ class RCTMGLFillLayer: RCTMGLVectorLayer {
   }
 
   override func addStyles() {
-    print("::addStyles ")
     if let style : Style = self.style {
-      let styler =  RCTMGLStyle(style: self.style!)
+      let styler = RCTMGLStyle(style: self.style!)
       styler.bridge = self.bridge
       
       if var styleLayer = self.styleLayer as? FillLayer {

--- a/ios/RCTMGL-v10/RCTMGLImages.swift
+++ b/ios/RCTMGL-v10/RCTMGLImages.swift
@@ -5,7 +5,6 @@ class RCTMGLImages : UIView, RCTMGLMapComponent {
   var bridge : RCTBridge! = nil
   var remoteImages : [String:String] = [:]
   
-  
   @objc
   var onImageMissing: RCTBubblingEventBlock? = nil
   
@@ -15,12 +14,18 @@ class RCTMGLImages : UIView, RCTMGLMapComponent {
   @objc
   var nativeImages: [String] = []
   
-  func addToMap(_ map: RCTMGLMapView) {
+  // MARK: - RCTMGLMapComponent
+
+  func waitForStyleLoad() -> Bool {
+    return false
+  }
+  
+  func addToMap(_ map: RCTMGLMapView, style: Style) {
     map.images.append(self)
     map.setupEvents()
     
-    self.addNativeImages(style: map.mapboxMap.style, nativeImages: nativeImages)
-    self.addRemoteImages(style: map.mapboxMap.style, remoteImages: images)
+    self.addNativeImages(style: style, nativeImages: nativeImages)
+    self.addRemoteImages(style: style, remoteImages: images)
   }
   
   func removeFromMap(_ map: RCTMGLMapView) {

--- a/ios/RCTMGL-v10/RCTMGLLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLLayer.swift
@@ -61,6 +61,11 @@ class RCTMGLLayer : UIView, RCTMGLMapComponent, RCTMGLSourceConsumer {
   
   var styleLayer: Layer? = nil
   
+  // MARK: - RCTMGLMapComponent
+  func waitForStyleLoad() -> Bool {
+    return true
+  }
+  
   func removeAndReaddLayer() {
     if let style = style {
       self.removeFromMap(style)
@@ -76,9 +81,13 @@ class RCTMGLLayer : UIView, RCTMGLMapComponent, RCTMGLSourceConsumer {
   }
   
   func addStylesAndUpdate() {
+    guard styleLayer != nil else {
+      return
+    }
+
     addStyles()
     if let style = style,
-       let map = map {
+      let map = map {
       if style.styleManager.styleLayerExists(forLayerId: id) {
         self.updateLayer(map)
       }
@@ -139,6 +148,7 @@ class RCTMGLLayer : UIView, RCTMGLMapComponent, RCTMGLSourceConsumer {
   
   func addToMap(_ map: RCTMGLMapView) {
     //
+    self.style = map.mapboxMap.style
     self.map = map
   }
   

--- a/ios/RCTMGL-v10/RCTMGLLight.swift
+++ b/ios/RCTMGL-v10/RCTMGLLight.swift
@@ -36,8 +36,14 @@ class RCTMGLLight: UIView, RCTMGLMapComponent {
   func isAddedToMap() -> Bool {
     return map != nil
   }
+  
+  // MARK: - RCTMGLMapComponent
 
-  func addToMap(_ map: RCTMGLMapView) {
+  func waitForStyleLoad() -> Bool {
+    return true
+  }
+
+  func addToMap(_ map: RCTMGLMapView, style: Style) {
     self.map = map.mapboxMap
     if (reactStyle != nil) {
       addStyles()

--- a/ios/RCTMGL-v10/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL-v10/RCTMGLMapViewManager.m
@@ -17,4 +17,11 @@ RCT_EXTERN_METHOD(queryTerrainElevation:(nonnull NSNumber*)reactTag
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(setSourceVisibility:(nonnull NSNumber *)reactTag
+                  visible:(BOOL)visible
+                  sourceId:(nonnull NSString*)sourceId
+                  sourceLayerId:(nullable NSString*)sourceLayerId
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 @end

--- a/ios/RCTMGL-v10/RCTMGLMapViewManager.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapViewManager.swift
@@ -56,4 +56,25 @@ class RCTMGLMapViewManager: RCTViewManager {
         }
       }
     }
+  
+  @objc
+  func setSourceVisibility(_ reactTag: NSNumber,
+                      visible: Bool,
+                      sourceId: String,
+                      sourceLayerId: String?,
+                      resolver: @escaping RCTPromiseResolveBlock,
+                      rejecter: @escaping RCTPromiseRejectBlock) -> Void {
+    self.bridge.uiManager.addUIBlock { (manager, viewRegistry) in
+      let view = viewRegistry![reactTag]
+      
+      guard let view = view! as? RCTMGLMapView else {
+        RCTLogError("Invalid react tag, could not find RCTMGLMapView");
+        rejecter("setSourceVisibility", "Unknown find reactTag: \(reactTag)", nil)
+        return;
+      }
+      
+      view.setSourceVisibility(visible, sourceId: sourceId, sourceLayerId:sourceLayerId)
+      resolver(nil)
+    }
+  }
 }

--- a/ios/RCTMGL-v10/RCTMGLMarkerView.swift
+++ b/ios/RCTMGL-v10/RCTMGLMarkerView.swift
@@ -5,7 +5,13 @@ class RCTMGLMarkerView : UIView, RCTMGLMapComponent {
   
   var map: RCTMGLMapView? = nil
   
-  func addToMap(_ map: RCTMGLMapView) {
+  // MARK: - RCTMGLMapComponent
+
+  func waitForStyleLoad() -> Bool {
+    return true
+  }
+  
+  func addToMap(_ map: RCTMGLMapView, style: Style) {
     self.map = map
     let point = point()!
     try! viewAnnotations()?.add(self, options: ViewAnnotationOptions.init(geometry: Geometry.point(point), width: self.bounds.width, height: self.bounds.height, associatedFeatureId: nil, allowOverlap: true, visible: true, anchor: .center, offsetX: 0, offsetY: 0, selected: false))

--- a/ios/RCTMGL-v10/RCTMGLPointAnnotation.swift
+++ b/ios/RCTMGL-v10/RCTMGLPointAnnotation.swift
@@ -175,7 +175,13 @@ class RCTMGLPointAnnotation : UIView, RCTMGLMapComponent {
 
   var map: RCTMGLMapView? = nil
   
-  func addToMap(_ map: RCTMGLMapView) {
+  // MARK: - RCTMGLMapComponent
+
+  func waitForStyleLoad() -> Bool {
+    return true
+  }
+  
+  func addToMap(_ map: RCTMGLMapView, style: Style) {
     self.map = map
     self.map?.pointAnnotationManager.add(annotation)
   }

--- a/ios/RCTMGL-v10/RCTMGLSource.swift
+++ b/ios/RCTMGL-v10/RCTMGLSource.swift
@@ -41,11 +41,16 @@ class RCTMGLSource : UIView, RCTMGLMapComponent {
     }
   }
   
-  func addToMap(_ map: RCTMGLMapView) {
+  // MARK: - RCTMGLMapComponent
+
+  func waitForStyleLoad() -> Bool {
+    return true
+  }
+  
+  func addToMap(_ map: RCTMGLMapView, style: Style) {
     self.map = map
     
     map.onMapStyleLoaded { mapboxMap in
-      let style = mapboxMap.style
       if style.sourceExists(withId: self.id) {
         self.source = try! style.source(withId: self.id)
       } else {

--- a/ios/RCTMGL-v10/RCTMGLStyleValue.swift
+++ b/ios/RCTMGL-v10/RCTMGLStyleValue.swift
@@ -37,7 +37,7 @@ class RCTMGLStyleValue {
   }
   
   func isVisible() -> Value<Visibility> {
-    return Value.constant(.visible)
+    return mglStyleValueEnum()
   }
   
   func getTransition() -> StyleTransition {
@@ -254,10 +254,8 @@ class RCTMGLStyleValue {
   }
   
   func mglStyleValueEnum<Enum : RawRepresentable>() -> Value<Enum> where Enum.RawValue == String {
-    print("Enum: \(value)")
     if let value = value as? Dictionary<String,Any> {
       let value = RCTMGLStyleValue.convert(value["stylevalue"] as! [String:Any])
-      print("###: \(value) \(Enum(rawValue: value as! String))")
       return Value.constant(Enum(rawValue: value as! String)!)
     } else {
       return Value.constant(Enum(rawValue: value as! String)!)

--- a/ios/RCTMGL-v10/RCTMGLTerrain.swift
+++ b/ios/RCTMGL-v10/RCTMGLTerrain.swift
@@ -17,6 +17,10 @@ class RCTMGLTerrain : UIView, RCTMGLMapComponent, RCTMGLSourceConsumer {
   @objc var sourceID: String? = nil
   
   @objc var exaggeration : Any? = nil
+  
+  func waitForStyleLoad() -> Bool {
+    return true
+  }
 
   func makeTerrain() -> Terrain {
     print("=> sourceID \(sourceID)")

--- a/javascript/utils/index.js
+++ b/javascript/utils/index.js
@@ -79,6 +79,9 @@ export function runNativeCommand(module, name, nativeRef, args = []) {
     );
   }
 
+  if (!managerInstance[name]) {
+    throw new Error(`Could not find ${name} for ${module}`);
+  }
   return managerInstance[name](handle, ...args);
 }
 


### PR DESCRIPTION
v10 iOS, fixes the 2 examples `ShowAndHideLayer.js` and `SourceLayerVisibility`

1. Allow components (most of them for now except camera), to defer addToMap after style has loaded. This is required for layers referencing existing layers in the style
2. implement `setSourceVisibility`
3. Fix visibility style constant