### PR TITLE
Re-order expo plugin instructions

### DIFF
--- a/plugin/install.md
+++ b/plugin/install.md
@@ -52,7 +52,6 @@ For `mapbox` or `mapbox-gl` you'll need to provide `RNMapboxMapsDownloadToken` a
 
 Next, rebuild your app as described in the ["Adding custom native code"](https://docs.expo.io/workflow/customizing/) guide.
 
-
 ## Manual Setup
 
 For bare workflow projects, you can follow the manual setup guides:

--- a/plugin/install.md
+++ b/plugin/install.md
@@ -32,8 +32,6 @@ After installing this package, add the [config plugin](https://docs.expo.io/guid
 }
 ```
 
-Next, rebuild your app as described in the ["Adding custom native code"](https://docs.expo.io/workflow/customizing/) guide.
-
 For `mapbox` or `mapbox-gl` you'll need to provide `RNMapboxMapsDownloadToken` as well.
 
 ```json
@@ -51,6 +49,9 @@ For `mapbox` or `mapbox-gl` you'll need to provide `RNMapboxMapsDownloadToken` a
   }
 }
 ```
+
+Next, rebuild your app as described in the ["Adding custom native code"](https://docs.expo.io/workflow/customizing/) guide.
+
 
 ## Manual Setup
 


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

This is just a tiny change to the expo plugin instructions.

- Re-order expo plugin instructions so people blindly following and using mapbox (me😅) don't end up needing to build the expo dev client twice
