### PR TITLE
Remove unused expo import

### DIFF
--- a/javascript/utils/StyleValue.ts
+++ b/javascript/utils/StyleValue.ts
@@ -4,7 +4,6 @@ import {
   processColor,
   ProcessedColorValue,
 } from 'react-native';
-import { UsesNonExemptEncryption } from '@expo/config-plugins/build/ios';
 
 import { getStyleType } from './styleMap';
 import BridgeValue, {


### PR DESCRIPTION
The `@expo/config-plugins` module was recently removed from `devDependencies`, but it was still imported in `StyleValue`, which was causing a build error. This removes the unused import.