### PR TITLE
Fix: iOS v10 add/remove components from map

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLMapView.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapView.swift
@@ -43,9 +43,10 @@ open class RCTMGLMapView : MapView {
     if let mapComponent = subview as? RCTMGLMapComponent {
       let style = mapView.mapboxMap.style
       if mapComponent.waitForStyleLoad() {
-        onStyleLoadedComponents.append(mapComponent)
-        if (style.isLoaded) {
+        if (self.styleLoaded) {
           mapComponent.addToMap(self, style: style)
+        } else {
+          onStyleLoadedComponents.append(mapComponent)
         }
       } else {
         mapComponent.addToMap(self, style: style)
@@ -62,8 +63,9 @@ open class RCTMGLMapView : MapView {
     if let mapComponent = subview as? RCTMGLMapComponent {
       if mapComponent.waitForStyleLoad() {
         onStyleLoadedComponents.removeAll { $0 === mapComponent }
+      } else {
+        mapComponent.removeFromMap(self)
       }
-      mapComponent.removeFromMap(self)
     } else {
       subview.reactSubviews()?.forEach { removeFromMap($0) }
     }

--- a/ios/RCTMGL-v10/RCTMGLMapView.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapView.swift
@@ -63,9 +63,8 @@ open class RCTMGLMapView : MapView {
     if let mapComponent = subview as? RCTMGLMapComponent {
       if mapComponent.waitForStyleLoad() {
         onStyleLoadedComponents.removeAll { $0 === mapComponent }
-      } else {
-        mapComponent.removeFromMap(self)
       }
+      mapComponent.removeFromMap(self)
     } else {
       subview.reactSubviews()?.forEach { removeFromMap($0) }
     }


### PR DESCRIPTION
## Description

Fixes an issue with adding/removing components to/from the map on iOS (v10) by correcting the style is loaded logic

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typings files (`index.d.ts`)
- [ ] I added/ updated a sample (`/example`)

## Screenshot OR Video

Example: Rendering an array of user added point annotations with lines drawn between them would stop adding new elements to the map by the third point (or no lines drawn depending upon rendering order). Same code on v8 worked and is now working again with the changes proposed
