### PR TITLE
Warn instead of crashing on `onDidFinishRenderingMap` error

### DIFF
--- a/android/rctmgl/src/main/java-mapboxgl/common/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java-mapboxgl/common/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -751,7 +751,12 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
             for (Pair<Integer, ReadableArray> preRenderMethod : mPreRenderMethods) {
                 Integer methodID = preRenderMethod.first;
                 ReadableArray args = preRenderMethod.second;
-                mManager.receiveCommand(this, methodID, args);
+
+                try {
+                    mManager.receiveCommand(this, methodID, args);
+                } catch (Exception ex) {
+                    Logger.w(LOG_TAG, String.format("Could not execute pre-render method %s: %s", methodID, ex.getMessage()));
+                }
             }
             mPreRenderMethods.clear();
             handleMapChangedEvent(EventTypes.DID_FINISH_RENDERING_MAP_FULLY);

--- a/android/rctmgl/src/main/java-mapboxgl/common/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
+++ b/android/rctmgl/src/main/java-mapboxgl/common/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.java
@@ -755,7 +755,7 @@ public class RCTMGLMapView extends MapView implements OnMapReadyCallback, Mapbox
                 try {
                     mManager.receiveCommand(this, methodID, args);
                 } catch (Exception ex) {
-                    Logger.w(LOG_TAG, String.format("Could not execute pre-render method %s: %s", methodID, ex.getMessage()));
+                    Logger.e(LOG_TAG, String.format("Could not execute pre-render method %s: %s", methodID, ex.getMessage()));
                 }
             }
             mPreRenderMethods.clear();


### PR DESCRIPTION
I was getting an array-as-string type conversion error on the line with `mManager.receiveCommand(...)`. I don't have time to look more deeply into it, but this at least prevents a crash while delivering a warning. 