### PR TITLE
Fix onDidFinishRenderingMap exception

### DIFF
--- a/android/rctmgl/src/main/java-mapboxgl/common/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
+++ b/android/rctmgl/src/main/java-mapboxgl/common/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.java
@@ -256,41 +256,41 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
         switch (commandID) {
             case METHOD_QUERY_FEATURES_POINT:
                 mapView.queryRenderedFeaturesAtPoint(
-                        args.getString(0),
+                        args.getArray(0).toString(),
                         ConvertUtils.toPointF(args.getArray(1)),
                         ExpressionParser.from(args.getArray(2)),
                         ConvertUtils.toStringList(args.getArray(3)));
                 break;
             case METHOD_QUERY_FEATURES_RECT:
                 mapView.queryRenderedFeaturesInRect(
-                        args.getString(0),
+                        args.getArray(0).toString(),
                         ConvertUtils.toRectF(args.getArray(1)),
                         ExpressionParser.from(args.getArray(2)),
                         ConvertUtils.toStringList(args.getArray(3)));
                 break;
             case METHOD_VISIBLE_BOUNDS:
-                mapView.getVisibleBounds(args.getString(0));
+                mapView.getVisibleBounds(args.getArray(0).toString());
                 break;
             case METHOD_GET_POINT_IN_VIEW:
-                mapView.getPointInView(args.getString(0), GeoJSONUtils.toLatLng(args.getArray(1)));
+                mapView.getPointInView(args.getArray(0).toString(), GeoJSONUtils.toLatLng(args.getArray(1)));
                 break;
             case METHOD_GET_COORDINATE_FROM_VIEW:
-                mapView.getCoordinateFromView(args.getString(0), ConvertUtils.toPointF(args.getArray(1)));
+                mapView.getCoordinateFromView(args.getArray(0).toString(), ConvertUtils.toPointF(args.getArray(1)));
                 break;
             case METHOD_TAKE_SNAP:
-                mapView.takeSnap(args.getString(0), args.getBoolean(1));
+                mapView.takeSnap(args.getArray(0).toString(), args.getBoolean(1));
                 break;
             case METHOD_GET_ZOOM:
-                mapView.getZoom(args.getString(0));
+                mapView.getZoom(args.getArray(0).toString());
                 break;
             case METHOD_GET_CENTER:
-                mapView.getCenter(args.getString(0));
+                mapView.getCenter(args.getArray(0).toString());
                 break;
             case METHOD_SET_HANDLED_MAP_EVENTS:
                 if(args != null) {
                     ArrayList<String> eventsArray = new ArrayList<>();
                     for (int i = 1; i < args.size(); i++) {
-                        eventsArray.add(args.getString(i));
+                        eventsArray.add(args.getArray(i).toString());
                     }
                     mapView.setHandledMapChangedEvents(eventsArray);
                 }
@@ -301,8 +301,8 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
             case METHOD_SET_SOURCE_VISIBILITY:
                 mapView.setSourceVisibility(
                         args.getBoolean(1),
-                        args.getString(2),
-                        args.getString(3)
+                        args.getArray(2).toString(),
+                        args.getArray(3).toString()
                 );
 
         }
@@ -350,4 +350,3 @@ public class RCTMGLMapViewManager extends AbstractEventEmitter<RCTMGLMapView> {
         }
     }
 }
-


### PR DESCRIPTION
Hi, 
On the android device, there is a problem when I add `<MapboxGL.RasterSource>` tag. To fix this problem I propose you this pull request.

## Description

Here the error :
Mapbox error Exception in onDidFinishRenderingMap {"level": "error", "message": "Exception in onDidFinishRenderingMap", "tag": "Mbgl-MapChangeReceiver"}

## Checklist

- [X] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typings files (`index.d.ts`)
- [ ] I added/ updated a sample (`/example`)
