### PR TITLE
iOS: Fix Raster Source setZoomLevel crash

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLRasterSource.swift
+++ b/ios/RCTMGL-v10/RCTMGLRasterSource.swift
@@ -8,8 +8,8 @@ class RCTMGLRasterSource : RCTMGLSource {
   
   @objc var tileUrlTemplates: [String]? = nil
   
-  @objc var minzoom: NSNumber?
-  @objc var maxzoom: NSNumber?
+  @objc var minZoomLevel: NSNumber?
+  @objc var maxZoomLevel: NSNumber?
   @objc var tileSize: NSNumber?
   
   @objc var tms: Bool = false
@@ -29,12 +29,12 @@ class RCTMGLRasterSource : RCTMGLSource {
       result.tileSize = tileSize.doubleValue
     }
     
-    if let minzoom = minzoom {
-      result.minzoom = minzoom.doubleValue
+    if let minZoomLevel = minZoomLevel {
+      result.minzoom = minZoomLevel.doubleValue
     }
     
-    if let maxzoom = maxzoom {
-      result.maxzoom = maxzoom.doubleValue
+    if let maxZoomLevel = maxZoomLevel {
+      result.maxzoom = maxZoomLevel.doubleValue
     }
     
     if tms {


### PR DESCRIPTION
- Reference the correct variable names passed in from React to avoid the crash

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes an iOS crash when setting the min/max zoom level on a raster source.

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typings files (`index.d.ts`)
- [ ] I added/ updated a sample (`/example`)

## Screenshot OR Video

![Simulator Screen Shot - iPhone 13 Pro - 2022-07-19 at 14 09 50](https://user-images.githubusercontent.com/10301026/179820017-175fab6f-b16b-4f72-91b7-e328458be520.png)

