### PR TITLE
iOS: Resolve RCTSwiftLog duplicate symbols build failure

### DIFF
--- a/ios/RCTMGL-v10/RCTLog.swift
+++ b/ios/RCTMGL-v10/RCTLog.swift
@@ -1,19 +1,19 @@
 func RCTLogError(_ message: String, _ file: String=#file, _ line: UInt=#line) {
-  RCTSwiftLog.error(message, file: file, line: line)
+  RCTMGLSwiftLog.error(message, file: file, line: line)
 }
 
 func RCTLogWarn(_ message: String, _ file: String=#file, _ line: UInt=#line) {
-  RCTSwiftLog.warn(message, file: file, line: line)
+  RCTMGLSwiftLog.warn(message, file: file, line: line)
 }
 
 func RCTLogInfo(_ message: String, _ file: String=#file, _ line: UInt=#line) {
-  RCTSwiftLog.info(message, file: file, line: line)
+  RCTMGLSwiftLog.info(message, file: file, line: line)
 }
 
 func RCTLog(_ message: String, _ file: String=#file, _ line: UInt=#line) {
-  RCTSwiftLog.log(message, file: file, line: line)
+  RCTMGLSwiftLog.log(message, file: file, line: line)
 }
 
 func RCTLogTrace(_ message: String, _ file: String=#file, _ line: UInt=#line) {
-  RCTSwiftLog.trace(message, file: file, line: line)
+  RCTMGLSwiftLog.trace(message, file: file, line: line)
 }

--- a/ios/RCTMGL-v10/RCTSwiftLog.h
+++ b/ios/RCTMGL-v10/RCTSwiftLog.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-@interface RCTSwiftLog : NSObject
+@interface RCTMGLSwiftLog : NSObject
 
 + (void)error:(NSString * _Nonnull)message file:(NSString * _Nonnull)file line:(NSUInteger)line;
 + (void)warn:(NSString * _Nonnull)message file:(NSString * _Nonnull)file line:(NSUInteger)line;

--- a/ios/RCTMGL-v10/RCTSwiftLog.m
+++ b/ios/RCTMGL-v10/RCTSwiftLog.m
@@ -2,7 +2,7 @@
 
 #import "RCTSwiftLog.h"
 
-@implementation RCTSwiftLog
+@implementation RCTMGLSwiftLog
 
 + (void)info:(NSString *)message file:(NSString *)file line:(NSUInteger)line
 {

--- a/rnmapbox-maps.podspec
+++ b/rnmapbox-maps.podspec
@@ -252,7 +252,6 @@ Pod::Spec.new do |s|
     case $RNMapboxMapsImpl
     when 'mapbox'
       sp.source_files = "ios/RCTMGL-v10/**/*.{h,m,swift}"
-      sp.public_header_files = 'ios/RCTMGL-v10/Bridge/*.h'
     when 'mapbox-gl'
       sp.source_files	= "ios/RCTMGL/**/*.{h,m}"
     when 'maplibre'


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes iOS build failures for duplicate symbols and file not found errors when use_frameworks! :linkage => :static is enabled and another module also defines RCTSwiftLog.

RCTSwiftLog's header was not public and therefore could not be found. The public_headers callout in the podspec was removed making all of the header files publicly accessible.

This then created a new issue which is also addressed here. react-native-video also has an RCTSwiftLog header and this was causing a duplicate symbol build failure. Therefore, RCTSwiftLog was simply renamed RCTMGLSwiftLog in the implementation to avoid the public header name collision.

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typings files (`index.d.ts`)
- [ ] I added/ updated a sample (`/example`)
