### PR TITLE
fixed animationMode Type formatting

### DIFF
--- a/docs/Camera.md
+++ b/docs/Camera.md
@@ -33,11 +33,7 @@ return (
 | &nbsp;&nbsp;paddingTop | `number` | `none` | `true` | Top padding in points |
 | &nbsp;&nbsp;paddingBottom | `number` | `none` | `true` | Bottom padding in points |
 | animationDuration | `number` | `none` | `false` | The duration the map takes to animate to a new configuration. |
-| animationMode | `\| 'flyTo'
-\| 'easeTo'
-\| 'linearTo'
-\| 'moveTo'
-\| 'none'` | `none` | `false` | The easing or path the camera uses to animate to a new configuration. |
+| animationMode | `'flyTo' \| 'easeTo' \| 'linearTo' \| 'moveTo' \| 'none'` | `none` | `false` | The easing or path the camera uses to animate to a new configuration. |
 | followUserMode | `UserTrackingMode` | `none` | `false` | The mode used to track the user location on the map. |
 | followUserLocation | `boolean` | `none` | `false` | Whether the map orientation follows the user location. |
 | followZoomLevel | `number` | `none` | `false` | The zoom level used when following the user location. |


### PR DESCRIPTION
## Description

Fixes the formatting of the Type column in the animation mode row.

Before:
<img width="431" alt="Screen Shot 2022-10-26 at 7 48 25 PM" src="https://user-images.githubusercontent.com/2466842/198160242-82385f84-c2e7-42ac-a8dc-f7057ac13ca7.png">

After:
<img width="656" alt="Screen Shot 2022-10-26 at 7 55 55 PM" src="https://user-images.githubusercontent.com/2466842/198160305-75170879-617b-4788-89d6-887f13216fca.png">

## Checklist

<!-- Check completed item: [X] -->

- [ ] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I updated the typings files - if js interface was changed (`index.d.ts`)
- [ ] I added/ updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
