### PR TITLE
Regenerate docs

### DIFF
--- a/docs/PointAnnotation.md
+++ b/docs/PointAnnotation.md
@@ -11,22 +11,8 @@ as with PointAnnotation on Android child views are rendered onto a bitmap for be
 ## props
 | Prop | Type | Default | Required | Description |
 | ---- | :-- | :----- | :------ | :---------- |
-| id | `string` | `none` | `true` | A string that uniquely identifies the annotation |
-| title | `string` | `none` | `false` | The string containing the annotation’s title. Note this is required to be set if you want to see a callout appear on iOS. |
-| snippet | `string` | `none` | `false` | The string containing the annotation’s snippet(subtitle). Not displayed in the default callout. |
-| selected | `boolean` | `none` | `false` | Manually selects/deselects annotation |
-| draggable | `boolean` | `false` | `false` | Enable or disable dragging. Defaults to false. |
-| coordinate | `tuple` | `none` | `true` | The center point (specified as a map coordinate) of the annotation. |
-| anchor | `shape` | `{ x: 0.5, y: 0.5 }` | `false` | Specifies the anchor being set on a particular point of the annotation.<br/>The anchor point is specified in the continuous space [0.0, 1.0] x [0.0, 1.0],<br/>where (0, 0) is the top-left corner of the image, and (1, 1) is the bottom-right corner.<br/>Note this is only for custom annotations not the default pin view.<br/>Defaults to the center of the view. |
-| &nbsp;&nbsp;x | `number` | `none` | `true` | See anchor |
-| &nbsp;&nbsp;y | `number` | `none` | `true` | See anchor |
-| onSelected | `func` | `none` | `false` | This callback is fired once this annotation is selected. Returns a Feature as the first param.<br/>*signature:*`(payload:{feature: Feature}) => void` |
-| onDeselected | `func` | `none` | `false` | This callback is fired once this annotation is deselected.<br/>*signature:*`(payload:{feature: Feature}) => void` |
-| onDragStart | `func` | `none` | `false` | This callback is fired once this annotation has started being dragged.<br/>*signature:*`(payload:{feature: Feature}) => void` |
-| onDragEnd | `func` | `none` | `false` | This callback is fired once this annotation has stopped being dragged.<br/>*signature:*`(payload:{feature: Feature}) => void` |
-| onDrag | `func` | `none` | `false` | This callback is fired while this annotation is being dragged.<br/>*signature:*`(payload:{feature: Feature}) => void` |
-| children | `ReactReactElement` | `none` | `true` | Expects one child, and an optional callout can be added as well |
-| style | `ViewProps['style']` | `none` | `false` | FIX ME NO DESCRIPTION |
+| anchor | `FIX ME UNKNOWN TYPE` | `{ x: 0.5, y: 0.5 }` | `false` | FIX ME NO DESCRIPTION |
+| draggable | `FIX ME UNKNOWN TYPE` | `false` | `false` | FIX ME NO DESCRIPTION |
 
 ## methods
 ### refresh()

--- a/docs/ShapeSource.md
+++ b/docs/ShapeSource.md
@@ -6,25 +6,7 @@ The shape may be an url or a GeoJSON object
 ## props
 | Prop | Type | Default | Required | Description |
 | ---- | :-- | :----- | :------ | :---------- |
-| id | `string` | `MapboxGL.StyleSource.DefaultSourceID` | `false` | A string that uniquely identifies the source. |
-| url | `string` | `none` | `false` | An HTTP(S) URL, absolute file URL, or local file URL relative to the current application’s resource bundle. |
-| shape | `\| GeoJSON.GeometryCollection
-\| GeoJSON.Feature
-\| GeoJSON.FeatureCollection
-\| GeoJSON.Geometry` | `none` | `false` | The contents of the source. A shape can represent a GeoJSON geometry, a feature, or a feature collection. |
-| cluster | `boolean` | `none` | `false` | Enables clustering on the source for point shapes. |
-| clusterRadius | `number` | `none` | `false` | Specifies the radius of each cluster if clustering is enabled.<br/>A value of 512 produces a radius equal to the width of a tile.<br/>The default value is 50. |
-| clusterMaxZoomLevel | `number` | `none` | `false` | Specifies the maximum zoom level at which to cluster points if clustering is enabled.<br/>Defaults to one zoom level less than the value of maxZoomLevel so that, at the maximum zoom level,<br/>the shapes are not clustered. |
-| clusterProperties | `object` | `none` | `false` | [`mapbox-gl` (v8) implementation only]<br/>Specifies custom properties on the generated clusters if clustering<br/>is enabled, aggregating values from clustered points.<br/><br/>Has the form `{ "property_name": [operator, map_expression]}`, where<br/> `operator` is a custom reduce expression that references a special `["accumulated"]` value -<br/>  it accumulates the property value from clusters/points the cluster contains<br/> `map_expression` produces the value of a single point<br/><br/>Example: `{ "resultingSum": [["+", ["accumulated"], ["get", "resultingSum"]], ["get", "scalerank"]] }` |
-| maxZoomLevel | `number` | `none` | `false` | Specifies the maximum zoom level at which to create vector tiles.<br/>A greater value produces greater detail at high zoom levels.<br/>The default value is 18. |
-| buffer | `number` | `none` | `false` | Specifies the size of the tile buffer on each side.<br/>A value of 0 produces no buffer. A value of 512 produces a buffer as wide as the tile itself.<br/>Larger values produce fewer rendering artifacts near tile edges and slower performance.<br/>The default value is 128. |
-| tolerance | `number` | `none` | `false` | Specifies the Douglas-Peucker simplification tolerance.<br/>A greater value produces simpler geometries and improves performance.<br/>The default value is 0.375. |
-| lineMetrics | `boolean` | `none` | `false` | Whether to calculate line distance metrics.<br/>This is required for line layers that specify lineGradient values.<br/>The default value is false. |
-| onPress | `func` | `none` | `false` | Source press listener, gets called when a user presses one of the children layers only<br/>if that layer has a higher z-index than another source layers<br/><br/>@param {Object} event<br/>@param {Object[]} event.features - the geojson features that have hit by the press (might be multiple)<br/>@param {Object} event.coordinates - the coordinates of the click<br/>@param {Object} event.point - the point of the click<br/>@return void<br/>*signature:*`(event:{features: Array, coordinates: {latitude: number, longitude: number}, point: {x: number, y: number}}) => void` |
-| hitbox | `shape` | `none` | `false` | Overrides the default touch hitbox(44x44 pixels) for the source layers |
-| &nbsp;&nbsp;width | `number` | `none` | `true` | `width` of hitbox |
-| &nbsp;&nbsp;height | `number` | `none` | `true` | `height` of hitbox |
-| children | `React.ReactElement \| React.ReactElement[]` | `none` | `true` | FIX ME NO DESCRIPTION |
+| id | `FIX ME UNKNOWN TYPE` | `MapboxGL.StyleSource.DefaultSourceID` | `false` | FIX ME NO DESCRIPTION |
 
 ## methods
 ### features([filter])

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -707,6 +707,379 @@
     "fileNameWithExt": "Camera.tsx",
     "name": "Camera"
   },
+  "offlineManager": {
+    "name": "offlineManager",
+    "fileNameWithExt": "offlineManager.js",
+    "description": "OfflineManager implements a singleton (shared object) that manages offline packs.\nAll of this class’s instance methods are asynchronous, reflecting the fact that offline resources are stored in a database.\nThe shared object maintains a canonical collection of offline packs.",
+    "props": [],
+    "styles": [],
+    "methods": [
+      {
+        "name": "createPack",
+        "description": "Creates and registers an offline pack that downloads the resources needed to use the given region offline.",
+        "params": [
+          {
+            "name": "options",
+            "description": "Create options for a offline pack that specifices zoom levels, style url, and the region to download.",
+            "type": {
+              "name": "OfflineCreatePackOptions"
+            },
+            "optional": false
+          },
+          {
+            "name": "progressListener",
+            "description": "Callback that listens for status events while downloading the offline resource.",
+            "type": {
+              "name": "Callback"
+            },
+            "optional": true
+          },
+          {
+            "name": "errorListener",
+            "description": "Callback that listens for status events while downloading the offline resource.",
+            "type": {
+              "name": "Callback"
+            },
+            "optional": true
+          }
+        ],
+        "examples": [
+          "const progressListener = (offlineRegion, status) => console.log(offlineRegion, status);\nconst errorListener = (offlineRegion, err) => console.log(offlineRegion, err);\n\nawait MapboxGL.offlineManager.createPack({\n  name: 'offlinePack',\n  styleURL: 'mapbox://...',\n  minZoom: 14,\n  maxZoom: 20,\n  bounds: [[neLng, neLat], [swLng, swLat]]\n}, progressListener, errorListener)"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "invalidatePack",
+        "description": "Invalidates the specified offline pack. This method checks that the tiles in the specified offline pack match those from the server. Local tiles that do not match the latest version on the server are updated.This is more efficient than deleting the offline pack and downloading it again. If the data stored locally matches that on the server, new data will not be downloaded.",
+        "params": [
+          {
+            "name": "name",
+            "description": "Name of the offline pack.",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "await MapboxGL.offlineManager.invalidatePack('packName')"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "deletePack",
+        "description": "Unregisters the given offline pack and allows resources that are no longer required by any remaining packs to be potentially freed.",
+        "params": [
+          {
+            "name": "name",
+            "description": "Name of the offline pack.",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "await MapboxGL.offlineManager.deletePack('packName')"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "invalidateAmbientCache",
+        "description": "Forces a revalidation of the tiles in the ambient cache and downloads a fresh version of the tiles from the tile server.\nThis is the recommend method for clearing the cache.\nThis is the most efficient method because tiles in the ambient cache are re-downloaded to remove outdated data from a device.\nIt does not erase resources from the ambient cache or delete the database, which can be computationally expensive operations that may carry unintended side effects.",
+        "params": [],
+        "examples": [
+          "await MapboxGL.offlineManager.invalidateAmbientCache();"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "clearAmbientCache",
+        "description": "Erases resources from the ambient cache.\nThis method clears the cache and decreases the amount of space that map resources take up on the device.",
+        "params": [],
+        "examples": [
+          "await MapboxGL.offlineManager.clearAmbientCache();"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "migrateOfflineCache",
+        "description": "Migrates the offline cache from pre-v10 SDKs to the new v10 cache location",
+        "params": [],
+        "examples": [
+          "await MapboxGL.offlineManager.migrateOfflineCache()"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "setMaximumAmbientCacheSize",
+        "description": "Sets the maximum size of the ambient cache in bytes. Disables the ambient cache if set to 0.\nThis method may be computationally expensive because it will erase resources from the ambient cache if its size is decreased.",
+        "params": [
+          {
+            "name": "size",
+            "description": "Size of ambient cache.",
+            "type": {
+              "name": "Number"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "await MapboxGL.offlineManager.setMaximumAmbientCacheSize(5000000);"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "resetDatabase",
+        "description": "Deletes the existing database, which includes both the ambient cache and offline packs, then reinitializes it.",
+        "params": [],
+        "examples": [
+          "await MapboxGL.offlineManager.resetDatabase();"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "getPacks",
+        "description": "Retrieves all the current offline packs that are stored in the database.",
+        "params": [],
+        "examples": [
+          "const offlinePacks = await MapboxGL.offlineManager.getPacks();"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "Array"
+          }
+        }
+      },
+      {
+        "name": "getPack",
+        "description": "Retrieves an offline pack that is stored in the database by name.",
+        "params": [
+          {
+            "name": "name",
+            "description": "Name of the offline pack.",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "const offlinePack = await MapboxGL.offlineManager.getPack();"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "OfflinePack"
+          }
+        }
+      },
+      {
+        "name": "mergeOfflineRegions",
+        "description": "Sideloads offline db",
+        "params": [
+          {
+            "name": "path",
+            "description": "Path to offline tile db on file system.",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "await MapboxGL.offlineManager.mergeOfflineRegions(path);"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "setTileCountLimit",
+        "description": "Sets the maximum number of Mapbox-hosted tiles that may be downloaded and stored on the current device.\nThe Mapbox Terms of Service prohibit changing or bypassing this limit without permission from Mapbox.",
+        "params": [
+          {
+            "name": "limit",
+            "description": "Map tile limit count.",
+            "type": {
+              "name": "Number"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "MapboxGL.offlineManager.setTileCountLimit(1000);"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "setProgressEventThrottle",
+        "description": "Sets the period at which download status events will be sent over the React Native bridge.\nThe default is 500ms.",
+        "params": [
+          {
+            "name": "throttleValue",
+            "description": "event throttle value in ms.",
+            "type": {
+              "name": "Number"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "MapboxGL.offlineManager.setProgressEventThrottle(500);"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "subscribe",
+        "description": "Subscribe to download status/error events for the requested offline pack.\nNote that createPack calls this internally if listeners are provided.",
+        "params": [
+          {
+            "name": "packName",
+            "description": "Name of the offline pack.",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          },
+          {
+            "name": "progressListener",
+            "description": "Callback that listens for status events while downloading the offline resource.",
+            "type": {
+              "name": "Callback"
+            },
+            "optional": false
+          },
+          {
+            "name": "errorListener",
+            "description": "Callback that listens for status events while downloading the offline resource.",
+            "type": {
+              "name": "Callback"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "const progressListener = (offlinePack, status) => console.log(offlinePack, status)\nconst errorListener = (offlinePack, err) => console.log(offlinePack, err)\nMapboxGL.offlineManager.subscribe('packName', progressListener, errorListener)"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "unsubscribe",
+        "description": "Unsubscribes any listeners associated with the offline pack.\nIt's a good idea to call this on componentWillUnmount.",
+        "params": [
+          {
+            "name": "packName",
+            "description": "Name of the offline pack.",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "MapboxGL.offlineManager.unsubscribe('packName')"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      }
+    ]
+  },
+  "snapshotManager": {
+    "name": "snapshotManager",
+    "fileNameWithExt": "snapshotManager.js",
+    "description": "The snapshotManager generates static raster images of the map.\nEach snapshot image depicts a portion of a map defined by an SnapshotOptions object you provide.\nThe snapshotter generates the snapshot asynchronous.",
+    "props": [],
+    "styles": [],
+    "methods": [
+      {
+        "name": "takeSnap",
+        "description": "Takes a snapshot of the base map using the provided Snapshot options. NOTE pitch, heading, zoomLevel only works when centerCoordinate is set!",
+        "params": [
+          {
+            "name": "options",
+            "description": "Snapshot options for create a static image of the base map",
+            "type": {
+              "name": "SnapshotOptions"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "// creates a temp file png of base map\nconst uri = await MapboxGL.snapshotManager.takeSnap({\n  centerCoordinate: [-74.126410, 40.797968],\n  width: width,\n  height: height,\n  zoomLevel: 12,\n  pitch: 30,\n  heading: 20,\n  styleURL: MapboxGL.StyleURL.Dark,\n  writeToDisk: true, // Create a temporary file\n});\n\n// creates base64 png of base map without logo\nconst uri = await MapboxGL.snapshotManager.takeSnap({\n  centerCoordinate: [-74.126410, 40.797968],\n  width: width,\n  height: height,\n  zoomLevel: 12,\n  pitch: 30,\n  heading: 20,\n  styleURL: MapboxGL.StyleURL.Dark,\n  withLogo: false, // Disable Mapbox logo (Android only)\n});\n\n// creates snapshot with bounds\nconst uri = await MapboxGL.snapshotManager.takeSnap({\n  bounds: [[-74.126410, 40.797968], [-74.143727, 40.772177]],\n  width: width,\n  height: height,\n  styleURL: MapboxGL.StyleURL.Dark,\n});"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "Promise"
+          }
+        }
+      }
+    ]
+  },
   "CircleLayer": {
     "description": "CircleLayer is a style layer that renders one or more filled circles on the map.",
     "displayName": "CircleLayer",
@@ -1368,379 +1741,6 @@
           ]
         },
         "transition": true
-      }
-    ]
-  },
-  "offlineManager": {
-    "name": "offlineManager",
-    "fileNameWithExt": "offlineManager.js",
-    "description": "OfflineManager implements a singleton (shared object) that manages offline packs.\nAll of this class’s instance methods are asynchronous, reflecting the fact that offline resources are stored in a database.\nThe shared object maintains a canonical collection of offline packs.",
-    "props": [],
-    "styles": [],
-    "methods": [
-      {
-        "name": "createPack",
-        "description": "Creates and registers an offline pack that downloads the resources needed to use the given region offline.",
-        "params": [
-          {
-            "name": "options",
-            "description": "Create options for a offline pack that specifices zoom levels, style url, and the region to download.",
-            "type": {
-              "name": "OfflineCreatePackOptions"
-            },
-            "optional": false
-          },
-          {
-            "name": "progressListener",
-            "description": "Callback that listens for status events while downloading the offline resource.",
-            "type": {
-              "name": "Callback"
-            },
-            "optional": true
-          },
-          {
-            "name": "errorListener",
-            "description": "Callback that listens for status events while downloading the offline resource.",
-            "type": {
-              "name": "Callback"
-            },
-            "optional": true
-          }
-        ],
-        "examples": [
-          "const progressListener = (offlineRegion, status) => console.log(offlineRegion, status);\nconst errorListener = (offlineRegion, err) => console.log(offlineRegion, err);\n\nawait MapboxGL.offlineManager.createPack({\n  name: 'offlinePack',\n  styleURL: 'mapbox://...',\n  minZoom: 14,\n  maxZoom: 20,\n  bounds: [[neLng, neLat], [swLng, swLat]]\n}, progressListener, errorListener)"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "invalidatePack",
-        "description": "Invalidates the specified offline pack. This method checks that the tiles in the specified offline pack match those from the server. Local tiles that do not match the latest version on the server are updated.This is more efficient than deleting the offline pack and downloading it again. If the data stored locally matches that on the server, new data will not be downloaded.",
-        "params": [
-          {
-            "name": "name",
-            "description": "Name of the offline pack.",
-            "type": {
-              "name": "String"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "await MapboxGL.offlineManager.invalidatePack('packName')"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "deletePack",
-        "description": "Unregisters the given offline pack and allows resources that are no longer required by any remaining packs to be potentially freed.",
-        "params": [
-          {
-            "name": "name",
-            "description": "Name of the offline pack.",
-            "type": {
-              "name": "String"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "await MapboxGL.offlineManager.deletePack('packName')"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "invalidateAmbientCache",
-        "description": "Forces a revalidation of the tiles in the ambient cache and downloads a fresh version of the tiles from the tile server.\nThis is the recommend method for clearing the cache.\nThis is the most efficient method because tiles in the ambient cache are re-downloaded to remove outdated data from a device.\nIt does not erase resources from the ambient cache or delete the database, which can be computationally expensive operations that may carry unintended side effects.",
-        "params": [],
-        "examples": [
-          "await MapboxGL.offlineManager.invalidateAmbientCache();"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "clearAmbientCache",
-        "description": "Erases resources from the ambient cache.\nThis method clears the cache and decreases the amount of space that map resources take up on the device.",
-        "params": [],
-        "examples": [
-          "await MapboxGL.offlineManager.clearAmbientCache();"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "migrateOfflineCache",
-        "description": "Migrates the offline cache from pre-v10 SDKs to the new v10 cache location",
-        "params": [],
-        "examples": [
-          "await MapboxGL.offlineManager.migrateOfflineCache()"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "setMaximumAmbientCacheSize",
-        "description": "Sets the maximum size of the ambient cache in bytes. Disables the ambient cache if set to 0.\nThis method may be computationally expensive because it will erase resources from the ambient cache if its size is decreased.",
-        "params": [
-          {
-            "name": "size",
-            "description": "Size of ambient cache.",
-            "type": {
-              "name": "Number"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "await MapboxGL.offlineManager.setMaximumAmbientCacheSize(5000000);"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "resetDatabase",
-        "description": "Deletes the existing database, which includes both the ambient cache and offline packs, then reinitializes it.",
-        "params": [],
-        "examples": [
-          "await MapboxGL.offlineManager.resetDatabase();"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "getPacks",
-        "description": "Retrieves all the current offline packs that are stored in the database.",
-        "params": [],
-        "examples": [
-          "const offlinePacks = await MapboxGL.offlineManager.getPacks();"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "Array"
-          }
-        }
-      },
-      {
-        "name": "getPack",
-        "description": "Retrieves an offline pack that is stored in the database by name.",
-        "params": [
-          {
-            "name": "name",
-            "description": "Name of the offline pack.",
-            "type": {
-              "name": "String"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "const offlinePack = await MapboxGL.offlineManager.getPack();"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "OfflinePack"
-          }
-        }
-      },
-      {
-        "name": "mergeOfflineRegions",
-        "description": "Sideloads offline db",
-        "params": [
-          {
-            "name": "path",
-            "description": "Path to offline tile db on file system.",
-            "type": {
-              "name": "String"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "await MapboxGL.offlineManager.mergeOfflineRegions(path);"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "setTileCountLimit",
-        "description": "Sets the maximum number of Mapbox-hosted tiles that may be downloaded and stored on the current device.\nThe Mapbox Terms of Service prohibit changing or bypassing this limit without permission from Mapbox.",
-        "params": [
-          {
-            "name": "limit",
-            "description": "Map tile limit count.",
-            "type": {
-              "name": "Number"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "MapboxGL.offlineManager.setTileCountLimit(1000);"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "setProgressEventThrottle",
-        "description": "Sets the period at which download status events will be sent over the React Native bridge.\nThe default is 500ms.",
-        "params": [
-          {
-            "name": "throttleValue",
-            "description": "event throttle value in ms.",
-            "type": {
-              "name": "Number"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "MapboxGL.offlineManager.setProgressEventThrottle(500);"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "subscribe",
-        "description": "Subscribe to download status/error events for the requested offline pack.\nNote that createPack calls this internally if listeners are provided.",
-        "params": [
-          {
-            "name": "packName",
-            "description": "Name of the offline pack.",
-            "type": {
-              "name": "String"
-            },
-            "optional": false
-          },
-          {
-            "name": "progressListener",
-            "description": "Callback that listens for status events while downloading the offline resource.",
-            "type": {
-              "name": "Callback"
-            },
-            "optional": false
-          },
-          {
-            "name": "errorListener",
-            "description": "Callback that listens for status events while downloading the offline resource.",
-            "type": {
-              "name": "Callback"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "const progressListener = (offlinePack, status) => console.log(offlinePack, status)\nconst errorListener = (offlinePack, err) => console.log(offlinePack, err)\nMapboxGL.offlineManager.subscribe('packName', progressListener, errorListener)"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "unsubscribe",
-        "description": "Unsubscribes any listeners associated with the offline pack.\nIt's a good idea to call this on componentWillUnmount.",
-        "params": [
-          {
-            "name": "packName",
-            "description": "Name of the offline pack.",
-            "type": {
-              "name": "String"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "MapboxGL.offlineManager.unsubscribe('packName')"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      }
-    ]
-  },
-  "snapshotManager": {
-    "name": "snapshotManager",
-    "fileNameWithExt": "snapshotManager.js",
-    "description": "The snapshotManager generates static raster images of the map.\nEach snapshot image depicts a portion of a map defined by an SnapshotOptions object you provide.\nThe snapshotter generates the snapshot asynchronous.",
-    "props": [],
-    "styles": [],
-    "methods": [
-      {
-        "name": "takeSnap",
-        "description": "Takes a snapshot of the base map using the provided Snapshot options. NOTE pitch, heading, zoomLevel only works when centerCoordinate is set!",
-        "params": [
-          {
-            "name": "options",
-            "description": "Snapshot options for create a static image of the base map",
-            "type": {
-              "name": "SnapshotOptions"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "// creates a temp file png of base map\nconst uri = await MapboxGL.snapshotManager.takeSnap({\n  centerCoordinate: [-74.126410, 40.797968],\n  width: width,\n  height: height,\n  zoomLevel: 12,\n  pitch: 30,\n  heading: 20,\n  styleURL: MapboxGL.StyleURL.Dark,\n  writeToDisk: true, // Create a temporary file\n});\n\n// creates base64 png of base map without logo\nconst uri = await MapboxGL.snapshotManager.takeSnap({\n  centerCoordinate: [-74.126410, 40.797968],\n  width: width,\n  height: height,\n  zoomLevel: 12,\n  pitch: 30,\n  heading: 20,\n  styleURL: MapboxGL.StyleURL.Dark,\n  withLogo: false, // Disable Mapbox logo (Android only)\n});\n\n// creates snapshot with bounds\nconst uri = await MapboxGL.snapshotManager.takeSnap({\n  bounds: [[-74.126410, 40.797968], [-74.143727, 40.772177]],\n  width: width,\n  height: height,\n  styleURL: MapboxGL.StyleURL.Dark,\n});"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "Promise"
-          }
-        }
       }
     ]
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -707,379 +707,6 @@
     "fileNameWithExt": "Camera.tsx",
     "name": "Camera"
   },
-  "offlineManager": {
-    "name": "offlineManager",
-    "fileNameWithExt": "offlineManager.js",
-    "description": "OfflineManager implements a singleton (shared object) that manages offline packs.\nAll of this class’s instance methods are asynchronous, reflecting the fact that offline resources are stored in a database.\nThe shared object maintains a canonical collection of offline packs.",
-    "props": [],
-    "styles": [],
-    "methods": [
-      {
-        "name": "createPack",
-        "description": "Creates and registers an offline pack that downloads the resources needed to use the given region offline.",
-        "params": [
-          {
-            "name": "options",
-            "description": "Create options for a offline pack that specifices zoom levels, style url, and the region to download.",
-            "type": {
-              "name": "OfflineCreatePackOptions"
-            },
-            "optional": false
-          },
-          {
-            "name": "progressListener",
-            "description": "Callback that listens for status events while downloading the offline resource.",
-            "type": {
-              "name": "Callback"
-            },
-            "optional": true
-          },
-          {
-            "name": "errorListener",
-            "description": "Callback that listens for status events while downloading the offline resource.",
-            "type": {
-              "name": "Callback"
-            },
-            "optional": true
-          }
-        ],
-        "examples": [
-          "const progressListener = (offlineRegion, status) => console.log(offlineRegion, status);\nconst errorListener = (offlineRegion, err) => console.log(offlineRegion, err);\n\nawait MapboxGL.offlineManager.createPack({\n  name: 'offlinePack',\n  styleURL: 'mapbox://...',\n  minZoom: 14,\n  maxZoom: 20,\n  bounds: [[neLng, neLat], [swLng, swLat]]\n}, progressListener, errorListener)"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "invalidatePack",
-        "description": "Invalidates the specified offline pack. This method checks that the tiles in the specified offline pack match those from the server. Local tiles that do not match the latest version on the server are updated.This is more efficient than deleting the offline pack and downloading it again. If the data stored locally matches that on the server, new data will not be downloaded.",
-        "params": [
-          {
-            "name": "name",
-            "description": "Name of the offline pack.",
-            "type": {
-              "name": "String"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "await MapboxGL.offlineManager.invalidatePack('packName')"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "deletePack",
-        "description": "Unregisters the given offline pack and allows resources that are no longer required by any remaining packs to be potentially freed.",
-        "params": [
-          {
-            "name": "name",
-            "description": "Name of the offline pack.",
-            "type": {
-              "name": "String"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "await MapboxGL.offlineManager.deletePack('packName')"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "invalidateAmbientCache",
-        "description": "Forces a revalidation of the tiles in the ambient cache and downloads a fresh version of the tiles from the tile server.\nThis is the recommend method for clearing the cache.\nThis is the most efficient method because tiles in the ambient cache are re-downloaded to remove outdated data from a device.\nIt does not erase resources from the ambient cache or delete the database, which can be computationally expensive operations that may carry unintended side effects.",
-        "params": [],
-        "examples": [
-          "await MapboxGL.offlineManager.invalidateAmbientCache();"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "clearAmbientCache",
-        "description": "Erases resources from the ambient cache.\nThis method clears the cache and decreases the amount of space that map resources take up on the device.",
-        "params": [],
-        "examples": [
-          "await MapboxGL.offlineManager.clearAmbientCache();"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "migrateOfflineCache",
-        "description": "Migrates the offline cache from pre-v10 SDKs to the new v10 cache location",
-        "params": [],
-        "examples": [
-          "await MapboxGL.offlineManager.migrateOfflineCache()"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "setMaximumAmbientCacheSize",
-        "description": "Sets the maximum size of the ambient cache in bytes. Disables the ambient cache if set to 0.\nThis method may be computationally expensive because it will erase resources from the ambient cache if its size is decreased.",
-        "params": [
-          {
-            "name": "size",
-            "description": "Size of ambient cache.",
-            "type": {
-              "name": "Number"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "await MapboxGL.offlineManager.setMaximumAmbientCacheSize(5000000);"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "resetDatabase",
-        "description": "Deletes the existing database, which includes both the ambient cache and offline packs, then reinitializes it.",
-        "params": [],
-        "examples": [
-          "await MapboxGL.offlineManager.resetDatabase();"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "getPacks",
-        "description": "Retrieves all the current offline packs that are stored in the database.",
-        "params": [],
-        "examples": [
-          "const offlinePacks = await MapboxGL.offlineManager.getPacks();"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "Array"
-          }
-        }
-      },
-      {
-        "name": "getPack",
-        "description": "Retrieves an offline pack that is stored in the database by name.",
-        "params": [
-          {
-            "name": "name",
-            "description": "Name of the offline pack.",
-            "type": {
-              "name": "String"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "const offlinePack = await MapboxGL.offlineManager.getPack();"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "OfflinePack"
-          }
-        }
-      },
-      {
-        "name": "mergeOfflineRegions",
-        "description": "Sideloads offline db",
-        "params": [
-          {
-            "name": "path",
-            "description": "Path to offline tile db on file system.",
-            "type": {
-              "name": "String"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "await MapboxGL.offlineManager.mergeOfflineRegions(path);"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "setTileCountLimit",
-        "description": "Sets the maximum number of Mapbox-hosted tiles that may be downloaded and stored on the current device.\nThe Mapbox Terms of Service prohibit changing or bypassing this limit without permission from Mapbox.",
-        "params": [
-          {
-            "name": "limit",
-            "description": "Map tile limit count.",
-            "type": {
-              "name": "Number"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "MapboxGL.offlineManager.setTileCountLimit(1000);"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "setProgressEventThrottle",
-        "description": "Sets the period at which download status events will be sent over the React Native bridge.\nThe default is 500ms.",
-        "params": [
-          {
-            "name": "throttleValue",
-            "description": "event throttle value in ms.",
-            "type": {
-              "name": "Number"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "MapboxGL.offlineManager.setProgressEventThrottle(500);"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "subscribe",
-        "description": "Subscribe to download status/error events for the requested offline pack.\nNote that createPack calls this internally if listeners are provided.",
-        "params": [
-          {
-            "name": "packName",
-            "description": "Name of the offline pack.",
-            "type": {
-              "name": "String"
-            },
-            "optional": false
-          },
-          {
-            "name": "progressListener",
-            "description": "Callback that listens for status events while downloading the offline resource.",
-            "type": {
-              "name": "Callback"
-            },
-            "optional": false
-          },
-          {
-            "name": "errorListener",
-            "description": "Callback that listens for status events while downloading the offline resource.",
-            "type": {
-              "name": "Callback"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "const progressListener = (offlinePack, status) => console.log(offlinePack, status)\nconst errorListener = (offlinePack, err) => console.log(offlinePack, err)\nMapboxGL.offlineManager.subscribe('packName', progressListener, errorListener)"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "unsubscribe",
-        "description": "Unsubscribes any listeners associated with the offline pack.\nIt's a good idea to call this on componentWillUnmount.",
-        "params": [
-          {
-            "name": "packName",
-            "description": "Name of the offline pack.",
-            "type": {
-              "name": "String"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "MapboxGL.offlineManager.unsubscribe('packName')"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      }
-    ]
-  },
-  "snapshotManager": {
-    "name": "snapshotManager",
-    "fileNameWithExt": "snapshotManager.js",
-    "description": "The snapshotManager generates static raster images of the map.\nEach snapshot image depicts a portion of a map defined by an SnapshotOptions object you provide.\nThe snapshotter generates the snapshot asynchronous.",
-    "props": [],
-    "styles": [],
-    "methods": [
-      {
-        "name": "takeSnap",
-        "description": "Takes a snapshot of the base map using the provided Snapshot options. NOTE pitch, heading, zoomLevel only works when centerCoordinate is set!",
-        "params": [
-          {
-            "name": "options",
-            "description": "Snapshot options for create a static image of the base map",
-            "type": {
-              "name": "SnapshotOptions"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "// creates a temp file png of base map\nconst uri = await MapboxGL.snapshotManager.takeSnap({\n  centerCoordinate: [-74.126410, 40.797968],\n  width: width,\n  height: height,\n  zoomLevel: 12,\n  pitch: 30,\n  heading: 20,\n  styleURL: MapboxGL.StyleURL.Dark,\n  writeToDisk: true, // Create a temporary file\n});\n\n// creates base64 png of base map without logo\nconst uri = await MapboxGL.snapshotManager.takeSnap({\n  centerCoordinate: [-74.126410, 40.797968],\n  width: width,\n  height: height,\n  zoomLevel: 12,\n  pitch: 30,\n  heading: 20,\n  styleURL: MapboxGL.StyleURL.Dark,\n  withLogo: false, // Disable Mapbox logo (Android only)\n});\n\n// creates snapshot with bounds\nconst uri = await MapboxGL.snapshotManager.takeSnap({\n  bounds: [[-74.126410, 40.797968], [-74.143727, 40.772177]],\n  width: width,\n  height: height,\n  styleURL: MapboxGL.StyleURL.Dark,\n});"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "Promise"
-          }
-        }
-      }
-    ]
-  },
   "CircleLayer": {
     "description": "CircleLayer is a style layer that renders one or more filled circles on the map.",
     "displayName": "CircleLayer",
@@ -1741,6 +1368,379 @@
           ]
         },
         "transition": true
+      }
+    ]
+  },
+  "offlineManager": {
+    "name": "offlineManager",
+    "fileNameWithExt": "offlineManager.js",
+    "description": "OfflineManager implements a singleton (shared object) that manages offline packs.\nAll of this class’s instance methods are asynchronous, reflecting the fact that offline resources are stored in a database.\nThe shared object maintains a canonical collection of offline packs.",
+    "props": [],
+    "styles": [],
+    "methods": [
+      {
+        "name": "createPack",
+        "description": "Creates and registers an offline pack that downloads the resources needed to use the given region offline.",
+        "params": [
+          {
+            "name": "options",
+            "description": "Create options for a offline pack that specifices zoom levels, style url, and the region to download.",
+            "type": {
+              "name": "OfflineCreatePackOptions"
+            },
+            "optional": false
+          },
+          {
+            "name": "progressListener",
+            "description": "Callback that listens for status events while downloading the offline resource.",
+            "type": {
+              "name": "Callback"
+            },
+            "optional": true
+          },
+          {
+            "name": "errorListener",
+            "description": "Callback that listens for status events while downloading the offline resource.",
+            "type": {
+              "name": "Callback"
+            },
+            "optional": true
+          }
+        ],
+        "examples": [
+          "const progressListener = (offlineRegion, status) => console.log(offlineRegion, status);\nconst errorListener = (offlineRegion, err) => console.log(offlineRegion, err);\n\nawait MapboxGL.offlineManager.createPack({\n  name: 'offlinePack',\n  styleURL: 'mapbox://...',\n  minZoom: 14,\n  maxZoom: 20,\n  bounds: [[neLng, neLat], [swLng, swLat]]\n}, progressListener, errorListener)"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "invalidatePack",
+        "description": "Invalidates the specified offline pack. This method checks that the tiles in the specified offline pack match those from the server. Local tiles that do not match the latest version on the server are updated.This is more efficient than deleting the offline pack and downloading it again. If the data stored locally matches that on the server, new data will not be downloaded.",
+        "params": [
+          {
+            "name": "name",
+            "description": "Name of the offline pack.",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "await MapboxGL.offlineManager.invalidatePack('packName')"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "deletePack",
+        "description": "Unregisters the given offline pack and allows resources that are no longer required by any remaining packs to be potentially freed.",
+        "params": [
+          {
+            "name": "name",
+            "description": "Name of the offline pack.",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "await MapboxGL.offlineManager.deletePack('packName')"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "invalidateAmbientCache",
+        "description": "Forces a revalidation of the tiles in the ambient cache and downloads a fresh version of the tiles from the tile server.\nThis is the recommend method for clearing the cache.\nThis is the most efficient method because tiles in the ambient cache are re-downloaded to remove outdated data from a device.\nIt does not erase resources from the ambient cache or delete the database, which can be computationally expensive operations that may carry unintended side effects.",
+        "params": [],
+        "examples": [
+          "await MapboxGL.offlineManager.invalidateAmbientCache();"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "clearAmbientCache",
+        "description": "Erases resources from the ambient cache.\nThis method clears the cache and decreases the amount of space that map resources take up on the device.",
+        "params": [],
+        "examples": [
+          "await MapboxGL.offlineManager.clearAmbientCache();"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "migrateOfflineCache",
+        "description": "Migrates the offline cache from pre-v10 SDKs to the new v10 cache location",
+        "params": [],
+        "examples": [
+          "await MapboxGL.offlineManager.migrateOfflineCache()"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "setMaximumAmbientCacheSize",
+        "description": "Sets the maximum size of the ambient cache in bytes. Disables the ambient cache if set to 0.\nThis method may be computationally expensive because it will erase resources from the ambient cache if its size is decreased.",
+        "params": [
+          {
+            "name": "size",
+            "description": "Size of ambient cache.",
+            "type": {
+              "name": "Number"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "await MapboxGL.offlineManager.setMaximumAmbientCacheSize(5000000);"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "resetDatabase",
+        "description": "Deletes the existing database, which includes both the ambient cache and offline packs, then reinitializes it.",
+        "params": [],
+        "examples": [
+          "await MapboxGL.offlineManager.resetDatabase();"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "getPacks",
+        "description": "Retrieves all the current offline packs that are stored in the database.",
+        "params": [],
+        "examples": [
+          "const offlinePacks = await MapboxGL.offlineManager.getPacks();"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "Array"
+          }
+        }
+      },
+      {
+        "name": "getPack",
+        "description": "Retrieves an offline pack that is stored in the database by name.",
+        "params": [
+          {
+            "name": "name",
+            "description": "Name of the offline pack.",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "const offlinePack = await MapboxGL.offlineManager.getPack();"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "OfflinePack"
+          }
+        }
+      },
+      {
+        "name": "mergeOfflineRegions",
+        "description": "Sideloads offline db",
+        "params": [
+          {
+            "name": "path",
+            "description": "Path to offline tile db on file system.",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "await MapboxGL.offlineManager.mergeOfflineRegions(path);"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "setTileCountLimit",
+        "description": "Sets the maximum number of Mapbox-hosted tiles that may be downloaded and stored on the current device.\nThe Mapbox Terms of Service prohibit changing or bypassing this limit without permission from Mapbox.",
+        "params": [
+          {
+            "name": "limit",
+            "description": "Map tile limit count.",
+            "type": {
+              "name": "Number"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "MapboxGL.offlineManager.setTileCountLimit(1000);"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "setProgressEventThrottle",
+        "description": "Sets the period at which download status events will be sent over the React Native bridge.\nThe default is 500ms.",
+        "params": [
+          {
+            "name": "throttleValue",
+            "description": "event throttle value in ms.",
+            "type": {
+              "name": "Number"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "MapboxGL.offlineManager.setProgressEventThrottle(500);"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "subscribe",
+        "description": "Subscribe to download status/error events for the requested offline pack.\nNote that createPack calls this internally if listeners are provided.",
+        "params": [
+          {
+            "name": "packName",
+            "description": "Name of the offline pack.",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          },
+          {
+            "name": "progressListener",
+            "description": "Callback that listens for status events while downloading the offline resource.",
+            "type": {
+              "name": "Callback"
+            },
+            "optional": false
+          },
+          {
+            "name": "errorListener",
+            "description": "Callback that listens for status events while downloading the offline resource.",
+            "type": {
+              "name": "Callback"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "const progressListener = (offlinePack, status) => console.log(offlinePack, status)\nconst errorListener = (offlinePack, err) => console.log(offlinePack, err)\nMapboxGL.offlineManager.subscribe('packName', progressListener, errorListener)"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "unsubscribe",
+        "description": "Unsubscribes any listeners associated with the offline pack.\nIt's a good idea to call this on componentWillUnmount.",
+        "params": [
+          {
+            "name": "packName",
+            "description": "Name of the offline pack.",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "MapboxGL.offlineManager.unsubscribe('packName')"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      }
+    ]
+  },
+  "snapshotManager": {
+    "name": "snapshotManager",
+    "fileNameWithExt": "snapshotManager.js",
+    "description": "The snapshotManager generates static raster images of the map.\nEach snapshot image depicts a portion of a map defined by an SnapshotOptions object you provide.\nThe snapshotter generates the snapshot asynchronous.",
+    "props": [],
+    "styles": [],
+    "methods": [
+      {
+        "name": "takeSnap",
+        "description": "Takes a snapshot of the base map using the provided Snapshot options. NOTE pitch, heading, zoomLevel only works when centerCoordinate is set!",
+        "params": [
+          {
+            "name": "options",
+            "description": "Snapshot options for create a static image of the base map",
+            "type": {
+              "name": "SnapshotOptions"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "// creates a temp file png of base map\nconst uri = await MapboxGL.snapshotManager.takeSnap({\n  centerCoordinate: [-74.126410, 40.797968],\n  width: width,\n  height: height,\n  zoomLevel: 12,\n  pitch: 30,\n  heading: 20,\n  styleURL: MapboxGL.StyleURL.Dark,\n  writeToDisk: true, // Create a temporary file\n});\n\n// creates base64 png of base map without logo\nconst uri = await MapboxGL.snapshotManager.takeSnap({\n  centerCoordinate: [-74.126410, 40.797968],\n  width: width,\n  height: height,\n  zoomLevel: 12,\n  pitch: 30,\n  heading: 20,\n  styleURL: MapboxGL.StyleURL.Dark,\n  withLogo: false, // Disable Mapbox logo (Android only)\n});\n\n// creates snapshot with bounds\nconst uri = await MapboxGL.snapshotManager.takeSnap({\n  bounds: [[-74.126410, 40.797968], [-74.143727, 40.772177]],\n  width: width,\n  height: height,\n  styleURL: MapboxGL.StyleURL.Dark,\n});"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "Promise"
+          }
+        }
       }
     ]
   },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -707,6 +707,379 @@
     "fileNameWithExt": "Camera.tsx",
     "name": "Camera"
   },
+  "offlineManager": {
+    "name": "offlineManager",
+    "fileNameWithExt": "offlineManager.js",
+    "description": "OfflineManager implements a singleton (shared object) that manages offline packs.\nAll of this class’s instance methods are asynchronous, reflecting the fact that offline resources are stored in a database.\nThe shared object maintains a canonical collection of offline packs.",
+    "props": [],
+    "styles": [],
+    "methods": [
+      {
+        "name": "createPack",
+        "description": "Creates and registers an offline pack that downloads the resources needed to use the given region offline.",
+        "params": [
+          {
+            "name": "options",
+            "description": "Create options for a offline pack that specifices zoom levels, style url, and the region to download.",
+            "type": {
+              "name": "OfflineCreatePackOptions"
+            },
+            "optional": false
+          },
+          {
+            "name": "progressListener",
+            "description": "Callback that listens for status events while downloading the offline resource.",
+            "type": {
+              "name": "Callback"
+            },
+            "optional": true
+          },
+          {
+            "name": "errorListener",
+            "description": "Callback that listens for status events while downloading the offline resource.",
+            "type": {
+              "name": "Callback"
+            },
+            "optional": true
+          }
+        ],
+        "examples": [
+          "const progressListener = (offlineRegion, status) => console.log(offlineRegion, status);\nconst errorListener = (offlineRegion, err) => console.log(offlineRegion, err);\n\nawait MapboxGL.offlineManager.createPack({\n  name: 'offlinePack',\n  styleURL: 'mapbox://...',\n  minZoom: 14,\n  maxZoom: 20,\n  bounds: [[neLng, neLat], [swLng, swLat]]\n}, progressListener, errorListener)"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "invalidatePack",
+        "description": "Invalidates the specified offline pack. This method checks that the tiles in the specified offline pack match those from the server. Local tiles that do not match the latest version on the server are updated.This is more efficient than deleting the offline pack and downloading it again. If the data stored locally matches that on the server, new data will not be downloaded.",
+        "params": [
+          {
+            "name": "name",
+            "description": "Name of the offline pack.",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "await MapboxGL.offlineManager.invalidatePack('packName')"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "deletePack",
+        "description": "Unregisters the given offline pack and allows resources that are no longer required by any remaining packs to be potentially freed.",
+        "params": [
+          {
+            "name": "name",
+            "description": "Name of the offline pack.",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "await MapboxGL.offlineManager.deletePack('packName')"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "invalidateAmbientCache",
+        "description": "Forces a revalidation of the tiles in the ambient cache and downloads a fresh version of the tiles from the tile server.\nThis is the recommend method for clearing the cache.\nThis is the most efficient method because tiles in the ambient cache are re-downloaded to remove outdated data from a device.\nIt does not erase resources from the ambient cache or delete the database, which can be computationally expensive operations that may carry unintended side effects.",
+        "params": [],
+        "examples": [
+          "await MapboxGL.offlineManager.invalidateAmbientCache();"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "clearAmbientCache",
+        "description": "Erases resources from the ambient cache.\nThis method clears the cache and decreases the amount of space that map resources take up on the device.",
+        "params": [],
+        "examples": [
+          "await MapboxGL.offlineManager.clearAmbientCache();"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "migrateOfflineCache",
+        "description": "Migrates the offline cache from pre-v10 SDKs to the new v10 cache location",
+        "params": [],
+        "examples": [
+          "await MapboxGL.offlineManager.migrateOfflineCache()"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "setMaximumAmbientCacheSize",
+        "description": "Sets the maximum size of the ambient cache in bytes. Disables the ambient cache if set to 0.\nThis method may be computationally expensive because it will erase resources from the ambient cache if its size is decreased.",
+        "params": [
+          {
+            "name": "size",
+            "description": "Size of ambient cache.",
+            "type": {
+              "name": "Number"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "await MapboxGL.offlineManager.setMaximumAmbientCacheSize(5000000);"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "resetDatabase",
+        "description": "Deletes the existing database, which includes both the ambient cache and offline packs, then reinitializes it.",
+        "params": [],
+        "examples": [
+          "await MapboxGL.offlineManager.resetDatabase();"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "getPacks",
+        "description": "Retrieves all the current offline packs that are stored in the database.",
+        "params": [],
+        "examples": [
+          "const offlinePacks = await MapboxGL.offlineManager.getPacks();"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "Array"
+          }
+        }
+      },
+      {
+        "name": "getPack",
+        "description": "Retrieves an offline pack that is stored in the database by name.",
+        "params": [
+          {
+            "name": "name",
+            "description": "Name of the offline pack.",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "const offlinePack = await MapboxGL.offlineManager.getPack();"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "OfflinePack"
+          }
+        }
+      },
+      {
+        "name": "mergeOfflineRegions",
+        "description": "Sideloads offline db",
+        "params": [
+          {
+            "name": "path",
+            "description": "Path to offline tile db on file system.",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "await MapboxGL.offlineManager.mergeOfflineRegions(path);"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "setTileCountLimit",
+        "description": "Sets the maximum number of Mapbox-hosted tiles that may be downloaded and stored on the current device.\nThe Mapbox Terms of Service prohibit changing or bypassing this limit without permission from Mapbox.",
+        "params": [
+          {
+            "name": "limit",
+            "description": "Map tile limit count.",
+            "type": {
+              "name": "Number"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "MapboxGL.offlineManager.setTileCountLimit(1000);"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "setProgressEventThrottle",
+        "description": "Sets the period at which download status events will be sent over the React Native bridge.\nThe default is 500ms.",
+        "params": [
+          {
+            "name": "throttleValue",
+            "description": "event throttle value in ms.",
+            "type": {
+              "name": "Number"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "MapboxGL.offlineManager.setProgressEventThrottle(500);"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "subscribe",
+        "description": "Subscribe to download status/error events for the requested offline pack.\nNote that createPack calls this internally if listeners are provided.",
+        "params": [
+          {
+            "name": "packName",
+            "description": "Name of the offline pack.",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          },
+          {
+            "name": "progressListener",
+            "description": "Callback that listens for status events while downloading the offline resource.",
+            "type": {
+              "name": "Callback"
+            },
+            "optional": false
+          },
+          {
+            "name": "errorListener",
+            "description": "Callback that listens for status events while downloading the offline resource.",
+            "type": {
+              "name": "Callback"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "const progressListener = (offlinePack, status) => console.log(offlinePack, status)\nconst errorListener = (offlinePack, err) => console.log(offlinePack, err)\nMapboxGL.offlineManager.subscribe('packName', progressListener, errorListener)"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      },
+      {
+        "name": "unsubscribe",
+        "description": "Unsubscribes any listeners associated with the offline pack.\nIt's a good idea to call this on componentWillUnmount.",
+        "params": [
+          {
+            "name": "packName",
+            "description": "Name of the offline pack.",
+            "type": {
+              "name": "String"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "MapboxGL.offlineManager.unsubscribe('packName')"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
+      }
+    ]
+  },
+  "snapshotManager": {
+    "name": "snapshotManager",
+    "fileNameWithExt": "snapshotManager.js",
+    "description": "The snapshotManager generates static raster images of the map.\nEach snapshot image depicts a portion of a map defined by an SnapshotOptions object you provide.\nThe snapshotter generates the snapshot asynchronous.",
+    "props": [],
+    "styles": [],
+    "methods": [
+      {
+        "name": "takeSnap",
+        "description": "Takes a snapshot of the base map using the provided Snapshot options. NOTE pitch, heading, zoomLevel only works when centerCoordinate is set!",
+        "params": [
+          {
+            "name": "options",
+            "description": "Snapshot options for create a static image of the base map",
+            "type": {
+              "name": "SnapshotOptions"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "// creates a temp file png of base map\nconst uri = await MapboxGL.snapshotManager.takeSnap({\n  centerCoordinate: [-74.126410, 40.797968],\n  width: width,\n  height: height,\n  zoomLevel: 12,\n  pitch: 30,\n  heading: 20,\n  styleURL: MapboxGL.StyleURL.Dark,\n  writeToDisk: true, // Create a temporary file\n});\n\n// creates base64 png of base map without logo\nconst uri = await MapboxGL.snapshotManager.takeSnap({\n  centerCoordinate: [-74.126410, 40.797968],\n  width: width,\n  height: height,\n  zoomLevel: 12,\n  pitch: 30,\n  heading: 20,\n  styleURL: MapboxGL.StyleURL.Dark,\n  withLogo: false, // Disable Mapbox logo (Android only)\n});\n\n// creates snapshot with bounds\nconst uri = await MapboxGL.snapshotManager.takeSnap({\n  bounds: [[-74.126410, 40.797968], [-74.143727, 40.772177]],\n  width: width,\n  height: height,\n  styleURL: MapboxGL.StyleURL.Dark,\n});"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "Promise"
+          }
+        }
+      }
+    ]
+  },
   "CircleLayer": {
     "description": "CircleLayer is a style layer that renders one or more filled circles on the map.",
     "displayName": "CircleLayer",
@@ -3166,7 +3539,7 @@
     "name": "MapView"
   },
   "MarkerView": {
-    "description": "MarkerView allows you to place a interactive react native marker to the map.\n\nIf you have static view consider using PointAnnotation or SymbolLayer they'll offer much better performance\n.\nThis is based on [MakerView plugin](https://docs.mapbox.com/android/plugins/overview/markerview/) on Android\nand PointAnnotation on iOS.",
+    "description": "MarkerView represents an interactive React Native marker on the map.\n\nIf you have static views, consider using PointAnnotation or SymbolLayer to display\nan image, as they'll offer much better performance. Mapbox suggests using this\ncomponent for a maximum of around 100 views displayed at one time.\n\nThis is implemented with view annotations on [Android](https://docs.mapbox.com/android/maps/guides/annotations/view-annotations/)\nand [iOS](https://docs.mapbox.com/ios/maps/guides/annotations/view-annotations).\n\nThis component has no dedicated `onPress` method. Instead, you should handle gestures\nwith the React views passed in as `children`.",
     "displayName": "MarkerView",
     "methods": [],
     "props": [
@@ -3175,7 +3548,7 @@
         "required": true,
         "type": "tuple",
         "default": "none",
-        "description": "The center point (specified as a map coordinate) of the marker.\nSee also #anchor."
+        "description": "The center point (specified as a map coordinate) of the marker."
       },
       {
         "name": "anchor",
@@ -3188,26 +3561,40 @@
               "required": true,
               "type": "number",
               "default": "none",
-              "description": "`x` of anchor"
+              "description": "FIX ME NO DESCRIPTION"
             },
             {
               "name": "y",
               "required": true,
               "type": "number",
               "default": "none",
-              "description": "`y` of anchor"
+              "description": "FIX ME NO DESCRIPTION"
             }
           ]
         },
         "default": "{ x: 0.5, y: 0.5 }",
-        "description": "Specifies the anchor being set on a particular point of the annotation.\nThe anchor point is specified in the continuous space [0.0, 1.0] x [0.0, 1.0],\nwhere (0, 0) is the top-left corner of the image, and (1, 1) is the bottom-right corner.\nNote this is only for custom annotations not the default pin view.\nDefaults to the center of the view."
+        "description": "Any coordinate between (0, 0) and (1, 1), where (0, 0) is the top-left corner of\nthe view, and (1, 1) is the bottom-right corner. Defaults to the center at (0.5, 0.5)."
+      },
+      {
+        "name": "allowOverlap",
+        "required": false,
+        "type": "boolean",
+        "default": "false",
+        "description": "@v10\n\nWhether or not nearby markers on the map should all be displayed. If false, adjacent\nmarkers will 'collapse' and only one will be shown. Defaults to false."
+      },
+      {
+        "name": "isSelected",
+        "required": false,
+        "type": "boolean",
+        "default": "false",
+        "description": "FIX ME NO DESCRIPTION"
       },
       {
         "name": "children",
         "required": true,
         "type": "ReactReactElement",
         "default": "none",
-        "description": "Expects one child - can be container with multiple elements"
+        "description": "One or more valid React Native views."
       }
     ],
     "fileNameWithExt": "MarkerView.tsx",
@@ -3252,134 +3639,17 @@
     ],
     "props": [
       {
-        "name": "id",
-        "required": true,
-        "type": "string",
-        "default": "none",
-        "description": "A string that uniquely identifies the annotation"
-      },
-      {
-        "name": "title",
+        "name": "anchor",
         "required": false,
-        "type": "string",
-        "default": "none",
-        "description": "The string containing the annotation’s title. Note this is required to be set if you want to see a callout appear on iOS."
-      },
-      {
-        "name": "snippet",
-        "required": false,
-        "type": "string",
-        "default": "none",
-        "description": "The string containing the annotation’s snippet(subtitle). Not displayed in the default callout."
-      },
-      {
-        "name": "selected",
-        "required": false,
-        "type": "boolean",
-        "default": "none",
-        "description": "Manually selects/deselects annotation"
+        "type": "FIX ME UNKNOWN TYPE",
+        "default": "{ x: 0.5, y: 0.5 }",
+        "description": "FIX ME NO DESCRIPTION"
       },
       {
         "name": "draggable",
         "required": false,
-        "type": "boolean",
+        "type": "FIX ME UNKNOWN TYPE",
         "default": "false",
-        "description": "Enable or disable dragging. Defaults to false."
-      },
-      {
-        "name": "coordinate",
-        "required": true,
-        "type": "tuple",
-        "default": "none",
-        "description": "The center point (specified as a map coordinate) of the annotation."
-      },
-      {
-        "name": "anchor",
-        "required": false,
-        "type": {
-          "name": "shape",
-          "value": [
-            {
-              "name": "x",
-              "required": true,
-              "type": "number",
-              "default": "none",
-              "description": "See anchor"
-            },
-            {
-              "name": "y",
-              "required": true,
-              "type": "number",
-              "default": "none",
-              "description": "See anchor"
-            }
-          ]
-        },
-        "default": "{ x: 0.5, y: 0.5 }",
-        "description": "Specifies the anchor being set on a particular point of the annotation.\nThe anchor point is specified in the continuous space [0.0, 1.0] x [0.0, 1.0],\nwhere (0, 0) is the top-left corner of the image, and (1, 1) is the bottom-right corner.\nNote this is only for custom annotations not the default pin view.\nDefaults to the center of the view."
-      },
-      {
-        "name": "onSelected",
-        "required": false,
-        "type": {
-          "name": "func",
-          "funcSignature": "(payload:{feature: Feature}) => void"
-        },
-        "default": "none",
-        "description": "This callback is fired once this annotation is selected. Returns a Feature as the first param.\n*signature:*`(payload:{feature: Feature}) => void`"
-      },
-      {
-        "name": "onDeselected",
-        "required": false,
-        "type": {
-          "name": "func",
-          "funcSignature": "(payload:{feature: Feature}) => void"
-        },
-        "default": "none",
-        "description": "This callback is fired once this annotation is deselected.\n*signature:*`(payload:{feature: Feature}) => void`"
-      },
-      {
-        "name": "onDragStart",
-        "required": false,
-        "type": {
-          "name": "func",
-          "funcSignature": "(payload:{feature: Feature}) => void"
-        },
-        "default": "none",
-        "description": "This callback is fired once this annotation has started being dragged.\n*signature:*`(payload:{feature: Feature}) => void`"
-      },
-      {
-        "name": "onDragEnd",
-        "required": false,
-        "type": {
-          "name": "func",
-          "funcSignature": "(payload:{feature: Feature}) => void"
-        },
-        "default": "none",
-        "description": "This callback is fired once this annotation has stopped being dragged.\n*signature:*`(payload:{feature: Feature}) => void`"
-      },
-      {
-        "name": "onDrag",
-        "required": false,
-        "type": {
-          "name": "func",
-          "funcSignature": "(payload:{feature: Feature}) => void"
-        },
-        "default": "none",
-        "description": "This callback is fired while this annotation is being dragged.\n*signature:*`(payload:{feature: Feature}) => void`"
-      },
-      {
-        "name": "children",
-        "required": true,
-        "type": "ReactReactElement",
-        "default": "none",
-        "description": "Expects one child, and an optional callout can be added as well"
-      },
-      {
-        "name": "style",
-        "required": false,
-        "type": "ViewProps['style']",
-        "default": "none",
         "description": "FIX ME NO DESCRIPTION"
       }
     ],
@@ -3932,120 +4202,8 @@
       {
         "name": "id",
         "required": false,
-        "type": "string",
+        "type": "FIX ME UNKNOWN TYPE",
         "default": "MapboxGL.StyleSource.DefaultSourceID",
-        "description": "A string that uniquely identifies the source."
-      },
-      {
-        "name": "url",
-        "required": false,
-        "type": "string",
-        "default": "none",
-        "description": "An HTTP(S) URL, absolute file URL, or local file URL relative to the current application’s resource bundle."
-      },
-      {
-        "name": "shape",
-        "required": false,
-        "type": "\\| GeoJSON.GeometryCollection\n\\| GeoJSON.Feature\n\\| GeoJSON.FeatureCollection\n\\| GeoJSON.Geometry",
-        "default": "none",
-        "description": "The contents of the source. A shape can represent a GeoJSON geometry, a feature, or a feature collection."
-      },
-      {
-        "name": "cluster",
-        "required": false,
-        "type": "boolean",
-        "default": "none",
-        "description": "Enables clustering on the source for point shapes."
-      },
-      {
-        "name": "clusterRadius",
-        "required": false,
-        "type": "number",
-        "default": "none",
-        "description": "Specifies the radius of each cluster if clustering is enabled.\nA value of 512 produces a radius equal to the width of a tile.\nThe default value is 50."
-      },
-      {
-        "name": "clusterMaxZoomLevel",
-        "required": false,
-        "type": "number",
-        "default": "none",
-        "description": "Specifies the maximum zoom level at which to cluster points if clustering is enabled.\nDefaults to one zoom level less than the value of maxZoomLevel so that, at the maximum zoom level,\nthe shapes are not clustered."
-      },
-      {
-        "name": "clusterProperties",
-        "required": false,
-        "type": "object",
-        "default": "none",
-        "description": "[`mapbox-gl` (v8) implementation only]\nSpecifies custom properties on the generated clusters if clustering\nis enabled, aggregating values from clustered points.\n\nHas the form `{ \"property_name\": [operator, map_expression]}`, where\n `operator` is a custom reduce expression that references a special `[\"accumulated\"]` value -\n  it accumulates the property value from clusters/points the cluster contains\n `map_expression` produces the value of a single point\n\nExample: `{ \"resultingSum\": [[\"+\", [\"accumulated\"], [\"get\", \"resultingSum\"]], [\"get\", \"scalerank\"]] }`"
-      },
-      {
-        "name": "maxZoomLevel",
-        "required": false,
-        "type": "number",
-        "default": "none",
-        "description": "Specifies the maximum zoom level at which to create vector tiles.\nA greater value produces greater detail at high zoom levels.\nThe default value is 18."
-      },
-      {
-        "name": "buffer",
-        "required": false,
-        "type": "number",
-        "default": "none",
-        "description": "Specifies the size of the tile buffer on each side.\nA value of 0 produces no buffer. A value of 512 produces a buffer as wide as the tile itself.\nLarger values produce fewer rendering artifacts near tile edges and slower performance.\nThe default value is 128."
-      },
-      {
-        "name": "tolerance",
-        "required": false,
-        "type": "number",
-        "default": "none",
-        "description": "Specifies the Douglas-Peucker simplification tolerance.\nA greater value produces simpler geometries and improves performance.\nThe default value is 0.375."
-      },
-      {
-        "name": "lineMetrics",
-        "required": false,
-        "type": "boolean",
-        "default": "none",
-        "description": "Whether to calculate line distance metrics.\nThis is required for line layers that specify lineGradient values.\nThe default value is false."
-      },
-      {
-        "name": "onPress",
-        "required": false,
-        "type": {
-          "name": "func",
-          "funcSignature": "(event:{features: Array, coordinates: {latitude: number, longitude: number}, point: {x: number, y: number}}) => void"
-        },
-        "default": "none",
-        "description": "Source press listener, gets called when a user presses one of the children layers only\nif that layer has a higher z-index than another source layers\n\n@param {Object} event\n@param {Object[]} event.features - the geojson features that have hit by the press (might be multiple)\n@param {Object} event.coordinates - the coordinates of the click\n@param {Object} event.point - the point of the click\n@return void\n*signature:*`(event:{features: Array, coordinates: {latitude: number, longitude: number}, point: {x: number, y: number}}) => void`"
-      },
-      {
-        "name": "hitbox",
-        "required": false,
-        "type": {
-          "name": "shape",
-          "value": [
-            {
-              "name": "width",
-              "required": true,
-              "type": "number",
-              "default": "none",
-              "description": "`width` of hitbox"
-            },
-            {
-              "name": "height",
-              "required": true,
-              "type": "number",
-              "default": "none",
-              "description": "`height` of hitbox"
-            }
-          ]
-        },
-        "default": "none",
-        "description": "Overrides the default touch hitbox(44x44 pixels) for the source layers"
-      },
-      {
-        "name": "children",
-        "required": true,
-        "type": "React.ReactElement \\| React.ReactElement[]",
-        "default": "none",
         "description": "FIX ME NO DESCRIPTION"
       }
     ],
@@ -6210,378 +6368,5 @@
     ],
     "fileNameWithExt": "Annotation.js",
     "name": "Annotation"
-  },
-  "offlineManager": {
-    "name": "offlineManager",
-    "fileNameWithExt": "offlineManager.js",
-    "description": "OfflineManager implements a singleton (shared object) that manages offline packs.\nAll of this class’s instance methods are asynchronous, reflecting the fact that offline resources are stored in a database.\nThe shared object maintains a canonical collection of offline packs.",
-    "props": [],
-    "styles": [],
-    "methods": [
-      {
-        "name": "createPack",
-        "description": "Creates and registers an offline pack that downloads the resources needed to use the given region offline.",
-        "params": [
-          {
-            "name": "options",
-            "description": "Create options for a offline pack that specifices zoom levels, style url, and the region to download.",
-            "type": {
-              "name": "OfflineCreatePackOptions"
-            },
-            "optional": false
-          },
-          {
-            "name": "progressListener",
-            "description": "Callback that listens for status events while downloading the offline resource.",
-            "type": {
-              "name": "Callback"
-            },
-            "optional": true
-          },
-          {
-            "name": "errorListener",
-            "description": "Callback that listens for status events while downloading the offline resource.",
-            "type": {
-              "name": "Callback"
-            },
-            "optional": true
-          }
-        ],
-        "examples": [
-          "const progressListener = (offlineRegion, status) => console.log(offlineRegion, status);\nconst errorListener = (offlineRegion, err) => console.log(offlineRegion, err);\n\nawait MapboxGL.offlineManager.createPack({\n  name: 'offlinePack',\n  styleURL: 'mapbox://...',\n  minZoom: 14,\n  maxZoom: 20,\n  bounds: [[neLng, neLat], [swLng, swLat]]\n}, progressListener, errorListener)"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "invalidatePack",
-        "description": "Invalidates the specified offline pack. This method checks that the tiles in the specified offline pack match those from the server. Local tiles that do not match the latest version on the server are updated.This is more efficient than deleting the offline pack and downloading it again. If the data stored locally matches that on the server, new data will not be downloaded.",
-        "params": [
-          {
-            "name": "name",
-            "description": "Name of the offline pack.",
-            "type": {
-              "name": "String"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "await MapboxGL.offlineManager.invalidatePack('packName')"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "deletePack",
-        "description": "Unregisters the given offline pack and allows resources that are no longer required by any remaining packs to be potentially freed.",
-        "params": [
-          {
-            "name": "name",
-            "description": "Name of the offline pack.",
-            "type": {
-              "name": "String"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "await MapboxGL.offlineManager.deletePack('packName')"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "invalidateAmbientCache",
-        "description": "Forces a revalidation of the tiles in the ambient cache and downloads a fresh version of the tiles from the tile server.\nThis is the recommend method for clearing the cache.\nThis is the most efficient method because tiles in the ambient cache are re-downloaded to remove outdated data from a device.\nIt does not erase resources from the ambient cache or delete the database, which can be computationally expensive operations that may carry unintended side effects.",
-        "params": [],
-        "examples": [
-          "await MapboxGL.offlineManager.invalidateAmbientCache();"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "clearAmbientCache",
-        "description": "Erases resources from the ambient cache.\nThis method clears the cache and decreases the amount of space that map resources take up on the device.",
-        "params": [],
-        "examples": [
-          "await MapboxGL.offlineManager.clearAmbientCache();"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "migrateOfflineCache",
-        "description": "Migrates the offline cache from pre-v10 SDKs to the new v10 cache location",
-        "params": [],
-        "examples": [
-          "await MapboxGL.offlineManager.migrateOfflineCache()"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "setMaximumAmbientCacheSize",
-        "description": "Sets the maximum size of the ambient cache in bytes. Disables the ambient cache if set to 0.\nThis method may be computationally expensive because it will erase resources from the ambient cache if its size is decreased.",
-        "params": [
-          {
-            "name": "size",
-            "description": "Size of ambient cache.",
-            "type": {
-              "name": "Number"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "await MapboxGL.offlineManager.setMaximumAmbientCacheSize(5000000);"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "resetDatabase",
-        "description": "Deletes the existing database, which includes both the ambient cache and offline packs, then reinitializes it.",
-        "params": [],
-        "examples": [
-          "await MapboxGL.offlineManager.resetDatabase();"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "getPacks",
-        "description": "Retrieves all the current offline packs that are stored in the database.",
-        "params": [],
-        "examples": [
-          "const offlinePacks = await MapboxGL.offlineManager.getPacks();"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "Array"
-          }
-        }
-      },
-      {
-        "name": "getPack",
-        "description": "Retrieves an offline pack that is stored in the database by name.",
-        "params": [
-          {
-            "name": "name",
-            "description": "Name of the offline pack.",
-            "type": {
-              "name": "String"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "const offlinePack = await MapboxGL.offlineManager.getPack();"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "OfflinePack"
-          }
-        }
-      },
-      {
-        "name": "mergeOfflineRegions",
-        "description": "Sideloads offline db",
-        "params": [
-          {
-            "name": "path",
-            "description": "Path to offline tile db on file system.",
-            "type": {
-              "name": "String"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "await MapboxGL.offlineManager.mergeOfflineRegions(path);"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "setTileCountLimit",
-        "description": "Sets the maximum number of Mapbox-hosted tiles that may be downloaded and stored on the current device.\nThe Mapbox Terms of Service prohibit changing or bypassing this limit without permission from Mapbox.",
-        "params": [
-          {
-            "name": "limit",
-            "description": "Map tile limit count.",
-            "type": {
-              "name": "Number"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "MapboxGL.offlineManager.setTileCountLimit(1000);"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "setProgressEventThrottle",
-        "description": "Sets the period at which download status events will be sent over the React Native bridge.\nThe default is 500ms.",
-        "params": [
-          {
-            "name": "throttleValue",
-            "description": "event throttle value in ms.",
-            "type": {
-              "name": "Number"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "MapboxGL.offlineManager.setProgressEventThrottle(500);"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "subscribe",
-        "description": "Subscribe to download status/error events for the requested offline pack.\nNote that createPack calls this internally if listeners are provided.",
-        "params": [
-          {
-            "name": "packName",
-            "description": "Name of the offline pack.",
-            "type": {
-              "name": "String"
-            },
-            "optional": false
-          },
-          {
-            "name": "progressListener",
-            "description": "Callback that listens for status events while downloading the offline resource.",
-            "type": {
-              "name": "Callback"
-            },
-            "optional": false
-          },
-          {
-            "name": "errorListener",
-            "description": "Callback that listens for status events while downloading the offline resource.",
-            "type": {
-              "name": "Callback"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "const progressListener = (offlinePack, status) => console.log(offlinePack, status)\nconst errorListener = (offlinePack, err) => console.log(offlinePack, err)\nMapboxGL.offlineManager.subscribe('packName', progressListener, errorListener)"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      },
-      {
-        "name": "unsubscribe",
-        "description": "Unsubscribes any listeners associated with the offline pack.\nIt's a good idea to call this on componentWillUnmount.",
-        "params": [
-          {
-            "name": "packName",
-            "description": "Name of the offline pack.",
-            "type": {
-              "name": "String"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "MapboxGL.offlineManager.unsubscribe('packName')"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "void"
-          }
-        }
-      }
-    ]
-  },
-  "snapshotManager": {
-    "name": "snapshotManager",
-    "fileNameWithExt": "snapshotManager.js",
-    "description": "The snapshotManager generates static raster images of the map.\nEach snapshot image depicts a portion of a map defined by an SnapshotOptions object you provide.\nThe snapshotter generates the snapshot asynchronous.",
-    "props": [],
-    "styles": [],
-    "methods": [
-      {
-        "name": "takeSnap",
-        "description": "Takes a snapshot of the base map using the provided Snapshot options. NOTE pitch, heading, zoomLevel only works when centerCoordinate is set!",
-        "params": [
-          {
-            "name": "options",
-            "description": "Snapshot options for create a static image of the base map",
-            "type": {
-              "name": "SnapshotOptions"
-            },
-            "optional": false
-          }
-        ],
-        "examples": [
-          "// creates a temp file png of base map\nconst uri = await MapboxGL.snapshotManager.takeSnap({\n  centerCoordinate: [-74.126410, 40.797968],\n  width: width,\n  height: height,\n  zoomLevel: 12,\n  pitch: 30,\n  heading: 20,\n  styleURL: MapboxGL.StyleURL.Dark,\n  writeToDisk: true, // Create a temporary file\n});\n\n// creates base64 png of base map without logo\nconst uri = await MapboxGL.snapshotManager.takeSnap({\n  centerCoordinate: [-74.126410, 40.797968],\n  width: width,\n  height: height,\n  zoomLevel: 12,\n  pitch: 30,\n  heading: 20,\n  styleURL: MapboxGL.StyleURL.Dark,\n  withLogo: false, // Disable Mapbox logo (Android only)\n});\n\n// creates snapshot with bounds\nconst uri = await MapboxGL.snapshotManager.takeSnap({\n  bounds: [[-74.126410, 40.797968], [-74.143727, 40.772177]],\n  width: width,\n  height: height,\n  styleURL: MapboxGL.StyleURL.Dark,\n});"
-        ],
-        "returns": {
-          "description": "",
-          "type": {
-            "name": "Promise"
-          }
-        }
-      }
-    ]
   }
 }


### PR DESCRIPTION
[Moved to cleaner PR]

@mfazekas

The reason that I didn't regenerate the documentation in https://github.com/rnmapbox/maps/pull/2230 is that this is what happens when I do. I didn't want to turn that PR into a (unrelated) investigation of the doc generation, and I don't understand what has changed that would cause this.

All I know is that I didn't touch PointAnnotation or the type declarations in that PR. Any ideas?