### PR TITLE
iOS, v10 Fix race condition in production with images

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLImageQueue.swift
+++ b/ios/RCTMGL-v10/RCTMGLImageQueue.swift
@@ -73,11 +73,14 @@ class RCTMGLImageQueueOperation : Operation {
         if let completionHandler = weakSelf.completionHandler {
           completionHandler(error, image)
         }
-        weakSelf.setState(state:.Finished, except:.Finished)
+        _ = weakSelf.setState(state:.Finished, except:.Finished)
       }
-      weakSelf.cancellationBlock = cancellationBlock
-      if (weakSelf.setState(state:.Executing, only:.Initial) == .CancelDoNotExecute) {
-        weakSelf.callCancellationBlock()
+
+      if let weakSelf = weakSelf {
+        weakSelf.cancellationBlock = cancellationBlock
+        if (weakSelf.setState(state:.Executing, only:.Initial) == .CancelDoNotExecute) {
+          weakSelf.callCancellationBlock()
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes: #1866 

It looks in production the block passed to loadImage is called immediately. That causes operation to be released, therefore weakSelf will be nil.

```swift
let cancellationBlock = loader.loadImage(with: weakSelf.urlRequest, size: .zero, scale: CGFloat(weakSelf.scale), clipped: true, resizeMode: .stretch, progressBlock: { _,_  in }, partialLoad: { _ in }) { error, image in
        
        _ = weakSelf.setState(state:.Finished, except:.Finished) // <<<< - (1) this can result in self being destroyed
      }

       // <<<< -(2) weakSelf might be nil if (1) was executed before
      weakSelf.cancellationBlock = cancellationBlock
 ```

Use this to reproduce in  BugReportExample in example app - needs to run in production.
```
import React from 'react';
import {MapView, ShapeSource, SymbolLayer, Camera} from '@rnmapbox/maps';

const shape = {
  type: 'FeatureCollection',
  features: [
    {
      type: 'Feature',
      geometry: {
        type: 'Point',
        coordinates: [-74.00597, 40.71427],
      },
    },
  ],
};

export default () => (
  <MapView style={{flex: 1}}>
    <Camera centerCoordinate={[-74.00597, 40.71427]} zoomLevel={14} />
    <ShapeSource id="markers" shape={shape}>
      <SymbolLayer
        id="example"
        style={{iconImage: require('../assets/pin.png')}}
      />
    </ShapeSource>
  </MapView>
);
```