### PR TITLE
fix(v10,ios): fixed inconsistent order of rect values in iOS

### DIFF
--- a/example/src/examples/FillRasterLayer/QueryWithRect.js
+++ b/example/src/examples/FillRasterLayer/QueryWithRect.js
@@ -68,7 +68,8 @@ class QueryWithRect extends React.Component {
     const minX = Math.min(screenCoords[0][0], screenCoords[1][0]);
     const maxY = Math.max(screenCoords[0][1], screenCoords[1][1]);
     const minY = Math.min(screenCoords[0][1], screenCoords[1][1]);
-    return [maxY, maxX, minY, minX];
+    // Rect -> [top, right, bottom, left]
+    return [minY, maxX, maxY, minX];
   }
 
   get message() {

--- a/ios/RCTMGL-v10/RCTMGLMapViewManager.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapViewManager.swift
@@ -215,10 +215,10 @@ extension RCTMGLMapViewManager {
     resolver: @escaping RCTPromiseResolveBlock,
     rejecter: @escaping RCTPromiseRejectBlock) -> Void {
       withMapView(reactTag, name:"queryRenderedFeaturesInRect", rejecter: rejecter) { mapView in
-        let left = bbox.isEmpty ? 0.0 : CGFloat(bbox[0].floatValue)
-        let bottom = bbox.isEmpty ? 0.0 : CGFloat(bbox[1].floatValue)
-        let right = bbox.isEmpty ? 0.0 : CGFloat(bbox[2].floatValue)
-        let top = bbox.isEmpty ? 0.0 : CGFloat(bbox[3].floatValue)
+        let top = bbox.isEmpty ? 0.0 : CGFloat(bbox[0].floatValue)
+        let right = bbox.isEmpty ? 0.0 : CGFloat(bbox[1].floatValue)
+        let bottom = bbox.isEmpty ? 0.0 : CGFloat(bbox[2].floatValue)
+        let left = bbox.isEmpty ? 0.0 : CGFloat(bbox[3].floatValue)
         let rect = bbox.isEmpty ? CGRect(x: 0.0, y: 0.0, width: mapView.bounds.size.width, height: mapView.bounds.size.height) : CGRect(x: [left,right].min()!, y: [top,bottom].min()!, width: abs(right-left), height: abs(bottom-top))
         logged("queryRenderedFeaturesInRect.option", rejecter: rejecter) {
           let options = try RenderedQueryOptions(layerIds: layerIDs, filter: filter?.asExpression())


### PR DESCRIPTION

## Description

Fixes 
- Fixed inconsistent order of rect bound values in iOS
- Updated example with correct order of Rect bounds (Fill/RasterLayer --> Query Features Bounding Box)

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I updated the typings files - if js interface was changed (`index.d.ts`)
- [x] I added/ updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

| Before Fix  | After Fix |
| ------------- | ------------- |
|  <video src="https://user-images.githubusercontent.com/28037630/199347813-7272bf15-47de-4232-abac-4b0cb2a61ba2.mov">  | <video src="https://user-images.githubusercontent.com/28037630/199348615-661d321a-deb5-4be8-9969-954e05188b4f.mov">  |
| <video src="https://user-images.githubusercontent.com/28037630/199350304-26574e19-4b72-42ed-a773-7354560c1abc.mov">  | <video src="https://user-images.githubusercontent.com/28037630/199350623-3f88e125-ff31-44fb-8c56-dbfbcbb41f3f.mov">  |


