### PR TITLE
Allow user to enable/disable scale bar in Android v10

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.kt
@@ -33,6 +33,7 @@ import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
 import com.mapbox.maps.plugin.attribution.attribution
 import com.mapbox.maps.plugin.attribution.generated.AttributionSettings
+import com.mapbox.maps.plugin.scalebar.scalebar
 import com.mapbox.maps.plugin.compass.compass
 import com.mapbox.maps.plugin.delegates.listeners.*
 import com.mapbox.maps.plugin.gestures.*
@@ -871,6 +872,21 @@ open class RCTMGLMapView(private val mContext: Context, var mManager: RCTMGLMapV
                 )
                 0
             }
+        }
+    }
+
+    var mScaleBarEnabled = false
+
+    fun setReactScaleBarEnabled(scaleBarEnabled: Boolean) {
+        mScaleBarEnabled = scaleBarEnabled
+        updateScaleBar()
+    }
+
+    fun updateScaleBar() {
+        // TODO: Add more options
+        // https://docs.mapbox.com/android/maps/api/10.8.1/mapbox-maps-android/com.mapbox.maps.plugin.scalebar.generated/-scale-bar-settings/
+        scalebar.updateSettings {
+            enabled = mScaleBarEnabled
         }
     }
 

--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.kt
@@ -136,6 +136,11 @@ open class RCTMGLMapViewManager(context: ReactApplicationContext?) :
         mapView!!.setReactLogoPosition(logoPosition);
     }
 
+    @ReactProp(name = "scaleBarEnabled")
+    fun setScaleBarEnabled(mapView: RCTMGLMapView?, scaleBarEnabled: Boolean) {
+        mapView!!.setReactScaleBarEnabled(scaleBarEnabled);
+    }
+
     @ReactProp(name = "compassEnabled")
     fun setCompassEnabled(mapView: RCTMGLMapView?, compassEnabled: Boolean) {
         mapView!!.setReactCompassEnabled(compassEnabled);


### PR DESCRIPTION
## Description

Fixes #2295 

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
- [x] I updated the typings files - if js interface was changed (`index.d.ts`)
- [x] I added/ updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

Before (notice top left):
![telegram-cloud-photo-size-1-5064543788571142729-y](https://user-images.githubusercontent.com/41524992/195719635-116004a8-085f-4cc9-bd2e-e865169ba3af.jpg)

After:
![telegram-cloud-photo-size-1-5064543788571142730-y](https://user-images.githubusercontent.com/41524992/195719621-339b1ca3-34c0-4fb0-acb2-976462349476.jpg)
