### PR TITLE
fix(ios,v10): Do not specify source for SkyLayer, Validate points

### DIFF
--- a/ios/RCTMGL-v10/Extensions/CLLocationCoordinate2D+validate.swift
+++ b/ios/RCTMGL-v10/Extensions/CLLocationCoordinate2D+validate.swift
@@ -1,0 +1,29 @@
+import MapboxMaps
+
+internal extension CLLocationCoordinate2D {
+  private func doValidate() -> Result<Void,Error> {
+    if latitude < -90.0 || latitude > 90.0 {
+      return .failure(RCTMGLError.paramError("latitude should be between -90 and 90 but it was \(latitude)"))
+    }
+    
+    return .success(())
+  }
+
+  func validate() throws {
+    switch doValidate() {
+    case .success():
+      return
+    case .failure(let error):
+      throw error
+    }
+  }
+
+  func isValid() -> Bool {
+    switch doValidate() {
+    case .success():
+      return true
+    case .failure(_):
+      return false
+    }
+  }
+}

--- a/ios/RCTMGL-v10/RCTMGLCamera.swift
+++ b/ios/RCTMGL-v10/RCTMGLCamera.swift
@@ -19,20 +19,25 @@ struct CameraUpdateItem {
   var duration: TimeInterval?
   
   func execute(map: RCTMGLMapView, cameraAnimator: inout BasicCameraAnimator?) {
-    switch mode {
-      case .flight:
-        var _camera = camera
-        _camera.padding = nil
-        map.camera.fly(to: _camera, duration: duration)
-        changePadding(map: map, cameraAnimator: &cameraAnimator, curve: .linear)
-      case .ease:
-        map.camera.ease(to: camera, duration: duration ?? 0, curve: .easeInOut, completion: nil)
-      case .linear:
-        map.camera.ease(to: camera, duration: duration ?? 0, curve: .linear, completion: nil)
-      case .none:
-        map.mapboxMap.setCamera(to: camera)
-      default:
-        map.mapboxMap.setCamera(to: camera)
+    logged("CameraUpdateItem.execute") {
+      if let center = camera.center {
+        try center.validate()
+      }
+      switch mode {
+        case .flight:
+          var _camera = camera
+          _camera.padding = nil
+          map.camera.fly(to: _camera, duration: duration)
+          changePadding(map: map, cameraAnimator: &cameraAnimator, curve: .linear)
+        case .ease:
+          map.camera.ease(to: camera, duration: duration ?? 0, curve: .easeInOut, completion: nil)
+        case .linear:
+          map.camera.ease(to: camera, duration: duration ?? 0, curve: .linear, completion: nil)
+        case .none:
+          map.mapboxMap.setCamera(to: camera)
+        default:
+          map.mapboxMap.setCamera(to: camera)
+      }
     }
   }
   

--- a/ios/RCTMGL-v10/RCTMGLLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLLayer.swift
@@ -217,7 +217,8 @@ class RCTMGLLayer : UIView, RCTMGLMapComponent, RCTMGLSourceConsumer {
     }
     
     if let sourceID = sourceID {
-      if !(existingLayer && sourceID == DEFAULT_SOURCE_ID) {
+      if !(existingLayer && sourceID == DEFAULT_SOURCE_ID) && hasSource() {
+        
         layer.source = sourceID
       }
     }
@@ -295,5 +296,9 @@ class RCTMGLLayer : UIView, RCTMGLMapComponent, RCTMGLSourceConsumer {
     } catch {
       Logger.log(level: .error, message: "inserting layer failed at position \(layerPosition): \(error.localizedDescription)")
     }
+  }
+  
+  internal func hasSource() -> Bool {
+    return true
   }
 }

--- a/ios/RCTMGL-v10/RCTMGLMarkerView.swift
+++ b/ios/RCTMGL-v10/RCTMGLMarkerView.swift
@@ -12,9 +12,14 @@ class RCTMGLMarkerView : UIView, RCTMGLMapComponent {
   }
   
   func addToMap(_ map: RCTMGLMapView, style: Style) {
-    self.map = map
-    let point = point()!
-    try! viewAnnotations()?.add(self, options: ViewAnnotationOptions.init(geometry: Geometry.point(point), width: self.bounds.width, height: self.bounds.height, associatedFeatureId: nil, allowOverlap: true, visible: true, anchor: .center, offsetX: 0, offsetY: 0, selected: false))
+    logged("RCTMGLMarkerView.addToMap") {
+      self.map = map
+      let point = point()!
+
+      try point.coordinates.validate()
+
+      try viewAnnotations()?.add(self, options: ViewAnnotationOptions.init(geometry: Geometry.point(point), width: self.bounds.width, height: self.bounds.height, associatedFeatureId: nil, allowOverlap: true, visible: true, anchor: .center, offsetX: 0, offsetY: 0, selected: false))
+    }
   }
   
   func viewAnnotations() -> ViewAnnotationManager? {

--- a/ios/RCTMGL-v10/RCTMGLSkyLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLSkyLayer.swift
@@ -46,4 +46,7 @@ class RCTMGLSkyLayer: RCTMGLLayer {
     return true
   }
 
+  internal override func hasSource() -> Bool {
+    return false
+  }
 }


### PR DESCRIPTION
Validate points on MarkerView add, to fix prevent exception `latitude must be between -90 and 90 but was -111.566000`. We should now log error, with rnmapbox error handler instead.