### PR TITLE
fix(ios,v10): followUserLocation=false should disable following user …

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -365,13 +365,13 @@ PODS:
     - React-jsi (= 0.69.4)
     - React-logger (= 0.69.4)
     - React-perflogger (= 0.69.4)
-  - rnmapbox-maps (10.0.0-beta.34):
+  - rnmapbox-maps (10.0.0-beta.40):
     - MapboxMaps (~> 10.8.1)
     - React
     - React-Core
-    - rnmapbox-maps/DynamicLibrary (= 10.0.0-beta.34)
+    - rnmapbox-maps/DynamicLibrary (= 10.0.0-beta.40)
     - Turf
-  - rnmapbox-maps/DynamicLibrary (10.0.0-beta.34):
+  - rnmapbox-maps/DynamicLibrary (10.0.0-beta.40):
     - MapboxMaps (~> 10.8.1)
     - React
     - React-Core
@@ -601,7 +601,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 9adb4a3cbb598d1bbd46a05256f445e4b8c70603
   React-runtimeexecutor: 61ee22a8cdf8b6bb2a7fb7b4ba2cc763e5285196
   ReactCommon: 8f67bd7e0a6afade0f20718f859dc8c2275f2e83
-  rnmapbox-maps: 0dae96e6a80b12db7eccbef90e4e4f795b4168bc
+  rnmapbox-maps: fda750ccc75ebee387d3f71ecb6c201b7f56c714
   RNScreens: 0df01424e9e0ed7827200d6ed1087ddd06c493f9
   RNSVG: ecd661f380a07ba690c9c5929c475a44f432d674
   RNVectorIcons: 4143ba35feebab8fdbe6bc43d1e776b393d47ac8

--- a/ios/RCTMGL-v10/RCTMGLCamera.swift
+++ b/ios/RCTMGL-v10/RCTMGLCamera.swift
@@ -194,6 +194,12 @@ class RCTMGLCamera : RCTMGLMapComponentBase, LocationConsumer {
   
   func _updateCameraFromTrackingMode() {
     withMapView { map in
+      guard self.followUserLocation else {
+        map.viewport.idle()
+        map.location.removeLocationConsumer(consumer: self)
+        return
+      }
+
       if let locationModule = RCTMGLLocationModule.shared {
         map.location.overrideLocationProvider(with: locationModule.locationProvider)
       }
@@ -242,7 +248,10 @@ class RCTMGLCamera : RCTMGLMapComponentBase, LocationConsumer {
           _camera.pitch = stopPitch
           followOptions.pitch = stopPitch
         }
+      } else {
+        followOptions.pitch = nil
       }
+
       if let zoom = self.followZoomLevel as? CGFloat {
         if (zoom >= 0.0) {
           _camera.zoom = zoom
@@ -403,7 +412,8 @@ class RCTMGLCamera : RCTMGLMapComponentBase, LocationConsumer {
   // MARK: - LocationConsumer
   
   func locationUpdate(newLocation: Location) {
-    if followUserLocation {
+    // viewport manages following user location
+    if false && followUserLocation {
       withMapView { map in
         var animationType = CameraMode.none
         if let m = self.animationMode as? String, let m = CameraMode(rawValue: m) {


### PR DESCRIPTION
…location, fixed jerkiness in follow mode, removed pinch in follow mode

Changes: 
1. If followUserLocation=false, set viewport to idle and unregister from location updates
2. During location tracking we don't update camera manually as now viewport manages it
3. Set pitch to `nil` so that following user location will not adjust pitch.

See: #2178

Should fix most of the issues mentioned in https://github.com/rnmapbox/maps/issues/2178#issuecomment-1242706279