### PR TITLE
Fix/view prop types

### DIFF
--- a/javascript/utils/index.js
+++ b/javascript/utils/index.js
@@ -1,11 +1,6 @@
 import React from 'react';
-import {
-  ViewPropTypes,
-  View,
-  NativeModules,
-  findNodeHandle,
-  Platform,
-} from 'react-native';
+import { View, NativeModules, findNodeHandle, Platform } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 import resolveAssetSource from 'react-native/Libraries/Image/resolveAssetSource';
 import PropTypes from 'prop-types';
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "@turf/length": "6.5.0",
     "@turf/nearest-point-on-line": "6.5.0",
     "@types/geojson": "^7946.0.7",
-    "debounce": "^1.2.0"
+    "debounce": "^1.2.0",
+    "deprecated-react-native-prop-types": "^2.3.0"
   },
   "devDependencies": {
     "@babel/core": "7.17.5",


### PR DESCRIPTION
## Description

RN 69 came out and with it new release they remove ViewPropTypes from react-native.
This PropTypes is used in the index.js from utils folder and the fact that it got removed provoke a fatal error.

To solve this we use deprecated-react-native-prop-types as temporary solution until someone found a better solution.

