### PR TITLE
android, maplibre,mapbox-gl: add setWellKnownTileServer impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,22 @@ Please add unreleased changes in the following style:
 PR Title ([#123](link to my pr))
 ```
 
-Implement clustering properties to ShapeSource ([#1745](https://github.com/react-native-mapbox-gl/maps/pull/1745))
-
-### UNRELEASED/10.0.0-beta.0
+### UNRELEASED/10.0.0-beta.10
 
 #### Breaking changes:
 
 The setup was changed - see install instructions for more details. In a nuthsell:
 * On both android/ios to select mapbox implementation use `RNMapboxMapsImpl`/`$RNMapboxMapsImpl` variable which can be one of (`maplibre`,`mapbox`(aka v10),`mapbox-gl`)
+* Default implementation is `maplibre` as it requires not further setup. *WARNING* using mapbox styles from `maplibre` has different pricing than mapbox native sdk-s.
 * On Podfile `$RNMBGL.(pre|post)_install` was changed `$RNMapboxMaps.(pre|post)_install`
 * Package name was changed from `@react-native-mapbox-gl/maps` to `@rnmapbox/maps`. If you just testing with the v10 version you can use something like [babel-plugin-transform-rename-import](https://www.npmjs.com/package/babel-plugin-transform-rename-import) to keep using the old imports for a while.
 
+* `MapboxGL.setAccessToken` now requires `MapboxGL.setWellKnownTileServer` on maplibre.
+
+
 #### Changes:
 
+- Implement clustering properties to ShapeSource ([#1745](https://github.com/react-native-mapbox-gl/maps/pull/1745))
 - Initial Mapbox V10 support ([#1750](https://github.com/rnmapbox/maps/pull/1750))
 - Updated MapLibre on Android to 9.5.2 ([#1780](https://github.com/rnmapbox/maps/pull/1780))
 

--- a/android/rctmgl/src/main/java-mapboxgl/common/com/mapbox/rctmgl/modules/RCTMGLModule.java
+++ b/android/rctmgl/src/main/java-mapboxgl/common/com/mapbox/rctmgl/modules/RCTMGLModule.java
@@ -249,7 +249,16 @@ public class RCTMGLModule extends ReactContextBaseJavaModule {
         Map<String, String> locationModuleCallbackNames = new HashMap<>();
         locationModuleCallbackNames.put("Update", RCTMGLLocationModule.LOCATION_UPDATE);
 
+        // tileServer
+        Map<String, String> tileServers =  InstanceManagerImpl.getTileServers();
+
+        // implementation
+        Map<String, String> implementation = new HashMap<>();
+        implementation.put("Library", InstanceManagerImpl.getLibraryName());
+
         return MapBuilder.<String, Object>builder()
+                .put("TileServers", tileServers)
+                .put("Implementation", implementation)
                 .put("StyleURL", styleURLS)
                 .put("EventTypes", eventTypes)
                 .put("UserTrackingModes", userTrackingModes)
@@ -282,6 +291,11 @@ public class RCTMGLModule extends ReactContextBaseJavaModule {
                 .put("OfflineCallbackName", offlineModuleCallbackNames)
                 .put("LocationCallbackName", locationModuleCallbackNames)
                 .build();
+    }
+
+    @ReactMethod
+    public void setWellKnownTileServer(final String tileServer) {
+        InstanceManagerImpl.setWellKnownTileServer(tileServer);
     }
 
     @ReactMethod

--- a/android/rctmgl/src/main/java-mapboxgl/mapbox/com/mapbox/rctmgl/impl/InstanceManagerImpl.java
+++ b/android/rctmgl/src/main/java-mapboxgl/mapbox/com/mapbox/rctmgl/impl/InstanceManagerImpl.java
@@ -8,7 +8,24 @@ public class InstanceManagerImpl {
     Mapbox.getInstance(context, accessToken);
   }
 
+  public static void setWellKnownTileServer(String wellKnownTileServer) {
+    if (wellKnownTileServer != "mapbox") {
+      Logger.w("InstanceManagerImpl", "setWellKnownTileServer: only mapbox is supported");
+      return;
+    }
+  }
+
   public static String getAccessToken() {
     return Mapbox.getAccessToken();
+  }
+
+  public static String getLibraryName() {
+    return "mapbox-gl";
+  }
+
+  public static Map<String,String> getTileServers() {
+    HashMap<String, String> result = new HashMap();
+    result.put("Mapbox", "mapbox");
+    return result;
   }
 }

--- a/android/rctmgl/src/main/java-mapboxgl/maplibre/com/mapbox/rctmgl/impl/InstanceManagerImpl.java
+++ b/android/rctmgl/src/main/java-mapboxgl/maplibre/com/mapbox/rctmgl/impl/InstanceManagerImpl.java
@@ -13,7 +13,7 @@ public class InstanceManagerImpl {
   public static void getInstance(Context context, String accessToken) {
     if (wellKnownTileServer == null) {
       Logger.w("InstanceManagerImpl", "setAccessToken requires setWellKnownTileServer for MapLibre, see setWellKnownTileServer docs for implications");
-      wellKnownTileServer = "maplibre";
+      wellKnownTileServer = WellKnownTileServer.MapLibre.name();
     }
     Mapbox.getInstance(context, accessToken,  WellKnownTileServer.valueOf(wellKnownTileServer) );
   }

--- a/android/rctmgl/src/main/java-mapboxgl/maplibre/com/mapbox/rctmgl/impl/InstanceManagerImpl.java
+++ b/android/rctmgl/src/main/java-mapboxgl/maplibre/com/mapbox/rctmgl/impl/InstanceManagerImpl.java
@@ -1,15 +1,42 @@
 package com.mapbox.rctmgl.impl;
 
 import android.content.Context;
+
 import com.mapbox.mapboxsdk.Mapbox;
 import com.mapbox.mapboxsdk.WellKnownTileServer;
+import com.mapbox.mapboxsdk.log.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class InstanceManagerImpl {
   public static void getInstance(Context context, String accessToken) {
-    Mapbox.getInstance(context, accessToken, WellKnownTileServer.Mapbox);
+    if (wellKnownTileServer == null) {
+      Logger.w("InstanceManagerImpl", "setAccessToken requires setWellKnownTileServer for MapLibre, see setWellKnownTileServer docs for implications");
+      wellKnownTileServer = "maplibre";
+    }
+    Mapbox.getInstance(context, accessToken,  WellKnownTileServer.valueOf(wellKnownTileServer) );
+  }
+
+  public static Map<String,String> getTileServers() {
+    HashMap<String, String> result = new HashMap();
+    result.put("Mapbox", WellKnownTileServer.Mapbox.name());
+    result.put("MapLibre", WellKnownTileServer.MapLibre.name());
+    result.put("MapTiler", WellKnownTileServer.MapTiler.name());
+    return result;
+  }
+
+  static String wellKnownTileServer = null;
+
+  public static void setWellKnownTileServer(String wellKnownTileServer) {
+    InstanceManagerImpl.wellKnownTileServer = wellKnownTileServer;
   }
 
   public static String getAccessToken() {
-    return null;
+    return Mapbox.getApiKey();
+  }
+
+  public static String getLibraryName() {
+    return "maplibre";
   }
 }

--- a/docs/MapboxGL.md
+++ b/docs/MapboxGL.md
@@ -13,6 +13,16 @@
 sets the accessToken, which is required when you want to use mapbox tiles
 not required when using other tiles
 
+#### setWellKnownTileServer(tileServer)
+
+##### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+| `tileServer` | `String` | `Yes` | tile server |
+
+##### Description
+No-op on non MapLibre implemntations. Use MapboxGL.TileServer.Mapbox to consume mapbox tiles with maplibre. *Note*: Consuming mapbox with MapLibre has different pricing than with the official SDK. Other values: MapboxGL.TileServer.MapLibre, MapboxGL.TileServer.MapTiler
+
 #### getAccessToken()
 
 ##### arguments

--- a/javascript/utils/Logger.js
+++ b/javascript/utils/Logger.js
@@ -111,4 +111,6 @@ class Logger {
   }
 }
 
+Logger.sharedInstance().start();
+
 export default Logger;


### PR DESCRIPTION
Impemented setWellKnownTileServer for android.
*BREAKING CHANGE*: setWellKnownTileServer is now required on maplibre before setting access token. This is because consuming mapbox from maplibre will have different pricing. So user cannot consume mapbox with maplibre by mistake/without being aware of that.

See #1935 