### PR TITLE
Add aboveLayerID to UserLocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## UNRELEASED
 
+Add aboveLayerID to UserLocation ([#2135](https://github.com/rnmapbox/maps/pull/2135))
+
 ```
 Please add unreleased changes in the following style:
 PR Title ([#123](link to my pr))

--- a/docs/UserLocation.md
+++ b/docs/UserLocation.md
@@ -9,6 +9,7 @@
 | renderMode | `enum` | `'normal'` | `false` | Which render mode to use.<br/>Can either be `normal` or `native` |
 | androidRenderMode | `enum` | `none` | `false` | native/android only render mode<br/><br/> - normal: just a circle<br/> - compass: triangle with heading<br/> - gps: large arrow<br/><br/>@platform android |
 | visible | `bool` | `true` | `false` | Whether location icon is visible |
+| aboveLayerID | `string` | `undefined` | `false` | In `normal` render mode, optional layer above which to render location indicator |
 | onPress | `func` | `none` | `false` | Callback that is triggered on location icon press |
 | onUpdate | `func` | `none` | `false` | Callback that is triggered on location update |
 | showsUserHeadingIndicator | `bool` | `false` | `false` | Show or hide small arrow which indicates direction the device is pointing relative to north. |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -5720,6 +5720,13 @@
         "description": "Whether location icon is visible"
       },
       {
+        "name": "aboveLayerID",
+        "required": false,
+        "type": "string",
+        "default": "undefined",
+        "description": "In `normal` render mode, optional layer above which to render location indicator"
+      },
+      {
         "name": "onPress",
         "required": false,
         "type": "func",

--- a/index.d.ts
+++ b/index.d.ts
@@ -605,6 +605,7 @@ export interface UserLocationProps {
   renderMode?: 'normal' | 'native';
   showsUserHeadingIndicator?: boolean;
   visible?: boolean;
+  aboveLayerID?: string;
 }
 
 export type WithExpression<T> = {

--- a/javascript/components/UserLocation.js
+++ b/javascript/components/UserLocation.js
@@ -31,15 +31,17 @@ const layerStyles = {
   },
 };
 
-export const normalIcon = (showsUserHeadingIndicator, heading) => [
+export const normalIcon = (showsUserHeadingIndicator, heading, aboveLayerID) => [
   <CircleLayer
     key="mapboxUserLocationPluseCircle"
     id="mapboxUserLocationPluseCircle"
+    aboveLayerID={aboveLayerID}
     style={layerStyles.normal.pluse}
   />,
   <CircleLayer
     key="mapboxUserLocationWhiteCircle"
     id="mapboxUserLocationWhiteCircle"
+    aboveLayerID="mapboxUserLocationPluseCircle"
     style={layerStyles.normal.background}
   />,
   <CircleLayer
@@ -83,6 +85,11 @@ class UserLocation extends React.Component {
     visible: PropTypes.bool,
 
     /**
+     * In `normal` render mode, optional layer above which to render location indicator
+     */
+    aboveLayerID: PropTypes.string,
+
+    /**
      * Callback that is triggered on location icon press
      */
     onPress: PropTypes.func,
@@ -111,6 +118,7 @@ class UserLocation extends React.Component {
   static defaultProps = {
     animated: true,
     visible: true,
+    aboveLayerID: undefined,
     showsUserHeadingIndicator: false,
     minDisplacement: 0,
     renderMode: 'normal',
@@ -240,7 +248,7 @@ class UserLocation extends React.Component {
 
   render() {
     const { heading, coordinates } = this.state;
-    const { children, visible, showsUserHeadingIndicator, onPress, animated } =
+    const { children, visible, aboveLayerID, showsUserHeadingIndicator, onPress, animated } =
       this.props;
 
     if (!visible) {
@@ -265,7 +273,7 @@ class UserLocation extends React.Component {
           iconRotate: heading,
         }}
       >
-        {children || normalIcon(showsUserHeadingIndicator, heading)}
+        {children || normalIcon(showsUserHeadingIndicator, heading, aboveLayerID)}
       </Annotation>
     );
   }


### PR DESCRIPTION
## Description

Fixes #534 

We can now specify a layer id above which all UserLocation layers should render, effectively allowing us to render UserLocation above everything else on our map.

## Checklist

- [x] I have tested this on a device/simulator for each compatible OS
- [X] I updated the documentation with running `yarn generate` in the root folder
- [x] I mentioned this change in `CHANGELOG.md`
- [X] I updated the typings files (`index.d.ts`)
- [ ] I added/ updated a sample (`/example`)

## Screenshot OR Video

Before:
![photo_2022-08-17 15 41 22](https://user-images.githubusercontent.com/41524992/185256274-4501761c-277e-4573-a800-5f0bb69d4881.jpeg)

After
![photo_2022-08-17 15 41 26](https://user-images.githubusercontent.com/41524992/185256292-33c10d7c-df46-4fd4-94ad-9005b78769f2.jpeg)

