### PR TITLE
fix: react-native used the web version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "author": "React Native Mapbox Team",
   "main": "./javascript/index.js",
   "browser": "./javascript/index.web.js",
+  "react-native": "./javascript/index.js",
   "keywords": [
     "gl",
     "ios",


### PR DESCRIPTION
Use `react-native` in package.json to point to non web version.

Fixes: #2149 
