### PR TITLE
fix(v10,ios,offline): Show offline pack as completed if it is complet…

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLOfflineModule.swift
+++ b/ios/RCTMGL-v10/RCTMGLOfflineModule.swift
@@ -270,7 +270,7 @@ class RCTMGLOfflineModule: RCTEventEmitter {
       let progressPercentage =  Float(progress.completedResourceCount) / Float(progress.requiredResourceCount)
       
       result = [
-        "state": state.rawValue,
+        "state": (progress.completedResourceCount == progress.requiredResourceCount) ? State.complete.rawValue : state.rawValue,
         "name": name,
         "percentage": progressPercentage * 100.0,
         "completedResourceCount": progress.completedResourceCount,


### PR DESCRIPTION
…ed by resource counts

Fixes `(await pack.status()).state` to be `complete` when it's completed form counts.