### PR TITLE
Feature: compassFadeWhenNorth

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.kt
@@ -846,11 +846,17 @@ open class RCTMGLMapView(private val mContext: Context, var mManager: RCTMGLMapV
     }
 
     var mCompassEnabled = false
+    var mCompassFadeWhenNorth = true
     var mCompassViewMargins: ReadableMap? = null
     var mCompassViewPosition: Int = -1
 
     fun setReactCompassEnabled(compassEnabled: Boolean) {
         mCompassEnabled = compassEnabled
+        updateCompass()
+    }
+
+    fun setReactCompassFadeWhenNorth(compassFadeWhenNorth: Boolean) {
+        mCompassFadeWhenNorth = compassFadeWhenNorth
         updateCompass()
     }
 
@@ -894,6 +900,7 @@ open class RCTMGLMapView(private val mContext: Context, var mManager: RCTMGLMapV
     private fun updateCompass() {
         compass.updateSettings {
             enabled = mCompassEnabled
+            fadeWhenFacingNorth = mCompassFadeWhenNorth
             if (mCompassViewPosition >= 0) {
                 position = toGravity("compass", mCompassViewPosition)
             }

--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.kt
@@ -846,7 +846,7 @@ open class RCTMGLMapView(private val mContext: Context, var mManager: RCTMGLMapV
     }
 
     var mCompassEnabled = false
-    var mCompassFadeWhenNorth = true
+    var mCompassFadeWhenNorth = false
     var mCompassViewMargins: ReadableMap? = null
     var mCompassViewPosition: Int = -1
 

--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.kt
@@ -135,6 +135,11 @@ open class RCTMGLMapViewManager(context: ReactApplicationContext?) :
         mapView!!.setReactCompassEnabled(compassEnabled!!);
     }
 
+    @ReactProp(name = "compassFadeWhenNorth")
+    fun setCompassFadeWhenNorth(mapView: RCTMGLMapView?, compassFadeWhenNorth: Boolean) {
+        mapView!!.setReactCompassFadeWhenNorth(compassFadeWhenNorth!!);
+    }
+
     @ReactProp(name = "compassViewMargins")
     fun setCompassViewMargins(mapView: RCTMGLMapView?, compassViewMargins: ReadableMap?) {
         mapView!!.setReactCompassViewMargins(compassViewMargins!!);

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -21,7 +21,7 @@
 | logoEnabled | `bool` | `true` | `false` | Enable/Disable the logo on the map. |
 | logoPosition | `custom` | `none` | `false` | Adds logo offset, e.g. `{top: 8, left: 8}` will put the logo in top-left corner of the map |
 | compassEnabled | `bool` | `none` | `false` | Enable/Disable the compass from appearing on the map |
-| compassFadeWhenNorth | `bool` | `none` | `true` | Enable/Disable if the compass should fade out when the map is pointing north |
+| compassFadeWhenNorth | `bool` | `none` | `false` | Enable/Disable if the compass should fade out when the map is pointing north |
 | compassPosition | `custom` | `none` | `false` | [`mapbox` (v10) implementation only] Adds compass offset, e.g. `{top: 8, left: 8}` will put the compass in top-left corner of the map |
 | compassViewPosition | `number` | `none` | `false` | Change corner of map the compass starts at. 0: TopLeft, 1: TopRight, 2: BottomLeft, 3: BottomRight |
 | compassViewMargins | `object` | `none` | `false` | Add margins to the compass with x and y values |

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -20,8 +20,8 @@
 | tintColor | `union` | `none` | `false` | MapView's tintColor |
 | logoEnabled | `bool` | `true` | `false` | Enable/Disable the logo on the map. |
 | logoPosition | `custom` | `none` | `false` | Adds logo offset, e.g. `{top: 8, left: 8}` will put the logo in top-left corner of the map |
-| compassEnabled | `bool` | `none` | `false` | Enable/Disable the compass from appearing on the map |
-| compassFadeWhenNorth | `bool` | `none` | `false` | Enable/Disable if the compass should fade out when the map is pointing north |
+| compassEnabled | `bool` | `false` | `false` | Enable/Disable the compass from appearing on the map |
+| compassFadeWhenNorth | `bool` | `false` | `false` | [`mapbox` (v10) implementation only] Enable/Disable if the compass should fade out when the map is pointing north |
 | compassPosition | `custom` | `none` | `false` | [`mapbox` (v10) implementation only] Adds compass offset, e.g. `{top: 8, left: 8}` will put the compass in top-left corner of the map |
 | compassViewPosition | `number` | `none` | `false` | Change corner of map the compass starts at. 0: TopLeft, 1: TopRight, 2: BottomLeft, 3: BottomRight |
 | compassViewMargins | `object` | `none` | `false` | Add margins to the compass with x and y values |

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -21,6 +21,7 @@
 | logoEnabled | `bool` | `true` | `false` | Enable/Disable the logo on the map. |
 | logoPosition | `custom` | `none` | `false` | Adds logo offset, e.g. `{top: 8, left: 8}` will put the logo in top-left corner of the map |
 | compassEnabled | `bool` | `none` | `false` | Enable/Disable the compass from appearing on the map |
+| compassFadeWhenNorth | `bool` | `none` | `true` | Enable/Disable if the compass should fade out when the map is pointing north |
 | compassPosition | `custom` | `none` | `false` | [`mapbox` (v10) implementation only] Adds compass offset, e.g. `{top: 8, left: 8}` will put the compass in top-left corner of the map |
 | compassViewPosition | `number` | `none` | `false` | Change corner of map the compass starts at. 0: TopLeft, 1: TopRight, 2: BottomLeft, 3: BottomRight |
 | compassViewMargins | `object` | `none` | `false` | Add margins to the compass with x and y values |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3200,14 +3200,14 @@
         "name": "compassEnabled",
         "required": false,
         "type": "bool",
-        "default": "none",
+        "default": "false",
         "description": "Enable/Disable the compass from appearing on the map"
       },
       {
         "name": "compassFadeWhenNorth",
         "required": false,
         "type": "bool",
-        "default": "true",
+        "default": "false",
         "description": "Enable/Disable if the compass should fade out when the map is pointing north"
       },
       {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3204,6 +3204,13 @@
         "description": "Enable/Disable the compass from appearing on the map"
       },
       {
+        "name": "compassFadeWhenNorth",
+        "required": false,
+        "type": "bool",
+        "default": "true",
+        "description": "Enable/Disable if the compass should fade out when the map is pointing north"
+      },
+      {
         "name": "compassPosition",
         "required": false,
         "type": "custom",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3208,7 +3208,7 @@
         "required": false,
         "type": "bool",
         "default": "false",
-        "description": "Enable/Disable if the compass should fade out when the map is pointing north"
+        "description": "[`mapbox` (v10) implementation only] Enable/Disable if the compass should fade out when the map is pointing north"
       },
       {
         "name": "compassPosition",

--- a/index.d.ts
+++ b/index.d.ts
@@ -542,6 +542,7 @@ export interface MapViewProps extends ViewProps {
   logoEnabled?: boolean;
   logoPosition?: OrnamentPosition;
   compassEnabled?: boolean;
+  compassFadeWhenNorth?: boolean;
   compassPosition?: OrnamentPosition;
   compassViewPosition?: number;
   compassViewMargins?: Point;

--- a/ios/RCTMGL-v10/RCTMGLMapView.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapView.swift
@@ -155,7 +155,11 @@ open class RCTMGLMapView : MapView {
   }
   
   @objc func setReactCompassEnabled(_ value: Bool) {
-    mapView.ornaments.options.compass.visibility = value ? .visible : .hidden
+    mapView.ornaments.options.compass.visibility = value ? .adaptive : .hidden
+  }
+  
+  @objc func setReactCompassFadeWhenNorth(_ value: Bool) {
+    mapView.ornaments.options.compass.visibility = value ? .adaptive : .visible
   }
   
   @objc func setReactCompassPosition(_ position: [String: Int]!) {

--- a/ios/RCTMGL-v10/RCTMGLMapView.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapView.swift
@@ -4,6 +4,8 @@ import MapKit
 
 @objc(RCTMGLMapView)
 open class RCTMGLMapView : MapView {
+  var compassEnabled: Bool = false
+  var compassFadeWhenNorth: Bool = false
   var reactOnPress : RCTBubblingEventBlock?
   var reactOnLongPress : RCTBubblingEventBlock?
   var reactOnMapChange : RCTBubblingEventBlock?
@@ -155,11 +157,15 @@ open class RCTMGLMapView : MapView {
   }
   
   @objc func setReactCompassEnabled(_ value: Bool) {
-    mapView.ornaments.options.compass.visibility = value ? .adaptive : .hidden
+    compassEnabled = value
+    mapView.ornaments.options.compass.visibility = value ? compassFadeWhenNorth ? .adaptive : .visible : .hidden
   }
   
   @objc func setReactCompassFadeWhenNorth(_ value: Bool) {
-    mapView.ornaments.options.compass.visibility = value ? .adaptive : .visible
+    compassFadeWhenNorth = value
+    if (compassEnabled) {
+      mapView.ornaments.options.compass.visibility = value ? .adaptive : .visible
+    }
   }
   
   @objc func setReactCompassPosition(_ position: [String: Int]!) {

--- a/ios/RCTMGL-v10/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL-v10/RCTMGLMapViewManager.m
@@ -8,6 +8,7 @@ RCT_REMAP_VIEW_PROPERTY(attributionPosition, reactAttributionPosition, NSDiction
 RCT_REMAP_VIEW_PROPERTY(logoEnabled, reactLogoEnabled, BOOL)
 RCT_REMAP_VIEW_PROPERTY(logoPosition, reactLogoPosition, NSDictionary)
 RCT_REMAP_VIEW_PROPERTY(compassEnabled, reactCompassEnabled, BOOL)
+RCT_REMAP_VIEW_PROPERTY(compassFadeWhenNorth, reactCompassFadeWhenNorth, BOOL)
 RCT_REMAP_VIEW_PROPERTY(compassPosition, reactCompassPosition, NSDictionary)
 RCT_REMAP_VIEW_PROPERTY(compassViewPosition, reactCompassViewPosition, NSInteger)
 RCT_REMAP_VIEW_PROPERTY(compassViewMargins, reactCompassViewMargins, CGPoint)

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -145,6 +145,11 @@ class MapView extends NativeBridgeComponent(React.Component) {
     compassEnabled: PropTypes.bool,
 
     /**
+     * [`mapbox` (v10) implementation only] Enable/Disable whether the compass fades out when the map is pointing north
+     */
+    compassFadeWhenNorth: PropTypes.bool,
+
+    /**
      * [`mapbox` (v10) implementation only] Adds compass offset, e.g. `{top: 8, left: 8}` will put the compass in top-left corner of the map
      */
     compassPosition: ornamentPositionPropType,

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -145,7 +145,7 @@ class MapView extends NativeBridgeComponent(React.Component) {
     compassEnabled: PropTypes.bool,
 
     /**
-     * [`mapbox` (v10) implementation only] Enable/Disable whether the compass fades out when the map is pointing north
+     * [`mapbox` (v10) implementation only] Enable/Disable if the compass should fade out when the map is pointing north
      */
     compassFadeWhenNorth: PropTypes.bool,
 
@@ -306,6 +306,8 @@ class MapView extends NativeBridgeComponent(React.Component) {
     pitchEnabled: true,
     rotateEnabled: true,
     attributionEnabled: true,
+    compassEnabled: false,
+    compassFadeWhenNorth: false,
     logoEnabled: true,
     scaleBarEnabled: true,
     surfaceView: false,


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Added the ability to control whether or not the compass fades out when pointing north. On Android the default was true, and on iOS the default was false. This brings consistency across platforms by defaulting to true ("breaking" for iOS) and adds the ability to toggle this behavior on/off with a new prop

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
- [ ] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typings files (`index.d.ts`)
- [ ] I added/ updated a sample (`/example`)
