### PR TITLE
Fixing unmounting of layers during runtime (v10, iOS)

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLMapView.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapView.swift
@@ -224,6 +224,8 @@ open class RCTMGLMapView : MapView {
     if let source = subview as? RCTMGLSource {
       sources.append(source)
     }
+
+    super.insertReactSubview(subview, at: atIndex)
   }
   
   @objc open override func removeReactSubview(_ subview:UIView!) {
@@ -233,6 +235,8 @@ open class RCTMGLMapView : MapView {
     if let source = subview as? RCTMGLSource {
       sources.removeAll { $0 == source }
     }
+
+    super.removeReactSubview(subview)
   }
 
   public required init(frame:CGRect) {


### PR DESCRIPTION
## Description

In the new swift implementation, the MapView's removeReactSubview is never called by the RTCManager, resulting in removed React Components not being unmounted from the map.

To solve this, the corresponding super methods are called resulting in the removeReactSubview method being called and layers removed from the map.

## Checklist

- [X] I have tested this on a device/simulator for each compatible OS
- [ ] I formatted JS and TS files with running `yarn lint:fix` in the root folder
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typings files (`index.d.ts`)
- [ ] I added/ updated a sample (`/example`)

## Example code

```javascript
const App = () => {
  const [visible, setVisible] = useState(false)

  return (
    <MapView
      onPress={() => setVisible(!visible)}
      style={{flex: 1}}>

      {visible && <RasterSource
        id="source"
        tileUrlTemplates={['https://stamen-tiles.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.jpg']}>

        <RasterLayer
          id="raster"
          style={{rasterOpacity: 0.5}}
        />
      </RasterSource>}
    </MapView>
  )
}
```