### PR TITLE
Add onCameraChanged on Android for v10

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/events/constants/EventTypes.java
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/events/constants/EventTypes.java
@@ -11,6 +11,8 @@ public class EventTypes {
     public static final String REGION_DID_CHANGE  = "regiondidchange";
     public static final String USER_LOCATION_UPDATED = "userlocationdupdated";
 
+    public static final String CAMERA_CHANGED = "camerachanged";
+
     public static final String WILL_START_LOADING_MAP = "willstartloadingmap";
     public static final String DID_FINISH_LOADING_MAP = "didfinishloadingmap";
     public static final String DID_FAIL_LOADING_MAP = "didfailloadingmap";

--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/modules/RCTMGLModule.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/modules/RCTMGLModule.kt
@@ -63,6 +63,7 @@ class RCTMGLModule(private val mReactContext: ReactApplicationContext) : ReactCo
         eventTypes["DidFinishRenderingMap"] = EventTypes.DID_FINISH_RENDERING_MAP
         eventTypes["DidFinishRenderingMapFully"] = EventTypes.DID_FINISH_RENDERING_MAP_FULLY
         eventTypes["DidFinishLoadingStyle"] = EventTypes.DID_FINISH_LOADING_STYLE
+        eventTypes["CameraChanged"] = EventTypes.CAMERA_CHANGED
 
         // style source constants
         val styleSourceConsts: MutableMap<String, String> = HashMap()

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -33,7 +33,7 @@ MapView backed by Mapbox Native GL
 | onRegionWillChange | `func` | `none` | `false` | <v10 only<br/><br/>This event is triggered whenever the currently displayed map region is about to change. |
 | onRegionIsChanging | `func` | `none` | `false` | This event is triggered whenever the currently displayed map region is changing. |
 | onRegionDidChange | `func` | `none` | `false` | This event is triggered whenever the currently displayed map region finished changing. |
-| onCameraChanged | `func` | `none` | `false` | iOS, v10 only, experimental.<br/><br/>Called when the currently displayed map area changes.<br/>Replaces onRegionIsChanging, so can't set both |
+| onCameraChanged | `func` | `none` | `false` | v10 only, experimental.<br/><br/>Called when the currently displayed map area changes.<br/>Replaces onRegionIsChanging, so can't set both |
 | onMapIdle | `func` | `none` | `false` | iOS, v10 only, experimental<br/><br/>Called when the currently displayed map area stops changing.<br/>Replaces onRegionDidChange, so can't set both |
 | onWillStartLoadingMap | `func` | `none` | `false` | This event is triggered when the map is about to start loading a new map style. |
 | onDidFinishLoadingMap | `func` | `none` | `false` | This is triggered when the map has successfully loaded a new map style. |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3055,7 +3055,7 @@
         "required": false,
         "type": "func",
         "default": "none",
-        "description": "iOS, v10 only, experimental.\n\nCalled when the currently displayed map area changes.\nReplaces onRegionIsChanging, so can't set both",
+        "description": "v10 only, experimental.\n\nCalled when the currently displayed map area changes.\nReplaces onRegionIsChanging, so can't set both",
         "params": [
           {
             "name": "region",

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -215,7 +215,7 @@ class MapView extends NativeBridgeComponent(React.Component) {
     onRegionDidChange: PropTypes.func,
 
     /**
-     * iOS, v10 only, experimental.
+     * v10 only, experimental.
      *
      * Called when the currently displayed map area changes.
      * Replaces onRegionIsChanging, so can't set both


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Added the convenient, but previously iOS only `onCameraChanged` callback on Android. The `isGestureActive` and `isAnimatingFromGesture` properties are not yet updated but the camera properties should be helpful for transitioning to using onCameraChanged on all platforms, such as in our project.

## Checklist

<!-- Check completed item: [X] -->

- [X] I have tested this on a device/simulator for each compatible OS
- [X] I updated the documentation with running `yarn generate` in the root folder
