### PR TITLE
fix(camera): do not use defaultSettings to fill in missing info

### DIFF
--- a/javascript/components/Camera.tsx
+++ b/javascript/components/Camera.tsx
@@ -219,28 +219,6 @@ export const Camera = memo(
       // @ts-expect-error This avoids a type/value mismatch.
       const nativeCamera = useRef<RCTMGLCamera>(null);
 
-      const nativeDefaultStop = useMemo((): NativeCameraStop | null => {
-        if (!defaultSettings) {
-          return null;
-        }
-        const _defaultStop: NativeCameraStop = {
-          centerCoordinate: JSON.stringify(
-            makePoint(defaultSettings.centerCoordinate),
-          ),
-          bounds: JSON.stringify(defaultSettings.bounds),
-          heading: defaultSettings.heading ?? 0,
-          pitch: defaultSettings.pitch ?? 0,
-          zoom: defaultSettings.zoomLevel ?? 11,
-          paddingTop: defaultSettings.padding?.paddingTop ?? 0,
-          paddingBottom: defaultSettings.padding?.paddingBottom ?? 0,
-          paddingLeft: defaultSettings.padding?.paddingLeft ?? 0,
-          paddingRight: defaultSettings.padding?.paddingRight ?? 0,
-          duration: defaultSettings.animationDuration ?? 2000,
-          mode: nativeAnimationMode(defaultSettings.animationMode),
-        };
-        return _defaultStop;
-      }, [defaultSettings]);
-
       const buildNativeStop = useCallback(
         (
           stop: CameraStop,
@@ -255,7 +233,7 @@ export const Camera = memo(
             return null;
           }
 
-          const _nativeStop: NativeCameraStop = { ...nativeDefaultStop };
+          const _nativeStop: NativeCameraStop = {};
 
           if (stop.pitch !== undefined) _nativeStop.pitch = stop.pitch;
           if (stop.heading !== undefined) _nativeStop.heading = stop.heading;
@@ -287,8 +265,15 @@ export const Camera = memo(
 
           return _nativeStop;
         },
-        [props.followUserLocation, nativeDefaultStop],
+        [props.followUserLocation],
       );
+
+      const nativeDefaultStop = useMemo((): NativeCameraStop | null => {
+        if (!defaultSettings) {
+          return null;
+        }
+        return buildNativeStop(defaultSettings);
+      }, [defaultSettings, buildNativeStop]);
 
       const nativeStop = useMemo(() => {
         return buildNativeStop({


### PR DESCRIPTION
`{ ...nativeDefaultStop };` was filling in `centerCoorditnate` from default settings, so with `fitBounds` bounds did not apply as center was already set.

Fixes: #2121 

