### PR TITLE
Add missing imports for Logger, Map and HashMap to mapbox-gl InstanceManagerImpl

### DIFF
--- a/android/rctmgl/src/main/java-mapboxgl/mapbox/com/mapbox/rctmgl/impl/InstanceManagerImpl.java
+++ b/android/rctmgl/src/main/java-mapboxgl/mapbox/com/mapbox/rctmgl/impl/InstanceManagerImpl.java
@@ -2,6 +2,10 @@ package com.mapbox.rctmgl.impl;
 
 import android.content.Context;
 import com.mapbox.mapboxsdk.Mapbox;
+import com.mapbox.mapboxsdk.log.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class InstanceManagerImpl {
   public static void getInstance(Context context, String accessToken) {
@@ -23,7 +27,7 @@ public class InstanceManagerImpl {
     return "mapbox-gl";
   }
 
-  public static Map<String,String> getTileServers() {
+  public static Map<String, String> getTileServers() {
     HashMap<String, String> result = new HashMap();
     result.put("Mapbox", "mapbox");
     return result;


### PR DESCRIPTION
## Description

Fixes #1993

## Checklist

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
- [x] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typings files (`index.d.ts`)
- [x] I added/ updated a sample (`/example`)
