### PR TITLE
added support for camera stop bounds (android, v10)

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/camera/CameraStop.java
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/camera/CameraStop.java
@@ -193,9 +193,9 @@ public class CameraStop {
             paddingLeft = Float.valueOf(paddingLeft * metrics.scaledDensity).intValue();
 
             FeatureCollection collection = FeatureCollection.fromJson(readableMap.getString("bounds"));
-            /* v10todo
+
             stop.setBounds(GeoJSONUtils.toLatLngBounds(collection), paddingLeft, paddingRight,
-                    paddingTop, paddingBottom); */
+                    paddingTop, paddingBottom);
         }
 
         if (readableMap.hasKey("mode")) {


### PR DESCRIPTION

## Description

Added support for camera stop bounds. The relevant code was commented in the migration, I just uncommented it

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typings files (`index.d.ts`)
- [ ] I added/ updated a sample (`/example`)

## Screenshot OR Video

<img width="402" alt="image" src="https://user-images.githubusercontent.com/22196689/176692152-dc429cfa-f28d-4e7f-966b-1d3d32c42011.png">
