### PR TITLE
feat(ios,v10): implement custom http headers

### DIFF
--- a/docs/CustomHttpHeaders.md
+++ b/docs/CustomHttpHeaders.md
@@ -12,7 +12,11 @@ Custom headers are implemented using OkHttp interseptor for android and method s
 
 None
 
-#### IOS
+#### IOS with Mapbox-v10
+
+None
+
+#### IOS with Mapbox GL or Mapblibre
 
 To enable this on iOS you need to call `[[MGLCustomHeaders sharedInstance] initHeaders]` pretty early in the lifecycle of the application. This will swizzle the custom method.
 Suggested location is `[AppDelegate application: didFinishLaunchingWithOptions:]`

--- a/ios/RCTMGL-v10/CustomHttpHeaders.swift
+++ b/ios/RCTMGL-v10/CustomHttpHeaders.swift
@@ -1,0 +1,39 @@
+import MapboxMaps
+
+class CustomHttpHeaders : HttpServiceInterceptorInterface {
+  static var shared : CustomHttpHeaders = {
+    let headers = CustomHttpHeaders()
+    headers.install()
+    return headers
+  }()
+
+  var customHeaders : [String:String] = [:]
+
+  func install() {
+    HttpServiceFactory.getInstance().setInterceptorForInterceptor(self)
+  }
+
+  func reset() {
+    HttpServiceFactory.getInstance().setInterceptorForInterceptor(nil)
+  }
+
+  // MARK: - HttpServiceInterceptorInterface
+
+  func onRequest(for request: HttpRequest) -> HttpRequest {
+    customHeaders.forEach {(key, value) in
+      request.headers[key] = value
+    }
+    return request
+  }
+
+  func onDownload(forDownload download: DownloadOptions) -> DownloadOptions {
+    customHeaders.forEach {(key,value) in
+      download.request.headers[key] = value
+    }
+    return download
+  }
+
+  func onResponse(for response: HttpResponse) -> HttpResponse {
+    return response
+  }
+}

--- a/ios/RCTMGL-v10/MGLModule.m
+++ b/ios/RCTMGL-v10/MGLModule.m
@@ -4,4 +4,7 @@
 
 RCT_EXTERN_METHOD(setAccessToken:)
 
+RCT_EXTERN_METHOD(addCustomHeader:(NSString *)headerName forHeaderValue:(NSString *) headerValue)
+RCT_EXTERN_METHOD(removeCustomHeader:(NSString *)headerName)
+
 @end

--- a/ios/RCTMGL-v10/MGLModule.swift
+++ b/ios/RCTMGL-v10/MGLModule.swift
@@ -68,4 +68,12 @@ class MGLModule : NSObject {
   @objc func setAccessToken(_ token: String) {
       MGLModule.accessToken = token
   }
+
+  @objc func addCustomHeader(_ headerName: String, forHeaderValue headerValue: String ) {
+    CustomHttpHeaders.shared.customHeaders[headerName] = headerValue
+  }
+
+  @objc func removeCustomHeader(_ headerName: String) {
+    CustomHttpHeaders.shared.customHeaders[headerName] = nil
+  }
 }


### PR DESCRIPTION
Implement for v10,ios:

- `Mapbox.addCustomHeader(key,value)`
- `Mapbox.removeCustomHeader(key)`
