### PR TITLE
AbstractLayer and SymbolLayer filter as Expression

### DIFF
--- a/docs/SymbolLayer.md
+++ b/docs/SymbolLayer.md
@@ -11,7 +11,7 @@ SymbolLayer is a style layer that renders icon and text labels at points or alon
 | aboveLayerID | `string` | `none` | `false` | Inserts a layer above aboveLayerID. |
 | belowLayerID | `string` | `none` | `false` | Inserts a layer below belowLayerID |
 | layerIndex | `number` | `none` | `false` | Inserts a layer at a specified index |
-| filter | `Array` | `none` | `false` | Filter only the features in the source layer that satisfy a condition that you define |
+| filter | `Expression` | `none` | `false` | Filter only the features in the source layer that satisfy a condition that you define |
 | minZoomLevel | `number` | `none` | `false` | The minimum zoom level at which the layer gets parsed and appears. |
 | maxZoomLevel | `number` | `none` | `false` | The maximum zoom level at which the layer gets parsed and appears. |
 | style | `SymbolLayerStyleProps` | `none` | `true` | FIX ME NO DESCRIPTION |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -4395,7 +4395,7 @@
       {
         "name": "filter",
         "required": false,
-        "type": "Array",
+        "type": "Expression",
         "default": "none",
         "description": "Filter only the features in the source layer that satisfy a condition that you define"
       },

--- a/javascript/components/AbstractLayer.tsx
+++ b/javascript/components/AbstractLayer.tsx
@@ -4,7 +4,7 @@ import { NativeMethods, processColor } from 'react-native';
 
 import { getFilter } from '../utils/filterUtils';
 import { transformStyle } from '../utils/StyleValue';
-import { AllLayerStyleProps } from '../utils/MapboxStyles';
+import { AllLayerStyleProps, Expression } from '../utils/MapboxStyles';
 
 type PropsBase = {
   id: string;
@@ -14,7 +14,7 @@ type PropsBase = {
   aboveLayerID?: string;
   belowLayerID?: string;
   layerIndex?: number;
-  filter?: string[];
+  filter?: Expression;
   style: AllLayerStyleProps;
 };
 

--- a/javascript/components/SymbolLayer.tsx
+++ b/javascript/components/SymbolLayer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, NativeModules, requireNativeComponent } from 'react-native';
 
-import { type SymbolLayerStyleProps } from '../utils/MapboxStyles';
+import { Expression, type SymbolLayerStyleProps } from '../utils/MapboxStyles';
 import { type StyleValue } from '../utils/StyleValue';
 
 import AbstractLayer from './AbstractLayer';
@@ -46,7 +46,7 @@ export type Props = {
   /**
    *  Filter only the features in the source layer that satisfy a condition that you define
    */
-  filter?: string[];
+  filter?: Expression;
 
   /**
    * The minimum zoom level at which the layer gets parsed and appears.


### PR DESCRIPTION
## Description

Fixes #2274

Is it right to also change the `filter` type on `AbstractLayer`?

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
- [ ] I updated the typings files - if js interface was changed (`index.d.ts`)
- [ ] I added/ updated a sample - if a new feature was implemented (`/example`)

