### PR TITLE
Fix for android MapView styleurl error if null

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.kt
@@ -285,6 +285,9 @@ open class RCTMGLMapView(private val mContext: Context, var mManager: RCTMGLMapV
     }
 
     fun isJSONValid(test: String?): Boolean {
+        if (test == null) {
+            return false
+        }
         try {
             JSONObject(test)
         } catch (ex: JSONException) {


### PR DESCRIPTION
## Description

Fixed null exception from JSONObject string.length introduced with the change to Kotlin and null variables

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
- [x] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typings files (`index.d.ts`)
- [x] I added/ updated a sample (`/example`)