### PR TITLE
Change v10 Terrain Exaggeration on the fly

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/styles/terrain/RCTMGLTerrain.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/styles/terrain/RCTMGLTerrain.kt
@@ -37,6 +37,13 @@ class RCTMGLTerrain(context: Context?) : AbstractSourceConsumer(context) {
 
     fun setExaggeration(exaggeration: Dynamic?) {
         mExaggeration = exaggeration
+        if (exaggeration != null) {
+            when (exaggeration!!.type) {
+                ReadableType.Number -> mTerrain?.exaggeration(exaggeration!!.asDouble())
+                ReadableType.Array -> mTerrain?.exaggeration(ExpressionParser.from(exaggeration!!.asArray())!!)
+                else -> mTerrain?.exaggeration(0.0)
+            }
+        }
     }
 
     fun addStyles(terrain: Terrain) {

--- a/ios/RCTMGL-v10/RCTMGLTerrain.swift
+++ b/ios/RCTMGL-v10/RCTMGLTerrain.swift
@@ -10,7 +10,17 @@ class RCTMGLTerrain : UIView, RCTMGLMapComponent, RCTMGLSourceConsumer {
   
   @objc var sourceID: String? = nil
   
-  @objc var exaggeration : Any? = nil
+  @objc var exaggeration : Any? = nil {
+    didSet {
+      if (style != nil && terrain != nil) {
+        do {
+          try style.setTerrain(self.makeTerrain())
+        } catch {
+          Logger.log(level: .error, message: "setTerrain failed: \(error)")
+        }
+      }
+    }
+  }
   
   func waitForStyleLoad() -> Bool {
     return true


### PR DESCRIPTION
## Description

Fixes terrain exaggeration not changing after initial render if prop value is changed

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
- [x] I updated the typings files - if js interface was changed (`index.d.ts`)
- [x] I added/ updated a sample - if a new feature was implemented (`/example`)
