### PR TITLE
Allowing ability to set Padding as stop

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLCamera.swift
+++ b/ios/RCTMGL-v10/RCTMGLCamera.swift
@@ -232,6 +232,15 @@ class RCTMGLCamera : RCTMGLMapComponentBase, LocationConsumer {
       result.camera.bearing = CLLocationDirection(bearing)
     }
 
+    let padding = UIEdgeInsets(
+      top: stop["paddingTop"] as? Double ?? 0.0,
+      left: stop["paddingLeft"] as? Double ?? 0.0,
+      bottom: stop["paddingBottom"] as? Double ?? 0.0,
+      right: stop["paddingRight"] as? Double ?? 0.0
+    )
+    result.camera.padding = padding
+
+
     let duration: TimeInterval? = {
       if let d = stop["duration"] as? Double {
         return self.toTimeInterval(d)


### PR DESCRIPTION
Fixes issue where padding is not respected when using .setCamera()

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes issue where padding not respected when used in Camera Stops

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I formatted JS and TS files with running `yarn lint:fix` in the root folder
- [x] I updated the documentation with running `yarn generate` in the root folder
- [x] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typings files (`index.d.ts`)
- [x] I added/ updated a sample (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
