### PR TITLE
Allow geometry shapes, and impl getCoordinateFromView, getPointInView

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLMapView.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapView.swift
@@ -472,7 +472,7 @@ extension RCTMGLMapView {
     let style = self.mapboxMap.style
     
     style.allLayerIdentifiers.forEach { layerInfo in
-      let layer = logged("setSourceVisibility.layer") {
+      let layer = logged("setSourceVisibility.layer", info: { "\(layerInfo.id)" }) {
         try style.layer(withId: layerInfo.id)
       }
       if let layer = layer {

--- a/ios/RCTMGL-v10/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL-v10/RCTMGLMapViewManager.m
@@ -44,6 +44,16 @@ RCT_EXTERN_METHOD(getCenter:(nonnull NSNumber*)reactTag
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(getCoordinateFromView:(nonnull NSNumber*)reactTag
+                  atPoint:(CGPoint)point
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(getPointInView:(nonnull NSNumber*)reactTag
+                  atCoordinate:(NSArray<NSNumber*>*)coordinate
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(queryRenderedFeaturesAtPoint:(nonnull NSNumber*)reactTag
                   atPoint:(NSArray<NSNumber*>*)point
                   withFilter:(NSArray*)filter

--- a/ios/RCTMGL-v10/RCTMGLMapViewManager.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapViewManager.swift
@@ -111,6 +111,31 @@ extension RCTMGLMapViewManager {
       ]])
     }
   }
+
+  @objc
+  func getCoordinateFromView(
+    _ reactTag: NSNumber,
+    atPoint point: CGPoint,
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock) {
+      withMapboxMap(reactTag, name:"getCoordinateFromView", rejecter: rejecter) { mapboxMap in
+        let coordinates = mapboxMap.coordinate(for: point)
+        resolver(["coordinateFromView": [coordinates.longitude, coordinates.latitude]])
+      }
+  }
+
+  @objc
+  func getPointInView(
+    _ reactTag: NSNumber,
+    atCoordinate coordinate: [NSNumber],
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock) {
+      withMapboxMap(reactTag, name:"getPointInView", rejecter: rejecter) { mapboxMap in
+        let coordinate = CLLocationCoordinate2DMake(coordinate[1].doubleValue, coordinate[0].doubleValue)
+        let point = mapboxMap.point(for: coordinate)
+        resolver(["pointInView": [(point.x), (point.y)]])
+      }
+  }
 }
 
 // MARK: - queryRenderedFeatures

--- a/ios/RCTMGL-v10/RCTMGLShapeSource.swift
+++ b/ios/RCTMGL-v10/RCTMGLShapeSource.swift
@@ -106,7 +106,18 @@ extension RCTMGLShapeSource
     guard let data = shape.data(using: .utf8) else {
       throw RCTMGLError.parseError("shape is not utf8")
     }
-    return try JSONDecoder().decode(GeoJSONSourceData.self, from: data)
+    do {
+      return try JSONDecoder().decode(GeoJSONSourceData.self, from: data)
+    } catch {
+      let origError = error
+      do {
+        // workaround for mapbox issue, GeoJSONSourceData can't decode a single geometry
+        let geometry = try JSONDecoder().decode(Geometry.self, from: data)
+        return .geometry(geometry)
+      } catch {
+        throw origError
+      }
+    }
   }
 
   func parse(_ shape: String?) throws -> GeoJSONObject {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rnmapbox/maps",
   "description": "A Mapbox react native module for creating custom maps",
-  "version": "10.0.0-beta.5",
+  "version": "10.0.0-beta.6",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
v10, iOS:

- Workaround for upstream issue that GeoJSONSourceData cannot decode a simple `.geometry`
- Implement `getCoordinateFromView`, `getPointInView` 