### PR TITLE
fix(web): add mapbox-gl as an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,13 @@
   "peerDependencies": {
     "prop-types": ">=15.5.8",
     "react": ">=16.6.1",
-    "react-native": ">=0.59.9"
+    "react-native": ">=0.59.9",
+    "mapbox-gl": "^ 2.9.0"
+  },
+  "peerDependenciesMeta" : {
+    "mapbox-gl": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@expo/config-plugins": "^4.0.3",


### PR DESCRIPTION
* web version needs, mapbox-gl dependency, but we don't want to require it for native builds, so try it as an optional peer dependency.