### PR TITLE
Upgrade to @expo/config-plugins@5

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,18 +36,21 @@
     "prepare": "husky install"
   },
   "peerDependencies": {
+    "expo": "*",
     "mapbox-gl": "^ 2.9.0",
     "prop-types": ">=15.5.8",
     "react": ">=16.6.1",
     "react-native": ">=0.59.9"
   },
   "peerDependenciesMeta": {
+    "expo": {
+      "optional": true
+    },
     "mapbox-gl": {
       "optional": true
     }
   },
   "dependencies": {
-    "@expo/config-plugins": "^5.0.1",
     "@mapbox/geo-viewport": ">= 0.4.0",
     "@turf/along": "6.5.0",
     "@turf/distance": "6.5.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     }
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.0.3",
+    "@expo/config-plugins": "^5.0.1",
     "@mapbox/geo-viewport": ">= 0.4.0",
     "@turf/along": "6.5.0",
     "@turf/distance": "6.5.0",


### PR DESCRIPTION
## Description
Using the package with expo and running `doctor` throws the following warning:

```bash
$ expo-cli doctor                                                                                                                                                                    
Expected package @expo/config-plugins@^5.0.0
Found invalid:
  @expo/config-plugins@4.1.5
```

Therefore I upgraded the dependecy. I guess it's safe as the plugin build output doesn't even change. Our Expo app runs fine with it.

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS (used our own Expo project, even ran a full build) 
- [x] I updated the documentation with running `yarn generate` in the root folder
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typings files (`index.d.ts`)
- [ ] I added/ updated a sample (`/example`)