### PR TITLE
[iOS, maplibre] add setWellKnownTileServer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -104,6 +104,7 @@ declare namespace MapboxGL {
   function removeCustomHeader(headerName: string): void;
   function addCustomHeader(headerName: string, headerValue: string): void;
   function setAccessToken(accessToken: string | null): void;
+  function setWellKnownTileServer(tileServer: string): void;
   function getAccessToken(): Promise<string>;
   function setTelemetryEnabled(telemetryEnabled: boolean): void;
   function setConnected(connected: boolean): void;

--- a/ios/RCTMGL/MGLModule.m
+++ b/ios/RCTMGL/MGLModule.m
@@ -12,6 +12,8 @@
 #import "CameraMode.h"
 #import "RCTMGLSource.h"
 #import "MGLCustomHeaders.h"
+#import <React/RCTLog.h>
+
 @import Mapbox;
 
 @implementation MGLModule
@@ -27,12 +29,22 @@ RCT_EXPORT_MODULE();
 {
     // style urls
     NSMutableDictionary *styleURLS = [[NSMutableDictionary alloc] init];
+    // tile servers
+    NSMutableDictionary *tileServers =
+      [[NSMutableDictionary alloc] init];
+    // impl
+    const NSMutableDictionary* impl = [[NSMutableDictionary alloc] init];
 
 #ifdef RNMBGL_USE_MAPLIBRE
     for (MGLDefaultStyle* style in [MGLStyle predefinedStyles]) {
       [styleURLS setObject:[style.url absoluteString] forKey:style.name];
     }
     [styleURLS setObject:[[MGLStyle defaultStyleURL] absoluteString] forKey:@"Default"];
+    [tileServers setObject:@"mapbox" forKey:@"Mapbox"];
+    [tileServers setObject:@"maplibre" forKey:@"MapLibre"];
+    [tileServers setObject:@"maptiler" forKey:@"MapTiler"];
+    [impl setObject:@"maplibre" forKey:@"Library"];
+
 #else
     [styleURLS setObject:[MGLStyle.streetsStyleURL absoluteString] forKey:@"Street"];
     [styleURLS setObject:[MGLStyle.darkStyleURL absoluteString] forKey:@"Dark"];
@@ -40,6 +52,8 @@ RCT_EXPORT_MODULE();
     [styleURLS setObject:[MGLStyle.outdoorsStyleURL absoluteString] forKey:@"Outdoors"];
     [styleURLS setObject:[MGLStyle.satelliteStyleURL absoluteString] forKey:@"Satellite"];
     [styleURLS setObject:[MGLStyle.satelliteStreetsStyleURL absoluteString] forKey:@"SatelliteStreet"];
+    [tileServers setObject:@"mapbox" forKey:@"Mapbox"]
+    [impl setObject:@"mapbox-gl" forKey:@"Library"];
 #endif
 
     // event types
@@ -214,6 +228,8 @@ RCT_EXPORT_MODULE();
 
     return @{
          @"StyleURL": styleURLS,
+         @"TileServers": tileServers,
+         @"Implementation": impl,
          @"EventTypes": eventTypes,
          @"UserTrackingModes": userTrackingModes,
          @"UserLocationVerticalAlignment": userLocationVerticalAlignment,
@@ -254,6 +270,32 @@ RCT_EXPORT_METHOD(setAccessToken:(NSString *)accessToken)
     }
 #else
     [MGLAccountManager setAccessToken:accessToken];
+#endif
+}
+
+RCT_EXPORT_METHOD(setWellKnownTileServer:(NSString*)tileServer)
+{
+#ifdef RNMBGL_USE_MAPLIBRE
+  MGLWellKnownTileServer server = MGLMapLibre;
+  
+  if ([tileServer isEqualToString:@"maplibre"]) {
+    server = MGLMapLibre;
+  } else if ([tileServer isEqualToString:@"mapbox"]) {
+    server = MGLMapbox;
+  } else if ([tileServer isEqualToString:@"maptiler"]) {
+    server = MGLMapTiler;
+  } else {
+    RCTLogError(@"setWellKnownTileServer: %@ should be one of maplibre,mapbox,maptiler", tileServer);
+    return;
+  }
+
+  [MGLSettings useWellKnownTileServer: server];
+#else
+  if ([tileServer isEqualToString:@"mapbox"]) {
+    // nothing to do
+  } else {
+    RCTLogError(@"setWellKnownTileServer: %@ should be mapbox", tileServer);
+  }
 #endif
 }
 


### PR DESCRIPTION
[iOS, maplibre]

FixesiOS: #1861

Export `useWellKnownTileServer` as `setWellKnownTileServer`. Not yet implemented on Android or v10 versions (will be no-op on v10)

```jsx
MapboxGL.setWellKnownTileServer(MapboxGL.TileServers.Mapbox);
```