### PR TITLE
fix(v10,ios): color with alpha is always set to 1 in iOS

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.kt
@@ -269,12 +269,12 @@ open class RCTMGLMapViewManager(context: ReactApplicationContext?) :
                 );
             }
             METHOD_QUERY_FEATURES_RECT -> {
-                val rect = ConvertUtils.toStringList(args!!.getArray(3))
+                val layerIds = ConvertUtils.toStringList(args!!.getArray(3))
                 mapView.queryRenderedFeaturesInRect(
                         args!!.getString(0),
                         ConvertUtils.toRectF(args.getArray(1)),
                         ExpressionParser.from(args!!.getArray(2)),
-                        if (rect.size == 0) null else rect
+                        if (layerIds.size == 0) null else layerIds
                 );
             }
             METHOD_VISIBLE_BOUNDS -> {

--- a/ios/RCTMGL-v10/RCTMGLStyleValue.swift
+++ b/ios/RCTMGL-v10/RCTMGLStyleValue.swift
@@ -225,7 +225,7 @@ class RCTMGLStyleValue {
           red: CGFloat((Float((rgbValue & 0xff0000) >> 16)) / 255.0),
           green: CGFloat((Float((rgbValue & 0x00ff00) >> 8)) / 255.0),
           blue: CGFloat((Float((rgbValue & 0x0000ff) >> 0)) / 255.0),
-          alpha: 1.0)
+          alpha: CGFloat((rgbValue & 0xFF000000) >> 24) / 0xFF)
   }
 
   func mglStyleValueColor() -> Value<StyleColor> {


### PR DESCRIPTION
## Description

Fixes #<issue-number>
- Color with alpha is always set to 1 in iOS


## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I updated the typings files - if js interface was changed (`index.d.ts`)
- [ ] I added/ updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

Note: The `fillColor` of the **selected** `FillLayer` is set as `"hsla(267, 72%, 63%, 0.2)"`

| Before fix  | After fix |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/28037630/199795379-8d3f53e7-c230-45a8-a8a7-af0975f7a709.mov">  | <video src="https://user-images.githubusercontent.com/28037630/199795561-93892adb-03d9-48df-8142-4f195efbdfc3.mov">  |
