### PR TITLE
fix: MapboxGL.UserTrackingModes variable is undefined

### DIFF
--- a/javascript/index.js
+++ b/javascript/index.js
@@ -1,6 +1,6 @@
 import { NativeModules } from 'react-native';
 
-import { Camera, UserTrackingModes } from './components/Camera';
+import { Camera, UserTrackingMode } from './components/Camera';
 import { Atmosphere } from './components/Atmosphere';
 import MapView from './components/MapView';
 import Light from './components/Light';
@@ -45,7 +45,7 @@ const MapboxGL = { ...NativeModules.MGLModule };
 
 // static methods
 MapboxGL.requestAndroidLocationPermissions = requestAndroidLocationPermissions;
-MapboxGL.UserTrackingModes = UserTrackingModes;
+MapboxGL.UserTrackingModes = UserTrackingMode;
 
 // components
 MapboxGL.MapView = MapView;


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixed UserTrackingModes reference is broken and `example/src/examples/Camera/SetUserTrackingModes.js` cannot be displayed

ref: https://github.com/rnmapbox/maps/pull/2242

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I updated the typings files - if js interface was changed (`index.d.ts`)
- [ ] I added/ updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

<img src="https://user-images.githubusercontent.com/6457344/198530470-8b635bcc-e5dc-4377-8814-158c94f91072.png" height="600">

