### PR TITLE
iOS (v10) VectorSource Props

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLVectorSource.swift
+++ b/ios/RCTMGL-v10/RCTMGLVectorSource.swift
@@ -3,7 +3,11 @@ import MapboxMaps
 @objc
 class RCTMGLVectorSource : RCTMGLTileSource {
   
+  @objc var attribution: String?
+  @objc var maxZoomLevel: NSNumber?
+  @objc var minZoomLevel: NSNumber?
   @objc var tileUrlTemplates: [String] = []
+  @objc var tms: Bool = false
   
   override func sourceType() -> Source.Type {
     return VectorSource.self
@@ -17,7 +21,18 @@ class RCTMGLVectorSource : RCTMGLTileSource {
     } else {
       result.tiles = tileUrlTemplates
     }
-    
+    if let attribution = attribution {
+      result.attribution = attribution
+    }
+    if let maxZoomLevel = maxZoomLevel {
+      result.maxzoom = maxZoomLevel.doubleValue
+    }
+    if let minZoomLevel = minZoomLevel {
+      result.minzoom = minZoomLevel.doubleValue
+    }
+    if tms {
+      result.scheme = .tms
+    }
     return result
   }
   


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Add support for attribution, maxZoomLevel, minZoomLevel, and tms props when making a vector source on iOS (v10). Prior to this change, trying to set the min/max zoom level would raise an exception.

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typings files (`index.d.ts`)
- [ ] I added/ updated a sample (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
