### PR TITLE
fix(ios,v10): centerCoordinate should be converted to feature when passing to native layer

### DIFF
--- a/javascript/components/Camera.tsx
+++ b/javascript/components/Camera.tsx
@@ -224,7 +224,9 @@ export const Camera = memo(
           return null;
         }
         const _defaultStop: NativeCameraStop = {
-          centerCoordinate: JSON.stringify(defaultSettings.centerCoordinate),
+          centerCoordinate: JSON.stringify(
+            makePoint(defaultSettings.centerCoordinate),
+          ),
           bounds: JSON.stringify(defaultSettings.bounds),
           heading: defaultSettings.heading ?? 0,
           pitch: defaultSettings.pitch ?? 0,


### PR DESCRIPTION
Fixes: crash in Map/Source Layer Visibility for example. 


```jsx
<MapboxGL.Camera 
   defaultSettings={{
     centerCoordinate: [-74.005974, 40.712776],
     zoomLevel: 13
  }}
/>
```

Old implementation called `this._createStopConfig` for `defaultSettings`

https://github.com/rnmapbox/maps/blob/9148dd77d126c670308e79bb0bf6667c640d9a6a/javascript/components/Camera.js#L564-L569

The new implementation doesn't call it:
https://github.com/rnmapbox/maps/blob/120c375b65734c707b15b54a94f7bfc7e96fd39b/javascript/components/Camera.tsx#L226-L238

I think there is the same issue with `bounds` as unlike with `buildNativeStop` we're not calling `makeLatLngBounds` for bounds.