### PR TITLE
fix: publish app.plugin.js (#2361)

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "lib",
     "plugin",
     "assets",
+    "app.plugin.js",
     "index.d.ts",
     "rnmapbox-maps.podspec",
     "ios",


### PR DESCRIPTION
## Description

Fixes #2361

`app.plugin.js` is not published inside npm package.


## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I updated the typings files - if js interface was changed (`index.d.ts`)
- [ ] I added/ updated a sample - if a new feature was implemented (`/example`)
