### PR TITLE
Added RegionIs/DidChange compat to iOS,v10

### DIFF
--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -30,10 +30,10 @@
 | onPress | `func` | `none` | `false` | Map press listener, gets called when a user presses the map |
 | onLongPress | `func` | `none` | `false` | Map long press listener, gets called when a user long presses the map |
 | onRegionWillChange | `func` | `none` | `false` | <v10 only<br/><br/>This event is triggered whenever the currently displayed map region is about to change. |
-| onRegionIsChanging | `func` | `none` | `false` | <v10 only<br/><br/>This event is triggered whenever the currently displayed map region is changing. |
-| onRegionDidChange | `func` | `none` | `false` | <v10 only<br/><br/>This event is triggered whenever the currently displayed map region finished changing. |
-| onCameraChanged | `func` | `none` | `false` | v10 only<br/><br/>Called when the currently displayed map area changes. |
-| onMapIdle | `func` | `none` | `false` | v10 only<br/><br/>Called when the currently displayed map area stops changing. |
+| onRegionIsChanging | `func` | `none` | `false` | This event is triggered whenever the currently displayed map region is changing. |
+| onRegionDidChange | `func` | `none` | `false` | This event is triggered whenever the currently displayed map region finished changing. |
+| onCameraChanged | `func` | `none` | `false` | iOS, v10 only, experimental.<br/><br/>Called when the currently displayed map area changes.<br/>Replaces onRegionIsChanging, so can't set both |
+| onMapIdle | `func` | `none` | `false` | iOS, v10 only, experimental<br/><br/>Called when the currently displayed map area stops changing.<br/>Replaces onRegionDidChange, so can't set both |
 | onWillStartLoadingMap | `func` | `none` | `false` | This event is triggered when the map is about to start loading a new map style. |
 | onDidFinishLoadingMap | `func` | `none` | `false` | This is triggered when the map has successfully loaded a new map style. |
 | onDidFailLoadingMap | `func` | `none` | `false` | This event is triggered when the map has failed to load a new map style. |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3082,7 +3082,7 @@
         "required": false,
         "type": "func",
         "default": "none",
-        "description": "<v10 only\n\nThis event is triggered whenever the currently displayed map region is changing.",
+        "description": "This event is triggered whenever the currently displayed map region is changing.",
         "params": [
           {
             "name": "feature",
@@ -3099,7 +3099,7 @@
         "required": false,
         "type": "func",
         "default": "none",
-        "description": "<v10 only\n\nThis event is triggered whenever the currently displayed map region finished changing.",
+        "description": "This event is triggered whenever the currently displayed map region finished changing.",
         "params": [
           {
             "name": "feature",
@@ -3116,7 +3116,7 @@
         "required": false,
         "type": "func",
         "default": "none",
-        "description": "v10 only\n\nCalled when the currently displayed map area changes.",
+        "description": "iOS, v10 only, experimental.\n\nCalled when the currently displayed map area changes.\nReplaces onRegionIsChanging, so can't set both",
         "params": [
           {
             "name": "region",
@@ -3133,7 +3133,7 @@
         "required": false,
         "type": "func",
         "default": "none",
-        "description": "v10 only\n\nCalled when the currently displayed map area stops changing.",
+        "description": "iOS, v10 only, experimental\n\nCalled when the currently displayed map area stops changing.\nReplaces onRegionDidChange, so can't set both",
         "params": [
           {
             "name": "region",

--- a/ios/RCTMGL-v10/MGLModule.swift
+++ b/ios/RCTMGL-v10/MGLModule.swift
@@ -42,6 +42,8 @@ class MGLModule : NSObject {
         ],
       "EventTypes":
         [
+          "RegionIsChanging" : RCTMGLEvent.EventType.regionIsChanging.rawValue,
+          "RegionDidChange" : RCTMGLEvent.EventType.regionDidChange.rawValue,
           "CameraChanged" : RCTMGLEvent.EventType.cameraChanged.rawValue,
           "MapIdle" : RCTMGLEvent.EventType.mapIdle.rawValue,
           "DidFinishLoadingStyle": RCTMGLEvent.EventType.didFinishLoadingStyle.rawValue,

--- a/ios/RCTMGL-v10/RCTMGLEvent.swift
+++ b/ios/RCTMGL-v10/RCTMGLEvent.swift
@@ -21,7 +21,7 @@ class RCTMGLEvent : NSObject, RCTMGLEventProtocol {
     enum EventType : String {
       case tap
       case longPress
-      case regionWillChange
+      //case regionWillChange
       case regionIsChanging
       case regionDidChange
       case cameraChanged

--- a/ios/RCTMGL-v10/RCTMGLLogging.swift
+++ b/ios/RCTMGL-v10/RCTMGLLogging.swift
@@ -71,6 +71,15 @@ func logged<T>(_ msg: String, info: (() -> String)? = nil, level: Logger.LogLeve
   }
 }
 
+func logged<T>(_ msg: String, info: (() -> String)? = nil, errorResult: (Error) -> T, level: Logger.LogLevel = .error, fn : () throws -> T) -> T {
+  do {
+    return try fn()
+  } catch {
+    Logger.log(level:level, message: "\(msg) \(info?() ?? "") \(error.localizedDescription)")
+    return errorResult(error)
+  }
+}
+
 @objc(RCTMGLLogging)
 class RCTMGLLogging: RCTEventEmitter {
   static var shared : RCTMGLLogging? = nil

--- a/ios/RCTMGL-v10/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL-v10/RCTMGLMapViewManager.m
@@ -68,4 +68,9 @@ RCT_EXTERN_METHOD(queryRenderedFeaturesInRect:(nonnull NSNumber*)reactTag
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(setHandledMapChangedEvents:(nonnull NSNumber*)reactTag
+                  events:(NSArray<NSString*>*)events
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 @end

--- a/ios/RCTMGL-v10/RCTMGLMapViewManager.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapViewManager.swift
@@ -58,6 +58,7 @@ extension RCTMGLMapViewManager {
 }
 
 // MARK: - react methods
+
 extension RCTMGLMapViewManager {
     @objc
     func takeSnap(_ reactTag: NSNumber,
@@ -135,6 +136,19 @@ extension RCTMGLMapViewManager {
         let point = mapboxMap.point(for: coordinate)
         resolver(["pointInView": [(point.x), (point.y)]])
       }
+  }
+
+  @objc
+  func setHandledMapChangedEvents(
+    _ reactTag: NSNumber,
+    events: [String],
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock) {
+    withMapView(reactTag, name:"setHandledMapChangedEvents", rejecter: rejecter) { mapView in
+      mapView.handleMapChangedEvents = Set(events.compactMap {
+        RCTMGLEvent.EventType(rawValue: $0)
+      })
+    }
   }
 }
 


### PR DESCRIPTION
- onCameraChanged, onMapIdle is optional on v10 (now iOS only) and marked as experimental
- v10 will call onRegionIsChanging/onRegionDidChanging if those are defined (and no onCameraChanged, onMapIdle)
- since 1.5 now fixed https://github.com/mapbox/mapbox-maps-ios/pull/1275, use `layoutSubviews` 
- MapView.swift reorg