### PR TITLE
Fix error to string conversion, support bounds for snapshotter

### DIFF
--- a/ios/RCTMGL-v10/MGLSnapshotModule.swift
+++ b/ios/RCTMGL-v10/MGLSnapshotModule.swift
@@ -13,39 +13,43 @@ class MGLSnapshotModule : NSObject {
                 rejecter:@escaping RCTPromiseRejectBlock
   ) {
     DispatchQueue.main.async {
-      let (cameraOptions,snapshotterOptions) = try! self._getOptions(jsOptions)
-      let snapshotter = Snapshotter(options: snapshotterOptions)
-      snapshotter.setCamera(to: cameraOptions)
-      if let styleURL = jsOptions["styleURL"] as? String {
-        snapshotter.style.uri = StyleURI(rawValue:styleURL)
-      }
-      var snapshotterReference : Snapshotter? = snapshotter
-      snapshotter.start(overlayHandler: nil, completion: { result in
-        do {
-          switch (result) {
-          case .success(let image):
-            guard let writeToDisk = jsOptions["writeToDisk"] as? NSNumber else {
-              throw RCTMGLError.paramError("writeToDisk: is not a number")
+      logged("takeSnap", rejecter:rejecter) {
+        let snapshotterOptions = try self._getSnapshotterOptions(jsOptions)
+        let snapshotter = Snapshotter(options: snapshotterOptions)
+        let cameraOptions = try self._getCameraOptions(jsOptions, snapshotter)
+        
+        snapshotter.setCamera(to: cameraOptions)
+        if let styleURL = jsOptions["styleURL"] as? String {
+          snapshotter.style.uri = StyleURI(rawValue:styleURL)
+        }
+        var snapshotterReference : Snapshotter? = snapshotter
+        snapshotter.start(overlayHandler: nil, completion: { result in
+          do {
+            switch (result) {
+            case .success(let image):
+              guard let writeToDisk = jsOptions["writeToDisk"] as? NSNumber else {
+                throw RCTMGLError.paramError("writeToDisk: is not a number")
+              }
+              
+              let value = writeToDisk.boolValue ? RNMBImageUtils.createTempFile(image) : RNMBImageUtils.createBase64(image)
+              _ = snapshotterReference
+              snapshotterReference = nil
+              resolver(value.absoluteString)
+            case .failure(let error):
+              _ = snapshotterReference
+              snapshotterReference = nil
+              Logger.log(level: .error, message: ":: Error - snapshot failed \(error) \(error.localizedDescription)")
+              rejecter("MGLSnapshotModule.start", error.localizedDescription, error)
             }
-            
-            let value = writeToDisk.boolValue ? RNMBImageUtils.createTempFile(image) : RNMBImageUtils.createBase64(image)
-            _ = snapshotterReference
-            snapshotterReference = nil
-            resolver(value.absoluteString)
-          case .failure(let error):
-            _ = snapshotterReference
-            snapshotterReference = nil
-            Logger.log(level: .error, message: ":: Error - snapshot failed \(error) \(error.localizedDescription)")
+          } catch let error {
             rejecter("MGLSnapshotModule.start", error.localizedDescription, error)
           }
-        } catch let error {
-          rejecter("MGLSnapshotModule.start", error.localizedDescription, error)
-        }
-      })
+        })
+      }
     }
   }
-  
-  func _getOptions(_ jsOptions: [String:Any]) throws -> (CameraOptions, MapSnapshotOptions) {
+
+  func _getCameraOptions(_ jsOptions: [String:Any], _ snaphotter: Snapshotter) throws -> CameraOptions {
     guard let pitch = jsOptions["pitch"] as? NSNumber else {
       throw RCTMGLError.paramError("pitch: is not a number")
     }
@@ -57,16 +61,34 @@ class MGLSnapshotModule : NSObject {
     guard let heading = jsOptions["heading"] as? NSNumber else {
       throw RCTMGLError.paramError("heading: is not a number")
     }
-  
-    guard let centerCoordinateString = jsOptions["centerCoordinate"] as? String,
-          let centerCoordinateData = centerCoordinateString.data(using: .utf8),
-          let centerCoordinateGeometry = try JSONDecoder().decode(Feature.self, from: centerCoordinateData).geometry,
-          case .point(let centerCoordinatePoint) = centerCoordinateGeometry else {
-      throw RCTMGLError.paramError("centerCoordinate: bad format")
+    
+    if let centerCoordinateString = jsOptions["centerCoordinate"] as? String {
+      guard let centerCoordinateData = centerCoordinateString.data(using: .utf8),
+            let centerCoordinateGeometry = try JSONDecoder().decode(Feature.self, from: centerCoordinateData).geometry,
+            case .point(let centerCoordinatePoint) = centerCoordinateGeometry else {
+        throw RCTMGLError.paramError("centerCoordinate: bad format")
+      }
+      
+      return CameraOptions(center: centerCoordinatePoint.coordinates, padding: nil, anchor: nil, zoom: zoomLevel.doubleValue, bearing: heading.doubleValue, pitch: pitch.doubleValue)
     }
-    
-    let cameraOptions = CameraOptions(center: centerCoordinatePoint.coordinates, padding: nil, anchor: nil, zoom: zoomLevel.doubleValue, bearing: heading.doubleValue, pitch: pitch.doubleValue)
-    
+    else if let bounds = jsOptions["bounds"] as? String {
+      guard let boundsData = bounds.data(using: .utf8) else {
+        throw RCTMGLError.paramError("bounds: bad format")
+      }
+      let boundsFeatures = try JSONDecoder().decode(FeatureCollection.self, from: boundsData).features
+      let coords : [CLLocationCoordinate2D] = try boundsFeatures.map {
+        guard case .point(let centerCoordinatePoint) = $0.geometry else {
+          throw RCTMGLError.paramError("Invalid bounds geometry")
+        }
+        return centerCoordinatePoint.coordinates
+      }
+      return snaphotter.camera(for: coords, padding: .zero, bearing: heading.doubleValue, pitch: pitch.doubleValue)
+    } else {
+      throw RCTMGLError.paramError("neither centerCoordinate nor bounds provided")
+    }
+  }
+  
+  func _getSnapshotterOptions(_ jsOptions: [String:Any]) throws -> MapSnapshotOptions {
     guard let width = jsOptions["width"] as? NSNumber,
           let height = jsOptions["height"] as? NSNumber else {
       throw RCTMGLError.paramError("width, height: is not a number")
@@ -79,6 +101,6 @@ class MGLSnapshotModule : NSObject {
       resourceOptions: resourceOptions
     )
     
-    return (cameraOptions, mapSnapshotOptions)
+    return mapSnapshotOptions
   }
 }

--- a/ios/RCTMGL-v10/RCTMGLLogging.swift
+++ b/ios/RCTMGL-v10/RCTMGLLogging.swift
@@ -1,10 +1,14 @@
 import Foundation
 import MapboxMaps
 
-enum RCTMGLError: Error {
+enum RCTMGLError: Error, LocalizedError {
   case parseError(String)
   case failed(String)
   case paramError(String)
+
+  var errorDescription: String? {
+    return String(describing: self)
+  }
 }
 
 class Logger {


### PR DESCRIPTION
V10, iOS:
- Fix RCTMGL error description
- MGLSnapshotModule supports bounds now (previously only centerCoordinate was supported)