### PR TITLE
Convert Atmosphere to FC and integrate into example

### DIFF
--- a/docs/Atmosphere.md
+++ b/docs/Atmosphere.md
@@ -7,27 +7,6 @@
 | ---- | :--: | :-----: | :------: | :----------: |
 | style | `FIX ME UNKNOWN TYPE` | `none` | `true` | FIX ME NO DESCRIPTION |
 
-### methods
-#### getStyle()
-
-
-
-##### arguments
-| Name | Type | Required | Description  |
-| ---- | :--: | :------: | :----------: |
-
-
-
-#### baseProps()
-
-
-
-##### arguments
-| Name | Type | Required | Description  |
-| ---- | :--: | :------: | :----------: |
-
-
-
 
 ### styles
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2,52 +2,7 @@
   "Atmosphere": {
     "description": "",
     "displayName": "Atmosphere",
-    "methods": [
-      {
-        "name": "getStyle",
-        "docblock": null,
-        "modifiers": [],
-        "params": [],
-        "returns": {
-          "type": {
-            "name": "union",
-            "raw": "{ [key: string]: StyleValue } | undefined",
-            "elements": [
-              {
-                "name": "signature",
-                "type": "object",
-                "raw": "{ [key: string]: StyleValue }",
-                "signature": {
-                  "properties": [
-                    {
-                      "key": {
-                        "name": "string"
-                      },
-                      "value": {
-                        "name": "StyleValue",
-                        "required": true
-                      }
-                    }
-                  ]
-                }
-              },
-              {
-                "name": "undefined"
-              }
-            ]
-          }
-        }
-      },
-      {
-        "name": "baseProps",
-        "docblock": null,
-        "modifiers": [
-          "get"
-        ],
-        "params": [],
-        "returns": null
-      }
-    ],
+    "methods": [],
     "props": [
       {
         "name": "style",

--- a/example/src/examples/V10/TerrainSkyAtmosphere.tsx
+++ b/example/src/examples/V10/TerrainSkyAtmosphere.tsx
@@ -35,13 +35,12 @@ const TerrainSkyAtmosphere = memo((props: BaseExampleProps) => {
         styleURL={'mapbox://styles/mapbox-map-design/ckhqrf2tz0dt119ny6azh975y'}
       >
         <Camera
+          ref={cameraRef}
           centerCoordinate={[
             // -74.00597, 40.71427
             // -122.4189591, 37.6614238,
             -114.34411, 32.6141,
           ]}
-          // @ts-ignore
-          ref={cameraRef}
           zoomLevel={13.1}
           bearing={80}
           pitch={85}

--- a/example/src/examples/V10/TerrainSkyAtmosphere.tsx
+++ b/example/src/examples/V10/TerrainSkyAtmosphere.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { memo, useRef } from 'react';
 import { Button } from 'react-native';
 import {
   MapView,
@@ -7,6 +7,7 @@ import {
   Logger,
   Terrain,
   RasterDemSource,
+  Atmosphere,
 } from '@rnmapbox/maps';
 
 import Page from '../common/Page';
@@ -14,12 +15,9 @@ import { BaseExampleProps } from '../common/BaseExamplePropTypes';
 
 Logger.setLogLevel('verbose');
 
-const styles = {
-  mapView: { flex: 1 },
-};
-
-function SkyAndTerran(props: BaseExampleProps) {
+const TerrainSkyAtmosphere = memo((props: BaseExampleProps) => {
   const cameraRef = useRef<Camera>();
+
   return (
     <Page {...props}>
       <Button
@@ -33,27 +31,36 @@ function SkyAndTerran(props: BaseExampleProps) {
         }
       />
       <MapView
-        style={styles.mapView}
+        style={{ flex: 1 }}
         styleURL={'mapbox://styles/mapbox-map-design/ckhqrf2tz0dt119ny6azh975y'}
       >
         <Camera
           centerCoordinate={[
             // -74.00597, 40.71427
-            //-122.4189591, 37.6614238,
+            // -122.4189591, 37.6614238,
             -114.34411, 32.6141,
           ]}
+          // @ts-ignore
           ref={cameraRef}
           zoomLevel={13.1}
           bearing={80}
           pitch={85}
         />
-
         <RasterDemSource
           id="mapbox-dem"
           url="mapbox://mapbox.mapbox-terrain-dem-v1"
           tileSize={514}
           maxZoomLevel={14}
         >
+          <Atmosphere
+            style={{
+              color: 'rgb(186, 210, 235)',
+              highColor: 'rgb(36, 92, 223)',
+              horizonBlend: 0.02,
+              spaceColor: 'rgb(11, 11, 25)',
+              starIntensity: 0.6,
+            }}
+          />
           <SkyLayer
             id="sky-layer"
             style={{
@@ -62,12 +69,11 @@ function SkyAndTerran(props: BaseExampleProps) {
               skyAtmosphereSunIntensity: 15.0,
             }}
           />
-
           <Terrain exaggeration={1.5} />
         </RasterDemSource>
       </MapView>
     </Page>
   );
-}
+});
 
-export default SkyAndTerran;
+export default TerrainSkyAtmosphere;

--- a/example/src/scenes/Home.js
+++ b/example/src/scenes/Home.js
@@ -225,11 +225,11 @@ function ExampleGroupComponent({ items, navigation, showBack }) {
 
   const back = showBack
     ? {
-      onBack: () => {
-        console.log('GoBACK');
-        navigation.goBack();
-      },
-    }
+        onBack: () => {
+          console.log('GoBACK');
+          navigation.goBack();
+        },
+      }
     : {};
 
   const title = showBack

--- a/example/src/scenes/Home.js
+++ b/example/src/scenes/Home.js
@@ -73,7 +73,7 @@ import UserLocationChange from '../examples/UserLocation/UserLocationChange';
 import BugReportTemplate from '../examples/BugReportExample';
 import CacheManagement from '../examples/CacheManagement';
 // V10
-import SkyAndTerran from '../examples/V10/SkyAndTerran';
+import TerrainSkyAtmosphere from '../examples/V10/TerrainSkyAtmosphere';
 import QueryTerrainElevation from '../examples/V10/QueryTerrainElevation';
 import CameraAnimation from '../examples/V10/CameraAnimation';
 import MapHandlers from '../examples/V10/MapHandlers';
@@ -126,7 +126,7 @@ const BugReportPage = ({ ...props }) => (
 const Examples = [
   new ExampleItem('Bug Report Template', BugReportPage),
   new ExampleGroup('V10', [
-    new ExampleItem('Sky and Terrain', SkyAndTerran),
+    new ExampleItem('Terrain, Sky, & Atmosphere', TerrainSkyAtmosphere),
     new ExampleItem('Query Terrain Elevation', QueryTerrainElevation),
     new ExampleItem('Camera Animation', CameraAnimation),
     new ExampleItem('Map Handlers', MapHandlers),
@@ -225,11 +225,11 @@ function ExampleGroupComponent({ items, navigation, showBack }) {
 
   const back = showBack
     ? {
-        onBack: () => {
-          console.log('GoBACK');
-          navigation.goBack();
-        },
-      }
+      onBack: () => {
+        console.log('GoBACK');
+        navigation.goBack();
+      },
+    }
     : {};
 
   const title = showBack

--- a/javascript/components/Atmosphere.tsx
+++ b/javascript/components/Atmosphere.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo, useMemo } from 'react';
 import { HostComponent, requireNativeComponent } from 'react-native';
 
 import type { AtmosphereLayerStyleProps } from '../utils/MapboxStyles';
@@ -6,28 +6,21 @@ import { StyleValue, transformStyle } from '../utils/StyleValue';
 
 export const NATIVE_MODULE_NAME = 'RCTMGLAtmosphere';
 
-class Atmosphere extends React.PureComponent<{
+type Props = {
   style: AtmosphereLayerStyleProps;
-}> {
-  getStyle(): { [key: string]: StyleValue } | undefined {
-    return transformStyle(this.props.style);
-  }
+};
 
-  get baseProps() {
+const Atmosphere = memo((props: Props) => {
+  const baseProps = useMemo(() => {
     return {
-      ...this.props,
-      reactStyle: this.getStyle(),
+      ...props,
+      reactStyle: transformStyle(props.style),
       style: undefined,
     };
-  }
+  }, [props]);
 
-  render() {
-    const props = {
-      ...this.baseProps,
-    };
-    return <RCTMGLAtmosphere {...props} />;
-  }
-}
+  return <RCTMGLAtmosphere {...baseProps} />;
+});
 
 const RCTMGLAtmosphere: HostComponent<{
   reactStyle?: { [key: string]: StyleValue };


### PR DESCRIPTION
## Description

This changes `Atmosphere.tsx` to a functional component, and adds it to the sky/terrain example.

(I wanted to try the functional component syntax with a simpler Typescript component, before trying to update the much more complex `Camera`.)

## Screenshot

https://user-images.githubusercontent.com/2423291/179558302-d2ba95f1-b4c8-4a5e-b503-f47c077b9539.mov