### PR TITLE
V10, iOS: Only consider a source hit, when non empty features were hit

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLMapView.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapView.swift
@@ -341,8 +341,10 @@ extension RCTMGLMapView: GestureManagerDelegate {
            case .failure(let error):
             Logger.log(level: .error, message: "Error during handleTapInSources source.id=\(source.id ?? "n/a") error:\(error)")
           case .success(let features):
-            newHits[source.id] = features
-            newTouchedSources.append(source)
+            if !features.isEmpty {
+              newHits[source.id] = features
+              newTouchedSources.append(source)
+            }
             break
           }
           var nSources = sources


### PR DESCRIPTION
When a tap happens we first try to see if any sources were hit with `queryRenderedFeatures`, and if none we'll generate an `onPress` for the map. 
If the `queryRenderedFeatures` returns 0 features we not consider that as a hit, so we can give it to the map.


Fixes the custom icon example

![image](https://user-images.githubusercontent.com/52435/167929291-f8d68fc5-d825-4a44-898e-398f96a62d3b.png)
