### PR TITLE
fix(v10, android): fix image scale

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/utils/DownloadMapImageTask.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/utils/DownloadMapImageTask.kt
@@ -21,6 +21,7 @@ import com.facebook.imagepipeline.image.CloseableImage
 import com.facebook.imagepipeline.image.CloseableStaticBitmap
 import com.facebook.imagepipeline.request.ImageRequestBuilder
 import com.facebook.react.views.imagehelper.ImageSource
+import com.mapbox.rctmgl.components.images.addBitmapImage
 import java.io.File
 import java.lang.ref.WeakReference
 import java.util.AbstractMap
@@ -120,7 +121,7 @@ class DownloadMapImageTask(context: Context, map: MapboxMap, callback: OnAllImag
                 val bitmapImages = HashMap<String, Bitmap>()
                 for ((key, value) in images) {
                     bitmapImages[key] = value
-                    style.addImage(key, value)
+                    style.addBitmapImage(key, value)
                 }
                 // style.addImages(bitmapImages);
             }


### PR DESCRIPTION
Fixes: #2278 

Passing: `(1.0/((160.0/bitmap.density))).toFloat()` as scale to `addStyleImage` seems to solve the issue, but it's empirical rather than planned. There's no documentation on scale.

https://docs.mapbox.com/android/maps/api/10.8.1/mapbox-maps-android/com.mapbox.maps/-style-manager-interface/add-style-image.html


Tested on Simulator Pixel 4 API 26;

### V9 android:
![mapboxgl-android-v9-sizes](https://user-images.githubusercontent.com/52435/194525513-321346aa-fb21-4bfe-876b-85b05d3f59fb.png)


### V10 android:

![mapbox-android-v10](https://user-images.githubusercontent.com/52435/194525429-741db082-979e-4b4d-ad63-72564a4c3401.png)

### V6 iOS:
![ios-mapbox-gl](https://user-images.githubusercontent.com/52435/194525657-2cf7b56d-124d-408f-b3c8-70d5f3f4d0de.png)


### V10 iOS:

![image](https://user-images.githubusercontent.com/52435/194526813-c16aff92-b5b1-4bf8-95c7-619340299a90.png)



