### PR TITLE
fix(android): Prevent Error thrown on null values for layer Id's

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.kt
@@ -527,7 +527,11 @@ open class RCTMGLMapView(private val mContext: Context, var mManager: RCTMGLMapV
         layerWaiters.remove(layerId)
     }
 
-    fun waitForLayer(layerID: String, callback: FoundLayerCallback) {
+    fun waitForLayer(layerID: String?, callback: FoundLayerCallback) {
+        if(layerID == null){
+            callback.found(null)
+            return
+        }
         if (savedStyle != null) {
             val layer = savedStyle?.getLayer(layerID)
             if (layer != null) {

--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/styles/layers/RCTLayer.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/styles/layers/RCTLayer.kt
@@ -49,7 +49,7 @@ abstract class RCTLayer<T : Layer?>(protected var mContext: Context) : AbstractS
         mSourceID = sourceID
     }
 
-    fun setAboveLayerID(aboveLayerID: String) {
+    fun setAboveLayerID(aboveLayerID: String?) {
         if (mAboveLayerID != null && mAboveLayerID == aboveLayerID) {
             return
         }
@@ -60,7 +60,7 @@ abstract class RCTLayer<T : Layer?>(protected var mContext: Context) : AbstractS
         }
     }
 
-    fun setBelowLayerID(belowLayerID: String) {
+    fun setBelowLayerID(belowLayerID: String?) {
         if (mBelowLayerID != null && mBelowLayerID == belowLayerID) {
             return
         }
@@ -147,7 +147,7 @@ abstract class RCTLayer<T : Layer?>(protected var mContext: Context) : AbstractS
     }
 
     fun addAbove(aboveLayerID: String?) {
-        mMapView!!.waitForLayer(aboveLayerID!!, object : FoundLayerCallback {
+        mMapView!!.waitForLayer(aboveLayerID, object : FoundLayerCallback {
             override fun found(layer: Layer?) {
                 if (!hasInitialized()) {
                     return
@@ -160,7 +160,7 @@ abstract class RCTLayer<T : Layer?>(protected var mContext: Context) : AbstractS
     }
 
     fun addBelow(belowLayerID: String?) {
-        mMapView!!.waitForLayer(belowLayerID!!, object : FoundLayerCallback {
+        mMapView!!.waitForLayer(belowLayerID, object : FoundLayerCallback {
             override fun found(layer: Layer?) {
                 if (!hasInitialized()) {
                     return


### PR DESCRIPTION
## Description
The new v10 on Android throws an error when passing null values to the aboveLayerID and belowLayerID props on. This wasn't a problem on the pervious version.

Fixes #2158

## Checklist

- [x] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typings files (`index.d.ts`)
- [ ] I added/ updated a sample (`/example`)