### PR TITLE
Update map callbacks example

### DIFF
--- a/example/src/examples/V10/MapHandlers.js
+++ b/example/src/examples/V10/MapHandlers.js
@@ -23,7 +23,7 @@ const styles = {
     padding: 10,
   },
   divider: {
-    marginVertical: 10,
+    marginVertical: 6,
   },
   fadedText: {
     color: 'gray',
@@ -38,6 +38,7 @@ const MapHandlers = (props) => {
   const properties = mapState?.properties;
   const center = properties?.center;
   const bounds = properties?.bounds;
+  const heading = properties?.heading;
   const gestures = mapState?.gestures;
 
   const buildShape = (feature) => {
@@ -53,7 +54,7 @@ const MapHandlers = (props) => {
     setFeatures((prev) => [...prev, _feature]);
   };
 
-  const display = (position) => {
+  const displayCoord = (position) => {
     if (!position) {
       return '';
     }
@@ -113,13 +114,18 @@ const MapHandlers = (props) => {
           <Divider style={styles.divider} />
 
           <Text style={styles.fadedText}>center</Text>
-          <Text>{display(center)}</Text>
+          <Text>{displayCoord(center)}</Text>
 
           <Divider style={styles.divider} />
 
           <Text style={styles.fadedText}>bounds</Text>
-          <Text>NE: {display(bounds?.ne)}</Text>
-          <Text>NE: {display(bounds?.sw)}</Text>
+          <Text>NE: {displayCoord(bounds?.ne)}</Text>
+          <Text>SW: {displayCoord(bounds?.sw)}</Text>
+
+          <Divider style={styles.divider} />
+
+          <Text style={styles.fadedText}>heading</Text>
+          <Text>{heading.toFixed(2)}</Text>
 
           <Divider style={styles.divider} />
 
@@ -128,13 +134,23 @@ const MapHandlers = (props) => {
 
           <Divider style={styles.divider} />
 
-          <Text style={styles.fadedText}>isGestureActive</Text>
-          <Text>{gestures?.isGestureActive ? 'Yes' : 'No'}</Text>
+          <View
+            style={{
+              flex: 0,
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+            }}
+          >
+            <View>
+              <Text style={styles.fadedText}>isGestureActive</Text>
+              <Text>{gestures?.isGestureActive ? 'Yes' : 'No'}</Text>
+            </View>
 
-          <Divider style={styles.divider} />
-
-          <Text style={styles.fadedText}>isAnimatingFromGesture</Text>
-          <Text>{gestures?.isAnimatingFromGesture ? 'Yes' : 'No'}</Text>
+            <View>
+              <Text style={styles.fadedText}>isAnimatingFromGesture</Text>
+              <Text>{gestures?.isAnimatingFromGesture ? 'Yes' : 'No'}</Text>
+            </View>
+          </View>
         </View>
       </SafeAreaView>
     </Page>

--- a/example/src/examples/V10/MapHandlers.tsx
+++ b/example/src/examples/V10/MapHandlers.tsx
@@ -6,11 +6,22 @@ import {
   CircleLayer,
   ShapeSource,
   Logger,
+  MapState,
 } from '@rnmapbox/maps';
 import { Text, Divider } from '@rneui/base';
+import {
+  GeoJsonProperties,
+  Geometry,
+  GeometryCollection,
+  MultiPoint,
+  Point,
+  Position,
+} from 'geojson';
+import { Feature } from 'geojson';
 
 import Page from '../common/Page';
 import colors from '../../styles/colors';
+import { BaseExampleProps } from '../common/BaseExamplePropTypes';
 
 Logger.setLogLevel('verbose');
 
@@ -30,10 +41,25 @@ const styles = {
   },
 };
 
-const MapHandlers = (props) => {
+const MapHandlers = (props: BaseExampleProps) => {
   const [lastCallback, setLastCallback] = useState('');
-  const [mapState, setMapState] = useState({});
-  const [features, setFeatures] = useState([]);
+  const [mapState, setMapState] = useState<MapState>({
+    properties: {
+      center: [0, 0],
+      bounds: {
+        ne: [0, 0],
+        sw: [0, 0],
+      },
+      zoom: 0,
+      heading: 0,
+      pitch: 0,
+    },
+    gestures: {
+      isGestureActive: false,
+      isAnimatingFromGesture: false,
+    },
+  });
+  const [features, setFeatures] = useState<Feature<Geometry>[]>([]);
 
   const properties = mapState?.properties;
   const center = properties?.center;
@@ -41,20 +67,23 @@ const MapHandlers = (props) => {
   const heading = properties?.heading;
   const gestures = mapState?.gestures;
 
-  const buildShape = (feature) => {
+  const buildShape = (feature: Feature<Geometry>) => {
     return {
       type: 'Point',
+      // @ts-expect-error TODO
       coordinates: feature.geometry.coordinates,
     };
   };
 
-  const addFeature = (feature, kind) => {
-    const _feature = { ...feature };
-    _feature.properties.kind = kind;
+  const addFeature = (feature: Feature<Geometry>, kind: string) => {
+    const _feature: Feature<Geometry> = { ...feature };
+    if (_feature.properties) {
+      _feature.properties.kind = kind;
+    }
     setFeatures((prev) => [...prev, _feature]);
   };
 
-  const displayCoord = (position) => {
+  const displayCoord = (position: Position) => {
     if (!position) {
       return '';
     }
@@ -65,10 +94,10 @@ const MapHandlers = (props) => {
     <Page {...props}>
       <MapView
         style={styles.map}
-        onPress={(_feature) => {
+        onPress={(_feature: Feature<Geometry, GeoJsonProperties>) => {
           addFeature(_feature, 'press');
         }}
-        onLongPress={(_feature) => {
+        onLongPress={(_feature: Feature<Geometry, GeoJsonProperties>) => {
           addFeature(_feature, 'longPress');
         }}
         onCameraChanged={(_state) => {
@@ -86,9 +115,10 @@ const MapHandlers = (props) => {
           animationDuration={0}
         />
         {features.map((f, i) => {
+          // @ts-expect-error TODO
           const id = JSON.stringify(f.geometry.coordinates);
           const circleStyle =
-            f.properties.kind === 'press'
+            f.properties?.kind === 'press'
               ? {
                   circleColor: colors.primary.blue,
                   circleRadius: 6,
@@ -98,6 +128,7 @@ const MapHandlers = (props) => {
                   circleRadius: 12,
                 };
           return (
+            // @ts-expect-error TODO
             <ShapeSource key={id} id={`source-${id}`} shape={buildShape(f)}>
               <CircleLayer id={`layer-${id}`} style={circleStyle} />
             </ShapeSource>
@@ -125,7 +156,7 @@ const MapHandlers = (props) => {
           <Divider style={styles.divider} />
 
           <Text style={styles.fadedText}>heading</Text>
-          <Text>{heading.toFixed(2)}</Text>
+          <Text>{heading?.toFixed(2)}</Text>
 
           <Divider style={styles.divider} />
 

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -391,17 +391,17 @@ class MapView extends NativeBridgeComponent(
         );
         if (props.onRegionDidChange) {
           console.warn(
-            'rnmapbox/maps: only one of  MapView.onRegionDidChange or onMapIdle is supported',
+            'rnmapbox/maps: only one of MapView.onRegionDidChange or onMapIdle is supported',
           );
         }
       }
       if (addIfHasHandler('CameraChanged')) {
         console.warn(
-          'onCameraChanged is deprecated and will be removed in next beta - please use onRegionWillChange',
+          'onCameraChanged is deprecated and will be removed in next beta - please use onRegionIsChanging',
         );
         if (props.onRegionWillChange) {
           console.warn(
-            'rnmapbox/maps: only one of MapView.onRegionWillChange or onCameraChanged is supported',
+            'rnmapbox/maps: only one of MapView.onRegionIsChanging or onCameraChanged is supported',
           );
         }
       }

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -399,11 +399,17 @@ class MapView extends NativeBridgeComponent(
         console.warn(
           'onCameraChanged is deprecated and will be removed in next beta - please use onRegionIsChanging',
         );
-        if (props.onRegionWillChange) {
+        if (props.onRegionIsChanging) {
           console.warn(
             'rnmapbox/maps: only one of MapView.onRegionIsChanging or onCameraChanged is supported',
           );
         }
+      }
+
+      if (props.onRegionWillChange) {
+        console.warn(
+          'onRegionWillChange is deprecated and will be removed in v10 - please use onRegionIsChanging',
+        );
       }
 
       this._runNativeCommand('setHandledMapChangedEvents', this._nativeRef, [


### PR DESCRIPTION
This corrects several incorrect deprecation notices, and updates the v10 map callbacks example to TS.

My intention was to fix an issue when rotating the map, where the iOS `.cameraChanged` callback alternately fires with the camera state at the moment of starting the gesture, and the actual state. For instance, here is a typical log from `RCTMGLMapView.swift` of the `bearing` value during a pinch-to-rotate gesture:

```
6.421815145278117
7.825208541100609
6.421815145278117
8.806056099882483
6.421815145278117
8.806056099882483
6.421815145278117
9.694378738066519
6.421815145278117
10.537850335944086
6.421815145278117
11.492506191828681
6.421815145278117
12.418379956915544
6.421815145278117
13.140272292955729
6.421815145278117
14.255771518591871
```

This is apparently a known bug in the iOS SDK, [ostensibly fixed](https://github.com/mapbox/mapbox-maps-ios/issues/775) earlier this year. It doesn't appear fixed for me though. @mfazekas could you verify it's the same for you?