### PR TITLE
Update `PointAnnotation` type definition to include `style` prop

### DIFF
--- a/docs/PointAnnotation.md
+++ b/docs/PointAnnotation.md
@@ -14,6 +14,7 @@
 | anchor | `shape` | `{ x: 0.5, y: 0.5 }` | `false` | Specifies the anchor being set on a particular point of the annotation.<br/>The anchor point is specified in the continuous space [0.0, 1.0] x [0.0, 1.0],<br/>where (0, 0) is the top-left corner of the image, and (1, 1) is the bottom-right corner.<br/>Note this is only for custom annotations not the default pin view.<br/>Defaults to the center of the view. |
 | &nbsp;&nbsp;x | `number` | `none` | `true` | See anchor |
 | &nbsp;&nbsp;y | `number` | `none` | `true` | See anchor |
+| style | `any` | `none` | `false` | Customizable style attributes |
 | onSelected | `func` | `none` | `false` | This callback is fired once this annotation is selected. Returns a Feature as the first param. |
 | onDeselected | `func` | `none` | `false` | This callback is fired once this annotation is deselected. |
 | onDragStart | `func` | `none` | `false` | This callback is fired once this annotation has started being dragged. |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3176,6 +3176,13 @@
         "description": "Specifies the anchor being set on a particular point of the annotation.\nThe anchor point is specified in the continuous space [0.0, 1.0] x [0.0, 1.0],\nwhere (0, 0) is the top-left corner of the image, and (1, 1) is the bottom-right corner.\nNote this is only for custom annotations not the default pin view.\nDefaults to the center of the view."
       },
       {
+        "name": "style",
+        "required": false,
+        "type": "any",
+        "default": "none",
+        "description": "Customizable style attributes"
+      },
+      {
         "name": "onSelected",
         "required": false,
         "type": "func",

--- a/index.d.ts
+++ b/index.d.ts
@@ -852,6 +852,7 @@ export interface PointAnnotationProps {
   draggable?: boolean;
   coordinate: GeoJSON.Position;
   anchor?: Point;
+  style?: StyleProp<WithExpression<ViewStyle>>;
   children: JSX.Element;
   onSelected?: () => void;
   onDeselected?: () => void;
@@ -859,6 +860,8 @@ export interface PointAnnotationProps {
   onDrag?: () => void;
   onDragEnd?: () => void;
 }
+
+export type PointAnnotationStyle = StyleProp<WithExpression<ViewStyle>>;
 
 export type MarkerViewProps = PointAnnotationProps;
 

--- a/javascript/components/PointAnnotation.js
+++ b/javascript/components/PointAnnotation.js
@@ -80,6 +80,11 @@ class PointAnnotation extends NativeBridgeComponent(React.PureComponent) {
     }),
 
     /**
+     * Customizable style attributes
+     */
+    style: PropTypes.any,
+
+    /**
      * This callback is fired once this annotation is selected. Returns a Feature as the first param.
      */
     onSelected: PropTypes.func,


### PR DESCRIPTION
This adds a `style` prop to the `PointAnnotation` definition and docs. There's no functionality change - it just matches the typing to the existing component.