### PR TITLE
iOS, v10: add queryRenderedFeaturesAtPoint/InRect

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -360,13 +360,13 @@ PODS:
     - React-perflogger (= 0.68.1)
   - RNGestureHandler (1.9.0):
     - React-Core
-  - rnmapbox-maps (10.0.0-beta.1):
+  - rnmapbox-maps (10.0.0-beta.3):
     - MapboxMaps (~> 10.5.0)
     - React
     - React-Core
-    - rnmapbox-maps/DynamicLibrary (= 10.0.0-beta.1)
+    - rnmapbox-maps/DynamicLibrary (= 10.0.0-beta.3)
     - Turf
-  - rnmapbox-maps/DynamicLibrary (10.0.0-beta.1):
+  - rnmapbox-maps/DynamicLibrary (10.0.0-beta.3):
     - MapboxMaps (~> 10.5.0)
     - React
     - React-Core
@@ -596,7 +596,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 7285b499d0339104b2813a1f58ad1ada4adbd6c0
   ReactCommon: bf2888a826ceedf54b99ad1b6182d1bc4a8a3984
   RNGestureHandler: 9b7e605a741412e20e13c512738a31bd1611759b
-  rnmapbox-maps: b205f28ed72f45cfc2f043e1fe5d432692aabaf9
+  rnmapbox-maps: 75c78ebf20cbe15a72418cf7b616d45bcf245c2d
   RNScreens: 6e1ea5787989f92b0671049b808aef64fa1ef98c
   RNSVG: ce9d996113475209013317e48b05c21ee988d42e
   RNVectorIcons: 4143ba35feebab8fdbe6bc43d1e776b393d47ac8

--- a/example/src/examples/FillRasterLayer/QueryWithRect.js
+++ b/example/src/examples/FillRasterLayer/QueryWithRect.js
@@ -103,7 +103,7 @@ class QueryWithRect extends React.Component {
             >
               <MapboxGL.FillLayer
                 id="selectedNYCFill"
-                style={styles.selectedNeighborhood}
+                style={styles.selectedNeighborhoods}
               />
             </MapboxGL.ShapeSource>
           ) : null}

--- a/ios/RCTMGL-v10/Extensions/Array+asExpressions.swift
+++ b/ios/RCTMGL-v10/Extensions/Array+asExpressions.swift
@@ -1,0 +1,14 @@
+import MapboxMaps
+
+internal extension Array where Element == Any {
+  func asExpression() throws -> Expression? {
+    let filter = self
+    if filter.count > 0 {
+      let data = try JSONSerialization.data(withJSONObject: filter, options: .prettyPrinted)
+      let decodedExpression = try JSONDecoder().decode(Expression.self, from: data)
+      return decodedExpression
+    } else {
+      return nil
+    }
+  }
+}

--- a/ios/RCTMGL-v10/Extensions/CLLocationCoordinate2D+toArray.swift
+++ b/ios/RCTMGL-v10/Extensions/CLLocationCoordinate2D+toArray.swift
@@ -1,0 +1,7 @@
+import MapboxMaps
+
+internal extension CLLocationCoordinate2D {
+  func toArray() -> [Double] {
+    return [Double(longitude), Double(latitude)]
+  }
+}

--- a/ios/RCTMGL-v10/Extensions/DefaultStringInterpolation+optional.swift
+++ b/ios/RCTMGL-v10/Extensions/DefaultStringInterpolation+optional.swift
@@ -1,4 +1,4 @@
-extension DefaultStringInterpolation {
+internal extension DefaultStringInterpolation {
   mutating func appendInterpolation<T>(optional: T?) {
     appendInterpolation(String(describing: optional))
   }

--- a/ios/RCTMGL-v10/Extensions/Encodable+ToJSON.swift
+++ b/ios/RCTMGL-v10/Extensions/Encodable+ToJSON.swift
@@ -1,0 +1,13 @@
+internal extension Encodable {
+  func toJSON() throws -> Any {
+      return try JSONSerialization.jsonObject(with: JSONEncoder().encode(self))
+  }
+  
+  func toJSON() throws -> [String:Any] {
+    let result : Any = try toJSON()
+    guard let result = result as? [String:Any] else {
+      throw RCTMGLError.paramError("Expected object but got something else: \(result)")
+    }
+    return result
+  }
+}

--- a/ios/RCTMGL-v10/RCTMGLFillLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLFillLayer.swift
@@ -33,7 +33,7 @@ class RCTMGLFillLayer: RCTMGLVectorLayer {
       if var styleLayer = self.styleLayer as? FillLayer {
         styler.fillLayer(
           layer: &styleLayer,
-          reactStyle: reactStyle!,
+          reactStyle: reactStyle ?? [:],
           applyUpdater: { (updater) in try! style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout FillLayer) in updater(&layer) }},
           isValid: { return self.isAddedToMap() }
         )

--- a/ios/RCTMGL-v10/RCTMGLLogging.swift
+++ b/ios/RCTMGL-v10/RCTMGLLogging.swift
@@ -61,11 +61,12 @@ class Logger {
   }
 }
 
-func logged<T>(_ msg: String, fn : () throws -> T) -> T? {
+func logged<T>(_ msg: String, info: (() -> String)? = nil, level: Logger.LogLevel = .error, rejecter: RCTPromiseRejectBlock? = nil, fn : () throws -> T) -> T? {
   do {
     return try fn()
   } catch {
-    Logger.log(level:.error, message: "\(msg) \(error.localizedDescription)")
+    Logger.log(level:level, message: "\(msg) \(info?() ?? "") \(error.localizedDescription)")
+    rejecter?(msg, "\(info?() ?? "") \(error.localizedDescription)", error)
     return nil
   }
 }

--- a/ios/RCTMGL-v10/RCTMGLMapView.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapView.swift
@@ -376,7 +376,8 @@ extension RCTMGLMapView: GestureManagerDelegate {
               Logger.log(level:.error, message: "doHandleTap, no hits found when it should have")
               return
             }
-            let features = hitFeatures.map { $0.feature.toJSON() }
+            let features = hitFeatures.compactMap { queriedFeature in
+              logged("doHandleTap.hitFeatures") { try queriedFeature.feature.toJSON() } }
             let location = self.mapboxMap.coordinate(for: tapPoint)
             let event = RCTMGLEvent(
               type: (source is RCTMGLVectorSource) ? .vectorSourceLayerPress : .shapeSourceLayerPress,
@@ -402,7 +403,7 @@ extension RCTMGLMapView: GestureManagerDelegate {
                 "screenPointX": .number(Double(tapPoint.x)),
                 "screenPointY": .number(Double(tapPoint.y))
               ]
-              let event = RCTMGLEvent(type:.tap, payload: geojson.toJSON())
+              let event = RCTMGLEvent(type:.tap, payload: logged("reactOnPress") { try geojson.toJSON() })
               self.fireEvent(event: event, callback: reactOnPress)
             }
           }
@@ -422,7 +423,7 @@ extension RCTMGLMapView: GestureManagerDelegate {
         "screenPointX": .number(Double(position.x)),
         "screenPointY": .number(Double(position.y))
       ]
-      let event = RCTMGLEvent(type:.longPress, payload: geojson.toJSON())
+      let event = RCTMGLEvent(type:.longPress, payload: logged("doHandleLongPress") { try geojson.toJSON() })
       self.fireEvent(event: event, callback: reactOnLongPress)
     }
   }
@@ -591,32 +592,3 @@ class PointAnnotationManager : AnnotationInteractionDelegate {
   }
 }
 
-extension CLLocationCoordinate2D {
-  func toArray() -> [Double] {
-    return [Double(longitude), Double(latitude)]
-  }
-}
-
-extension Point {
-  func toJSON() -> [String: Any] {
-    do {
-      let data = try JSONEncoder().encode(self)
-      let value = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-      return value ?? [:]
-    } catch {
-      return [:]
-    }
-  }
-}
-
-extension Feature {
-  func toJSON() -> [String: Any] {
-    do {
-      let data = try JSONEncoder().encode(self)
-      let value = try JSONSerialization.jsonObject(with: data) as? [String: Any]
-      return value ?? [:]
-    } catch {
-      return [:]
-    }
-  }
-}

--- a/ios/RCTMGL-v10/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL-v10/RCTMGLMapViewManager.m
@@ -44,4 +44,18 @@ RCT_EXTERN_METHOD(getCenter:(nonnull NSNumber*)reactTag
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(queryRenderedFeaturesAtPoint:(nonnull NSNumber*)reactTag
+                  atPoint:(NSArray<NSNumber*>*)point
+                  withFilter:(NSArray*)filter
+                  withLayerIDs:(NSArray<NSString*>*)layerIDs
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(queryRenderedFeaturesInRect:(nonnull NSNumber*)reactTag
+                  withBBox:(NSArray<NSNumber*>*)bbox
+                  withFilter:(NSArray*)filter
+                  withLayerIDs:(NSArray<NSString*>*)layerIDs
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 @end

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rnmapbox/maps",
   "description": "A Mapbox react native module for creating custom maps",
-  "version": "10.0.0-beta.4",
+  "version": "10.0.0-beta.5",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
v10, iOS:
- implement queryRenderedFeaturesAtPoint, queryRenderedFeaturesInRect
- move extensions to `Extensions` folder
- do not shallow expecetions in `toJSON`, log the exceptions
- simplify `MapView` method implementation with `withMapView` and `withMapboxMap`