### PR TITLE
fix(v10): query method without filter params returns empty feature results

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.kt
@@ -269,11 +269,12 @@ open class RCTMGLMapViewManager(context: ReactApplicationContext?) :
                 );
             }
             METHOD_QUERY_FEATURES_RECT -> {
+                val rect = ConvertUtils.toStringList(args!!.getArray(3))
                 mapView.queryRenderedFeaturesInRect(
                         args!!.getString(0),
                         ConvertUtils.toRectF(args.getArray(1)),
                         ExpressionParser.from(args!!.getArray(2)),
-                        ConvertUtils.toStringList(args!!.getArray(3))
+                        if (rect.size == 0) null else rect
                 );
             }
             METHOD_VISIBLE_BOUNDS -> {

--- a/ios/RCTMGL-v10/RCTMGLMapViewManager.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapViewManager.swift
@@ -221,7 +221,7 @@ extension RCTMGLMapViewManager {
         let top = bbox.isEmpty ? 0.0 : CGFloat(bbox[3].floatValue)
         let rect = bbox.isEmpty ? CGRect(x: 0.0, y: 0.0, width: mapView.bounds.size.width, height: mapView.bounds.size.height) : CGRect(x: [left,right].min()!, y: [top,bottom].min()!, width: abs(right-left), height: abs(bottom-top))
         logged("queryRenderedFeaturesInRect.option", rejecter: rejecter) {
-          let options = try RenderedQueryOptions(layerIds: layerIDs, filter: filter?.asExpression())
+          let options = try RenderedQueryOptions(layerIds: layerIDs?.isEmpty ?? true ? nil : layerIDs, filter: filter?.asExpression())
           mapView.mapboxMap.queryRenderedFeatures(with: rect, options: options) { result in
             switch result {
             case .success(let features):


### PR DESCRIPTION

## Description

Fixes #<issue-number>
- Fixed: query method without filter params returns empty feature results. `map.queryRenderedFeaturesInRect(rect)`

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I updated the typings files - if js interface was changed (`index.d.ts`)
- [ ] I added/ updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

N/A
