### PR TITLE
[v10; iOS] Support Offline Raster Styles

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLOfflineModule.swift
+++ b/ios/RCTMGL-v10/RCTMGLOfflineModule.swift
@@ -324,7 +324,7 @@ class RCTMGLOfflineModule: RCTEventEmitter {
         let metadataStr = options["metadata"] as! String
         let metadata = try JSONSerialization.jsonObject(with: metadataStr.data(using: .utf8)!, options: []) as! [String:Any]
         let id = metadata["name"] as! String
-        let stylePackLoadOptions = StylePackLoadOptions(glyphsRasterizationMode: .ideographsRasterizedLocally, metadata: ["tag": id])!
+        let stylePackLoadOptions = StylePackLoadOptions(glyphsRasterizationMode: .ideographsRasterizedLocally, metadata: metadata)
 
         let boundsStr = options["bounds"] as! String
         let boundsData = boundsStr.data(using: .utf8)


### PR DESCRIPTION
## Description
[iOS only] Supports downloading of regions with raster styles (satellite).
Updated TilesetDescriptorOptions to use supported parameters (https://docs.mapbox.com/ios/maps/api/10.7.0/Extensions/TilesetDescriptorOptions.html#/s:So27MBMTilesetDescriptorOptionsC10MapboxMapsE8styleURI9zoomRange10pixelRatio0f4PackC0AbC05StyleG0V_SNys5UInt8VGSfSo08MBMStylel4LoadC0CSgtcfc).

Fixes #2169 

## Checklist

<!-- Check completed item: [X] -->

- [x ] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typings files (`index.d.ts`)
- [ ] I added/ updated a sample (`/example`)
