### PR TITLE
(v10) Revert SymbolLayer children type checking and use baseProps instead

### DIFF
--- a/javascript/components/SymbolLayer.tsx
+++ b/javascript/components/SymbolLayer.tsx
@@ -82,12 +82,12 @@ export class SymbolLayer extends AbstractLayer<Props, NativeTypeProps> {
   _shouldSnapshot() {
     let isSnapshot = false;
 
-    if (React.Children.count(this.props.children) <= 0) {
+    if (React.Children.count(this.baseProps.children) <= 0) {
       return isSnapshot;
     }
 
-    React.Children.forEach(this.props.children, (child) => {
-      if (child !== undefined && 'type' in child && child.type === View) {
+    React.Children.forEach(this.baseProps.children, (child) => {
+      if (child?.type === View) {
         isSnapshot = true;
       }
     });


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes #2312 

Unfortunately, the change I submitted in https://github.com/rnmapbox/maps/pull/2313 actually failed to handle a typing corner case (child can be null), so #2312 was not fully fixed.  However, I think the way this PR handles the typing of children makes more sense anyway.  Since `this.baseProps.children` has the typing described in the Props type (unfortunately `this.props.children` doesn't when @types/react is installed), referencing `this.baseProps.children` solves the problem automatically, and shouldn't change any behavior.

<!-- OR, if you're implementing a new feature: -->

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
- [x] I updated the typings files - if js interface was changed (`index.d.ts`)
- [x] I added/ updated a sample - if a new feature was implemented (`/example`)
