### PR TITLE
Adding missing EventType

### DIFF
--- a/setup-jest.js
+++ b/setup-jest.js
@@ -33,6 +33,7 @@ NativeModules.MGLModule = {
     'RegionDidChange',
     'WillStartLoadingMap',
     'DidFinishLoadingMap',
+    'DidFinishRenderingMapFully',
     'DidFailLoadingMap',
     'WillStartRenderingFrame',
     'DidFinishRenderingFrame',


### PR DESCRIPTION
Adding missing `DidFinishRenderingMapFully` EventType to setup-jest.js

## Description

Removes warning when running jest: 
```typescript
    console.warn
      rnmapbox maps: DidFinishRenderingMapFully is not supported

      at warn (node_modules/@rnmapbox/maps/javascript/components/MapView.js:365:21)
      at MapView.addIfHasHandler [as _setHandledMapChangedEvents] (node_modules/@rnmapbox/maps/javascript/components/MapView.js:386:7)
      at MapView._setHandledMapChangedEvents [as UNSAFE_componentWillReceiveProps] (node_modules/@rnmapbox/maps/javascript/components/MapView.js:354:10)
      at callComponentWillReceiveProps (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:4114:14)
      at updateClassInstance (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:4312:7)
      at updateClassComponent (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:8406:20)
      at beginWork (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:9990:16)
      at performUnitOfWork (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:13800:12)
```

## Checklist

- [ ] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typings files (`index.d.ts`)
- [ ] I added/ updated a sample (`/example`)

## Screenshot OR Video

