### PR TITLE
refactor!: deprecate onCameraChanged, onMapIdle

### DIFF
--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -33,8 +33,8 @@ MapView backed by Mapbox Native GL
 | onRegionWillChange | `func` | `none` | `false` | <v10 only<br/><br/>This event is triggered whenever the currently displayed map region is about to change. |
 | onRegionIsChanging | `func` | `none` | `false` | This event is triggered whenever the currently displayed map region is changing. |
 | onRegionDidChange | `func` | `none` | `false` | This event is triggered whenever the currently displayed map region finished changing. |
-| onCameraChanged | `func` | `none` | `false` | iOS, v10 only, experimental.<br/><br/>Called when the currently displayed map area changes.<br/>Replaces onRegionIsChanging, so can't set both |
-| onMapIdle | `func` | `none` | `false` | iOS, v10 only, experimental<br/><br/>Called when the currently displayed map area stops changing.<br/>Replaces onRegionDidChange, so can't set both |
+| onCameraChanged | `func` | `none` | `false` | iOS, v10 only, deprecated will be removed in next version - please use onRegionIsChanging. |
+| onMapIdle | `func` | `none` | `false` | iOS, v10 only, deprecated will be removed in next version - please use onRegionDidChange |
 | onWillStartLoadingMap | `func` | `none` | `false` | This event is triggered when the map is about to start loading a new map style. |
 | onDidFinishLoadingMap | `func` | `none` | `false` | This is triggered when the map has successfully loaded a new map style. |
 | onDidFailLoadingMap | `func` | `none` | `false` | This event is triggered when the map has failed to load a new map style. |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3055,34 +3055,14 @@
         "required": false,
         "type": "func",
         "default": "none",
-        "description": "iOS, v10 only, experimental.\n\nCalled when the currently displayed map area changes.\nReplaces onRegionIsChanging, so can't set both",
-        "params": [
-          {
-            "name": "region",
-            "description": "A payload containing the map center, bounds, and other properties.",
-            "type": {
-              "name": "MapState"
-            },
-            "optional": false
-          }
-        ]
+        "description": "iOS, v10 only, deprecated will be removed in next version - please use onRegionIsChanging."
       },
       {
         "name": "onMapIdle",
         "required": false,
         "type": "func",
         "default": "none",
-        "description": "iOS, v10 only, experimental\n\nCalled when the currently displayed map area stops changing.\nReplaces onRegionDidChange, so can't set both",
-        "params": [
-          {
-            "name": "region",
-            "description": "A payload containing the map center, bounds, and other properties.",
-            "type": {
-              "name": "MapState"
-            },
-            "optional": false
-          }
-        ]
+        "description": "iOS, v10 only, deprecated will be removed in next version - please use onRegionDidChange"
       },
       {
         "name": "onWillStartLoadingMap",

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -215,22 +215,12 @@ class MapView extends NativeBridgeComponent(React.Component) {
     onRegionDidChange: PropTypes.func,
 
     /**
-     * iOS, v10 only, experimental.
-     *
-     * Called when the currently displayed map area changes.
-     * Replaces onRegionIsChanging, so can't set both
-     *
-     * @param {MapState} region - A payload containing the map center, bounds, and other properties.
+     * iOS, v10 only, deprecated will be removed in next version - please use onRegionIsChanging.
      */
     onCameraChanged: PropTypes.func,
 
     /**
-     * iOS, v10 only, experimental
-     *
-     * Called when the currently displayed map area stops changing.
-     * Replaces onRegionDidChange, so can't set both
-     *
-     * @param {MapState} region - A payload containing the map center, bounds, and other properties.
+     * iOS, v10 only, deprecated will be removed in next version - please use onRegionDidChange
      */
     onMapIdle: PropTypes.func,
 
@@ -393,6 +383,9 @@ class MapView extends NativeBridgeComponent(React.Component) {
       addIfHasHandler('DidFinishLoadingStyle');
 
       if (addIfHasHandler('MapIdle')) {
+        console.warn(
+          'onMapIdle is deprecated and will be removed in next beta - please use onRegionDidChange',
+        );
         if (props.onRegionDidChange) {
           console.warn(
             'rnmapbox/maps: only one of  MapView.onRegionDidChange or onMapIdle is supported',
@@ -400,6 +393,9 @@ class MapView extends NativeBridgeComponent(React.Component) {
         }
       }
       if (addIfHasHandler('CameraChanged')) {
+        console.warn(
+          'onCameraChanged is deprecated and will be removed in next beta - please use onRegionWillChange',
+        );
         if (props.onRegionWillChange) {
           console.warn(
             'rnmapbox/maps: only one of MapView.onRegionWillChange or onCameraChanged is supported',


### PR DESCRIPTION
BREAKING CHANGE: experimental v10 ios only onCameraChanged, onMapIdle is deprecated, please use onRegionWillChange, onRegionDidChange

Closes: #2216
