### PR TITLE
fix(v10,android): fix mapview removal

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.kt
@@ -70,6 +70,7 @@ open class RCTMGLMapViewManager(context: ReactApplicationContext?) :
         if (mViews.containsKey(reactTag)) {
             mViews.remove(reactTag)
         }
+        mapView.onDropViewInstance()
         super.onDropViewInstance(mapView)
     }
 


### PR DESCRIPTION
-  Call ON_DESTROY lifecycle when the map view is removed
- Make sure we remove features from map before the map is destroyed to avoid leak messages from Mapbox (`Mapbox SDK memory leak detected! Style object (accessing removeStyleLayer) should not be stored and used after MapView is destroyed or new style has been loaded.`)