### PR TITLE
Update MarkerViewManager.java

### DIFF
--- a/android/rctmgl/src/main/java-mapboxgl/common/com/mapbox/rctmgl/components/annotation/MarkerViewManager.java
+++ b/android/rctmgl/src/main/java-mapboxgl/common/com/mapbox/rctmgl/components/annotation/MarkerViewManager.java
@@ -53,12 +53,14 @@ public class MarkerViewManager extends com.mapbox.mapboxsdk.plugins.markerview.M
     }
 
     public void updateMarkers(){
-
-        try {          
-            for( int i = 0; i < markers.size(); i++ ){
-                markerUpdate.invoke(markers.get(i));
-            }
-        } 
+        
+        try {   
+            if (markerUpdate != null) {       
+                for( int i = 0; i < markers.size(); i++ ){    
+                    markerUpdate.invoke(markers.get(i));
+                }
+             }
+         } 
         catch (IllegalArgumentException e) { System.out.println(e.toString()); }
         catch (IllegalAccessException e) { System.out.println(e.toString()); }
         catch (InvocationTargetException e) { System.out.println(e.toString()); }


### PR DESCRIPTION
When Android is running in release mode, `updateMarkers` can get called when `markerUpdate` is still null, resulting in a `NullPointerException` and crashing the app.

This happens on any screen a `MarkerView` is present on.

## Description

**EDIT:**

I suspect this issue may be related to [minification and the use of reflection](https://developer.android.com/studio/build/shrink-code#keep-code) for setting the `markerUpdate` variable, so I am open to advice on how to tackle it from that end instead as well


Fixes crashes in Android release mode when using `MarkerView`.

When Android is running in release mode, `updateMarkers` can get called when `markerUpdate` is still `null`, resulting in a `NullPointerException` and crashing the app.

This happens on any screen a `MarkerView` is present on.

```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Object java.lang.reflect.Method.invoke(java.lang.Object, java.lang.Object[])' on a null object reference
       at com.mapbox.rctmgl.components.annotation.MarkerViewManager.updateMarkers(MarkerViewManager.java:20)
       at com.mapbox.rctmgl.components.mapview.RCTMGLMapView$4.onCameraMove(RCTMGLMapView.java:14)
       at com.mapbox.mapboxsdk.maps.CameraChangeDispatcher.executeOnCameraMove(CameraChangeDispatcher.java:30)
       at com.mapbox.mapboxsdk.maps.CameraChangeDispatcher.access$100(CameraChangeDispatcher.java)
       at com.mapbox.mapboxsdk.maps.CameraChangeDispatcher$CameraChangeHandler.handleMessage(CameraChangeDispatcher.java:32)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loopOnce(Looper.java:226)
       at android.os.Looper.loop(Looper.java:313)
       at android.app.ActivityThread.main(ActivityThread.java:8663)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:567)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1135)
```
## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typings files (`index.d.ts`)
- [ ] I added/ updated a sample (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
