### PR TITLE
Add handler and documentation for MapView's scaleBarEnabled prop

### DIFF
--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -20,6 +20,7 @@
 | tintColor | `union` | `none` | `false` | MapView's tintColor |
 | logoEnabled | `bool` | `true` | `false` | Enable/Disable the logo on the map. |
 | logoPosition | `union` | `none` | `false` | Adds logo offset, e.g. `{top: 8, left: 8}` will put the logo in top-left corner of the map |
+| scaleBarEnabled | `bool` | `none` | `false` | Enable/Disable the scale bar from appearing on the map |
 | compassEnabled | `bool` | `none` | `false` | Enable/Disable the compass from appearing on the map |
 | compassViewPosition | `number` | `none` | `false` | Change corner of map the compass starts at. 0: TopLeft, 1: TopRight, 2: BottomLeft, 3: BottomRight |
 | compassViewMargins | `object` | `none` | `false` | Add margins to the compass with x and y values |

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -20,7 +20,7 @@
 | tintColor | `union` | `none` | `false` | MapView's tintColor |
 | logoEnabled | `bool` | `true` | `false` | Enable/Disable the logo on the map. |
 | logoPosition | `union` | `none` | `false` | Adds logo offset, e.g. `{top: 8, left: 8}` will put the logo in top-left corner of the map |
-| scaleBarEnabled | `bool` | `none` | `false` | Enable/Disable the scale bar from appearing on the map |
+| scaleBarEnabled | `bool` | `true` | `false` | Enable/Disable the scale bar from appearing on the map |
 | compassEnabled | `bool` | `none` | `false` | Enable/Disable the compass from appearing on the map |
 | compassViewPosition | `number` | `none` | `false` | Change corner of map the compass starts at. 0: TopLeft, 1: TopRight, 2: BottomLeft, 3: BottomRight |
 | compassViewMargins | `object` | `none` | `false` | Add margins to the compass with x and y values |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2998,6 +2998,13 @@
         "description": "Adds logo offset, e.g. `{top: 8, left: 8}` will put the logo in top-left corner of the map"
       },
       {
+        "name": "scaleBarEnabled",
+        "required": false,
+        "type": "bool",
+        "default": "true",
+        "description": "Enable/Disable the scale bar from appearing on the map"
+      },
+      {
         "name": "compassEnabled",
         "required": false,
         "type": "bool",

--- a/index.d.ts
+++ b/index.d.ts
@@ -460,6 +460,7 @@ export interface MapViewProps extends ViewProps {
   styleJSON?: string;
   preferredFramesPerSecond?: number;
   localizeLabels?: boolean;
+  scaleBarEnabled?: boolean;
   zoomEnabled?: boolean;
   scrollEnabled?: boolean;
   pitchEnabled?: boolean;

--- a/ios/RCTMGL-v10/RCTMGLMapView.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapView.swift
@@ -198,6 +198,10 @@ open class RCTMGLMapView : MapView {
     self.mapView.gestures.options.pitchEnabled = value
   }
 
+  @objc func setReactScaleBarEnabled(_ value: Bool) {
+    self.mapView.ornaments.options.scaleBar.visibility = value ? .visible : .hidden
+  }
+    
   func fireEvent(event: RCTMGLEvent, callback: @escaping RCTBubblingEventBlock) {
     callback(event.toJSON())
   }

--- a/ios/RCTMGL-v10/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL-v10/RCTMGLMapViewManager.m
@@ -12,6 +12,7 @@ RCT_REMAP_VIEW_PROPERTY(zoomEnabled, reactZoomEnabled, BOOL)
 RCT_REMAP_VIEW_PROPERTY(scrollEnabled, reactScrollEnabled, BOOL)
 RCT_REMAP_VIEW_PROPERTY(rotateEnabled, reactRotateEnabled, BOOL)
 RCT_REMAP_VIEW_PROPERTY(pitchEnabled, reactPitchEnabled, BOOL)
+RCT_REMAP_VIEW_PROPERTY(scaleBarEnabled, reactScaleBarEnabled, BOOL)
 
 RCT_EXTERN_METHOD(takeSnap:(nonnull NSNumber*)reactTag
                   writeToDisk:(BOOL)writeToDisk

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -149,6 +149,11 @@ class MapView extends NativeBridgeComponent(React.Component) {
     ]),
 
     /**
+     * Enable/Disable the scale bar from appearing on the map
+     */
+    scaleBarEnabled: PropTypes.bool,
+
+    /**
      * Enable/Disable the compass from appearing on the map
      */
     compassEnabled: PropTypes.bool,
@@ -296,6 +301,7 @@ class MapView extends NativeBridgeComponent(React.Component) {
     rotateEnabled: true,
     attributionEnabled: true,
     logoEnabled: true,
+    scaleBarEnabled: true,
     surfaceView: false,
     regionWillChangeDebounceTime: 10,
     regionDidChangeDebounceTime: 500,


### PR DESCRIPTION
## Description

v10 comes with a scale bar in the top left - this PR adds a ```scaleBarEnabled``` prop handler to the MapView, allowing to enable or disable the scale bar.

## Checklist

- [X] I have tested this on a device/simulator for each compatible OS
- [X] I formatted JS and TS files with running yarn lint:fix in the root folder
- [X] I updated the documentation with running yarn generate in the root folder
- [ ] I mentioned this change in CHANGELOG.md
- [X] I updated the typings files (index.d.ts)

## Code example

```javascript
<MapView scaleBarEnabled={false} />
```