### PR TITLE
Update animated `GeoJSON` types and classes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,8 @@ import type {
   MapboxGLEvent as _MapboxGLEvent,
   UserTrackingMode as _UserTrackingMode,
   UserTrackingModeChangeCallback as _UserTrackingModeChangeCallback,
+  AnimatedPoint as _AnimatedPoint,
+  AnimatedLineString as _AnimatedLineString,
 } from './javascript/types/index';
 import type { requestAndroidLocationPermissions as _requestAndroidLocationPermissions } from './javascript/requestAndroidLocationPermissions';
 
@@ -204,6 +206,28 @@ declare namespace MapboxGL {
         visibleBounds: number[];
       },
     ): void;
+
+    class AnimatedPoint {
+      constructor(point?: AnimatedPoint);
+      longitude: ReactNative.Animated.Value;
+      latitude: ReactNative.Animated.Value;
+      setValue: (point: GeoJSON.Point) => void;
+      setOffset: (point: GeoJSON.Point) => void;
+      flattenOffset: () => void;
+      stopAnimation: (cb?: () => GeoJSON.Point) => void;
+      addListener: (cb?: () => GeoJSON.Point) => void;
+      removeListener: (id: string) => void;
+      spring: (
+        config: Record<string, any>,
+      ) => ReactNative.Animated.CompositeAnimation;
+      timing: (
+        config: Record<string, any>,
+      ) => ReactNative.Animated.CompositeAnimation;
+    }
+
+    class AnimatedShape {
+      constructor(shape: AnimatedLineString);
+    }
   }
 
   namespace Animated {
@@ -219,28 +243,6 @@ declare namespace MapboxGL {
     class SymbolLayer extends Component<SymbolLayerProps> {}
     class RasterLayer extends Component<RasterLayerProps> {}
     class BackgroundLayer extends Component<BackgroundLayerProps> {}
-  }
-
-  /**
-   * Classes
-   */
-
-  class AnimatedPoint {
-    constructor(point?: GeoJSON.Point);
-    longitude: ReactNative.Animated.Value;
-    latitude: ReactNative.Animated.Value;
-    setValue: (point: GeoJSON.Point) => void;
-    setOffset: (point: GeoJSON.Point) => void;
-    flattenOffset: () => void;
-    stopAnimation: (cb?: () => GeoJSON.Point) => void;
-    addListener: (cb?: () => GeoJSON.Point) => void;
-    removeListener: (id: string) => void;
-    spring: (
-      config: Record<string, any>,
-    ) => ReactNative.Animated.CompositeAnimation;
-    timing: (
-      config: Record<string, any>,
-    ) => ReactNative.Animated.CompositeAnimation;
   }
 
   /**
@@ -1044,6 +1046,8 @@ export import CircleLayer = MapboxGL.CircleLayer;
 export import MapboxGLEvent = MapboxGL.MapboxGLEvent;
 export import UserTrackingMode = MapboxGL.UserTrackingMode;
 export import UserTrackingModeChangeCallback = MapboxGL.UserTrackingModeChangeCallback;
+export import AnimatedPoint = MapboxGL.AnimatedPoint;
+export import AnimatedShape = MapboxGL.AnimatedShape;
 
 export const { offlineManager } = MapboxGL;
 

--- a/javascript/types/index.ts
+++ b/javascript/types/index.ts
@@ -27,9 +27,11 @@ export type UserTrackingModeChangeCallback = (
 // Animated.
 
 export interface AnimatedPoint extends GeoJsonObject {
+  readonly type: 'Point';
   coordinates: (Animated.Value | number)[];
 }
 
 export interface AnimatedLineString extends GeoJsonObject {
+  readonly type: 'LineString';
   coordinates: (Animated.Value | number)[][];
 }

--- a/javascript/types/index.ts
+++ b/javascript/types/index.ts
@@ -1,4 +1,6 @@
 import { SyntheticEvent } from 'react';
+import { Animated } from 'react-native';
+import { GeoJsonObject } from 'geojson';
 
 // General.
 
@@ -21,3 +23,13 @@ export type UserTrackingModeChangeCallback = (
     }
   >,
 ) => void;
+
+// Animated.
+
+export interface AnimatedPoint extends GeoJsonObject {
+  coordinates: (Animated.Value | number)[];
+}
+
+export interface AnimatedLineString extends GeoJsonObject {
+  coordinates: (Animated.Value | number)[][];
+}


### PR DESCRIPTION
This PR doesn't have any functionality changes. It properly defines/exports `AnimatedPoint` and `AnimatedShape`, and pulls out the `Animated.Value` variants of the GeoJSON interfaces they rely on.

Note: Is `AnimatedShape` expected to support a shape other than `AnimatedLineString`? If so, I think we should define supported shapes explicitly.