### PR TITLE
iOS,v10: ShapeSource#getClusterLeaves

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLShapeSourceManager.m
+++ b/ios/RCTMGL-v10/RCTMGLShapeSourceManager.m
@@ -1,7 +1,8 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTViewManager.h>
 
-@interface RCT_EXTERN_MODULE(RCTMGLShapeSourceManager, RCTViewManager)
+@interface
+RCT_EXTERN_REMAP_MODULE(RCTMGLShapeSource, RCTMGLShapeSourceManager, RCTViewManager)
 
 RCT_EXPORT_VIEW_PROPERTY(id, NSString)
 RCT_EXPORT_VIEW_PROPERTY(url, NSString)
@@ -22,13 +23,14 @@ RCT_EXPORT_VIEW_PROPERTY(hitbox, NSDictionary)
 RCT_REMAP_VIEW_PROPERTY(onMapboxShapeSourcePress, onPress, RCTBubblingEventBlock)
 
 
+
 RCT_EXTERN_METHOD(getClusterExpansionZoom:(nonnull NSNumber*)reactTag
                                 clusterId:(nonnull NSNumber*)clusterId
                                  resolver:(RCTPromiseResolveBlock)resolve
                                  rejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(getClusterLeaves:(nonnull NSNumber*)reactTag
-                  clusterId:(nonnull NSNumber *)clusterId
+                  featureJSON:(nonnull NSString*)featureJSON
                   number:(NSUInteger) number
                   offset:(NSUInteger) offset
                   resolver:(RCTPromiseResolveBlock)resolve

--- a/ios/RCTMGL-v10/RCTMGLShapeSourceManager.swift
+++ b/ios/RCTMGL-v10/RCTMGLShapeSourceManager.swift
@@ -32,7 +32,7 @@ class RCTMGLShapeSourceManager: RCTViewManager {
   
   @objc func getClusterLeaves(
     _ reactTag: NSNumber,
-    clusterId: NSNumber,
+    featureJSON: String,
     number: uint,
     offset: uint,
     resolver: @escaping RCTPromiseResolveBlock,
@@ -40,12 +40,15 @@ class RCTMGLShapeSourceManager: RCTViewManager {
   {
     self.bridge.uiManager.addUIBlock { (manager, viewRegistry) in
       let shapeSource = viewRegistry?[reactTag] as! RCTMGLShapeSource
-      let shapes = shapeSource.getClusterLeaves(clusterId, number: number, offset: offset) { result in
+      let shapes = shapeSource.getClusterLeaves(featureJSON, number: number, offset: offset) { result in
         switch result {
         case .success(let features):
-          resolver([
-            "data": ["type":"FeatureCollection", "features": features.features]
-          ])
+          logged("getClusterLeaves", rejecter: rejecter) {
+            let featuresJSON : Any = try features.features.toJSON()
+            resolver([
+              "data": ["type":"FeatureCollection", "features": featuresJSON]
+            ])
+          }
         case .failure(let error):
           rejecter(error.localizedDescription, "Error.getClusterLeaves", error)
         }

--- a/ios/RCTMGL-v10/RCTMGLStyleValue.swift
+++ b/ios/RCTMGL-v10/RCTMGLStyleValue.swift
@@ -124,8 +124,13 @@ class RCTMGLStyleValue {
       }
     
       let result = values.map { items -> (String,Any) in
-        let key = items[0]
+        var key = items[0]
         let value = items[1]
+        if let keyd = key as? [String:String],
+          keyd["type"] == "string",
+          let value = keyd["value"] {
+          key = value
+        }
         guard let key = key as? String else {
           fatalError("First item should be a string key")
         }


### PR DESCRIPTION
iOS,v10: Fixes getClusterLeaves to use the new interface (see #1499), and fixes: #1930