### PR TITLE
Add handlers for MapViews zoom/scroll/rotate/pitchEnabled props (v10, iOS)

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLMapView.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapView.swift
@@ -117,11 +117,6 @@ open class RCTMGLMapView : MapView {
   var reactOnPress : RCTBubblingEventBlock? = nil
   var reactOnMapChange : RCTBubblingEventBlock? = nil
 
-  var reactZoomEnabled : Bool = true
-  var reactScrollEnabled : Bool = true
-  var reactRotateEnabled : Bool = true
-  var reactPitchEnabled : Bool = true
-
   var reactCamera : RCTMGLCamera? = nil
   var images : [RCTMGLImages] = []
   var sources : [RCTMGLSource] = []

--- a/ios/RCTMGL-v10/RCTMGLMapView.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapView.swift
@@ -116,7 +116,12 @@ public func dictionaryFrom(_ from: Turf.Feature?) throws -> [String:Any]? {
 open class RCTMGLMapView : MapView {
   var reactOnPress : RCTBubblingEventBlock? = nil
   var reactOnMapChange : RCTBubblingEventBlock? = nil
-  
+
+  var reactZoomEnabled : Bool = true
+  var reactScrollEnabled : Bool = true
+  var reactRotateEnabled : Bool = true
+  var reactPitchEnabled : Bool = true
+
   var reactCamera : RCTMGLCamera? = nil
   var images : [RCTMGLImages] = []
   var sources : [RCTMGLSource] = []
@@ -172,7 +177,30 @@ open class RCTMGLMapView : MapView {
       self.fireEvent(event: event, callback: self.reactOnMapChange!)
     })
   }
-    
+
+  @objc func setReactZoomEnabled(_ value: Bool) {
+    self.mapView.gestures.options.quickZoomEnabled = value
+    self.mapView.gestures.options.doubleTapToZoomInEnabled = value
+
+    // TODO: Introduced in Mapbox Maps SDK v10.4
+    // self.mapView.gestures.options.pinchZoomEnabled = value
+  }
+
+  @objc func setReactScrollEnabled(_ value: Bool) {
+    self.mapView.gestures.options.panEnabled = value
+
+    // TODO: Introduced in Mapbox Maps SDK v10.4
+    // self.mapView.gestures.options.pitchPanEnabled = value
+  }
+
+  @objc func setReactRotateEnabled(_ value: Bool) {
+    self.mapView.gestures.options.pinchRotateEnabled = value
+  }
+
+  @objc func setReactPitchEnabled(_ value: Bool) {
+    self.mapView.gestures.options.pitchEnabled = value
+  }
+
   func fireEvent(event: RCTMGLEvent, callback: @escaping RCTBubblingEventBlock) {
     callback(event.toJSON())
   }

--- a/ios/RCTMGL-v10/RCTMGLMapView.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapView.swift
@@ -176,16 +176,12 @@ open class RCTMGLMapView : MapView {
   @objc func setReactZoomEnabled(_ value: Bool) {
     self.mapView.gestures.options.quickZoomEnabled = value
     self.mapView.gestures.options.doubleTapToZoomInEnabled = value
-
-    // TODO: Introduced in Mapbox Maps SDK v10.4
-    // self.mapView.gestures.options.pinchZoomEnabled = value
+    self.mapView.gestures.options.pinchZoomEnabled = value
   }
 
   @objc func setReactScrollEnabled(_ value: Bool) {
     self.mapView.gestures.options.panEnabled = value
-
-    // TODO: Introduced in Mapbox Maps SDK v10.4
-    // self.mapView.gestures.options.pitchPanEnabled = value
+    self.mapView.gestures.options.pinchPanEnabled = value
   }
 
   @objc func setReactRotateEnabled(_ value: Bool) {

--- a/ios/RCTMGL-v10/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL-v10/RCTMGLMapViewManager.m
@@ -7,6 +7,11 @@ RCT_REMAP_VIEW_PROPERTY(styleURL, reactStyleURL, NSString)
 RCT_REMAP_VIEW_PROPERTY(onPress, reactOnPress, RCTBubblingEventBlock)
 RCT_REMAP_VIEW_PROPERTY(onMapChange, reactOnMapChange, RCTBubblingEventBlock)
 
+RCT_REMAP_VIEW_PROPERTY(zoomEnabled, reactZoomEnabled, BOOL)
+RCT_REMAP_VIEW_PROPERTY(scrollEnabled, reactScrollEnabled, BOOL)
+RCT_REMAP_VIEW_PROPERTY(rotateEnabled, reactRotateEnabled, BOOL)
+RCT_REMAP_VIEW_PROPERTY(pitchEnabled, reactPitchEnabled, BOOL)
+
 RCT_EXTERN_METHOD(takeSnap:(nonnull NSNumber*)reactTag
                   writeToDisk:(BOOL)writeToDisk
                   resolver:(RCTPromiseResolveBlock)resolve


### PR DESCRIPTION
## Description

Setting the MapView's ```zoomEnabled```, ```scrollEnabled```, ```rotateEnabled``` and ```pitchEnabled``` props was not handled by the swift side of things yet.

Reminder here: as soon as rnmapbox will migrate to the 10.4 sdk, additional [GestureOptions](https://docs.mapbox.com/ios/maps/api/10.4.0/Structs/GestureOptions.html) can be set (as prepared in the code)

## Checklist

- [X] I have tested this on a device/simulator for each compatible OS
- [ ] I mentioned this change in `CHANGELOG.md`

## Code example

```javascript
<MapView
  rotateEnabled={false}
  pitchEnabled={false}
  zoomEnabled={false}
  scrollEnabled={false}
/>
```
