### PR TITLE
Only wait for style if it has not loaded yet (v10, iOS)

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLMapView.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapView.swift
@@ -122,6 +122,7 @@ open class RCTMGLMapView : MapView {
   var sources : [RCTMGLSource] = []
   
   var onStyleLoadedComponents: [RCTMGLMapComponent] = []
+  var styleLoaded: Bool = false
   
   var _pendingInitialLayout = true
   
@@ -215,7 +216,7 @@ open class RCTMGLMapView : MapView {
     
   @objc open override func insertReactSubview(_ subview: UIView!, at atIndex: Int) {
     if let mapComponent = subview as? RCTMGLMapComponent {
-      if mapComponent.waitForStyleLoad() {
+      if !styleLoaded && mapComponent.waitForStyleLoad() {
         onStyleLoadedComponents.append(mapComponent)
       } else {
         mapComponent.addToMap(self, style: self.mapboxMap.style)
@@ -269,6 +270,7 @@ open class RCTMGLMapView : MapView {
       self.onStyleLoadedComponents.forEach { (component) in
         component.addToMap(self, style: self.mapboxMap.style)
       }
+      self.styleLoaded = true
       self.onStyleLoadedComponents = []
     })
   }


### PR DESCRIPTION
## Description

Fixes the freshly introduced "Wait for style" loading mechanism on iOS.

As the onStyleLoadedComponents array is only went through once after the mapLoaded event, layers added after this event are not added to the map.

This is solved by adding a styleLoaded attribute.

## Checklist

- [X] I have tested this on a device/simulator for each compatible OS
- [] I formatted JS and TS files with running `yarn lint:fix` in the root folder
- [] I updated the documentation with running `yarn generate` in the root folder
- [] I mentioned this change in `CHANGELOG.md`
- [] I updated the typings files (`index.d.ts`)
- [] I added/ updated a sample (`/example`)
