### PR TITLE
Add listener to Layer's filter prop to allow update during runtime (v10, iOS)

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLLayer.swift
@@ -20,7 +20,15 @@ class RCTMGLLayer : UIView, RCTMGLMapComponent, RCTMGLSourceConsumer {
   
   var style: Style? = nil
 
-  @objc var filter : Array<Any>? = nil
+  @objc var filter : Array<Any>? = nil {
+    didSet {
+      if self.styleLayer != nil {
+        self.setOptions(&self.styleLayer!)
+        self.removeAndReaddLayer()
+      }
+    }
+  }
+  
   @objc var id: String! = nil
   @objc var sourceID: String? = nil
   
@@ -129,7 +137,7 @@ class RCTMGLLayer : UIView, RCTMGLMapComponent, RCTMGLSourceConsumer {
       }
     }
   }
-  
+
   func updateLayer(_ map: RCTMGLMapView) {
     if let style = style, let _ = styleLayer {
       apply(style: style)
@@ -204,9 +212,13 @@ class RCTMGLLayer : UIView, RCTMGLMapComponent, RCTMGLSourceConsumer {
     }
     
     if let filter = filter, filter.count > 0 {
-      let data = try! JSONSerialization.data(withJSONObject: filter, options: .prettyPrinted)
-      let decodedExpression = try! JSONDecoder().decode(Expression.self, from: data)
-      layer.filter = decodedExpression
+      do {
+        let data = try JSONSerialization.data(withJSONObject: filter, options: .prettyPrinted)
+        let decodedExpression = try JSONDecoder().decode(Expression.self, from: data)
+        layer.filter = decodedExpression
+      } catch {
+        Logger.log(level: .error, message: "parsing filters failed for layer \(id)")
+      }
     } else {
       layer.filter = nil
     }
@@ -228,9 +240,7 @@ class RCTMGLLayer : UIView, RCTMGLMapComponent, RCTMGLSourceConsumer {
     if (self.styleLayer != nil) {
       try! style.removeLayer(withId: self.id)
     }
-    self.styleLayer = nil
   }
-  
   
   func insert(_ style: Style, layerPosition: LayerPosition, inserted: (() -> Void)? = nil) {
     var idToWaitFor : String? = nil


### PR DESCRIPTION
## Description

While the ```filter``` prop was already implemented to be set correctly while adding the layer to the map, a listener was still missing to take care of changes.

This PR implements this listener and readds the layer to the map after updating its options.

While implmenting this, the ```removeAndReaddLayer``` function was fixed by changing ```removeFromLayer``` to still keep the styleLayer in memory to make a reinsert in ```insert``` possible.

## Checklist

- [X] I have tested this on a device/simulator for each compatible OS
- [ ] I mentioned this change in `CHANGELOG.md`

