### PR TITLE
fix(v10,android): clean queued features

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.kt
@@ -317,6 +317,7 @@ open class RCTMGLMapView(private val mContext: Context, var mManager: RCTMGLMapV
             }
             queuedFeatures.clear()
         }
+        mQueuedFeatures = null;
     }
 
     private fun addAllFeaturesToMap() {


### PR DESCRIPTION
Fix v10, android. Queued features was not set to null, and it caused adding to queued features when the map is already loaded.