### PR TITLE
Fix v10 interface signature

### DIFF
--- a/ios/RCTMGL-v10/MGLModule.m
+++ b/ios/RCTMGL-v10/MGLModule.m
@@ -2,7 +2,7 @@
 
 @interface RCT_EXTERN_MODULE(MGLModule, NSObject)
 
-RCT_EXTERN_METHOD(setAccessToken:)
+RCT_EXTERN_METHOD(setAccessToken:(NSString *)accessToken resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(addCustomHeader:(NSString *)headerName forHeaderValue:(NSString *) headerValue)
 RCT_EXTERN_METHOD(removeCustomHeader:(NSString *)headerName)


### PR DESCRIPTION
Fixes bug caused by https://github.com/rnmapbox/maps/pull/2343, with the `setAccessToken` interface signature no longer matching the implementation.