### PR TITLE
feat: expo config-plugin update imports and dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "prepare": "bob build && husky install"
   },
   "peerDependencies": {
-    "mapbox-gl": "^ 2.9.0",
     "expo": ">=47.0.0",
+    "mapbox-gl": "^2.9.0",
     "prop-types": ">=15.5.8",
     "react": ">=16.6.1",
     "react-native": ">=0.59.9"

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "prepare": "bob build && husky install"
   },
   "peerDependencies": {
-    "expo": "*",
     "mapbox-gl": "^ 2.9.0",
+    "expo": ">=47.0.0",
     "prop-types": ">=15.5.8",
     "react": ">=16.6.1",
     "react-native": ">=0.59.9"
@@ -83,7 +83,8 @@
     "eslint-plugin-ft-flow": "^2.0.1",
     "eslint-plugin-import": "2.25.3",
     "eslint-plugin-jest": "^27.0.1",
-    "expo-module-scripts": "^2.0.0",
+    "expo": "^47.0.0",
+    "expo-module-scripts": "3.0.3",
     "husky": "^8.0.1",
     "jest": "27.5.1",
     "jest-cli": "27.5.1",

--- a/plugin/build/withMapbox.d.ts
+++ b/plugin/build/withMapbox.d.ts
@@ -1,4 +1,4 @@
-import { ConfigPlugin, XcodeProject } from '@expo/config-plugins';
+import { ConfigPlugin, XcodeProject } from 'expo/config-plugins';
 declare type InstallerBlockName = 'pre' | 'post';
 export declare type MapboxPlugProps = {
     RNMapboxMapsImpl?: string;

--- a/plugin/build/withMapbox.js
+++ b/plugin/build/withMapbox.js
@@ -6,7 +6,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.setExcludedArchitectures = exports.addMapboxInstallerBlock = exports.addInstallerBlock = exports.addConstantBlock = exports.applyCocoaPodsModifications = void 0;
 const fs_1 = require("fs");
 const path_1 = __importDefault(require("path"));
-const config_plugins_1 = require("@expo/config-plugins");
+const config_plugins_1 = require("expo/config-plugins");
 const generateCode_1 = require("@expo/config-plugins/build/utils/generateCode");
 let pkg = {
     name: '@rnmapbox/maps',
@@ -127,7 +127,7 @@ function setExcludedArchitectures(project) {
     for (const { buildSettings } of Object.values(configurations || {})) {
         // Guessing that this is the best way to emulate Xcode.
         // Using `project.addToBuildSettings` modifies too many targets.
-        if (typeof (buildSettings === null || buildSettings === void 0 ? void 0 : buildSettings.PRODUCT_NAME) !== 'undefined') {
+        if (typeof buildSettings?.PRODUCT_NAME !== 'undefined') {
             buildSettings['"EXCLUDED_ARCHS[sdk=iphonesimulator*]"'] = '"arm64"';
         }
     }

--- a/plugin/src/withMapbox.ts
+++ b/plugin/src/withMapbox.ts
@@ -11,7 +11,7 @@ import {
   WarningAggregator,
   withProjectBuildGradle,
   withAppBuildGradle,
-} from '@expo/config-plugins';
+} from 'expo/config-plugins';
 import {
   mergeContents,
   removeGeneratedContents,


### PR DESCRIPTION
See #2389 – this only fixes the dependencies and public APIs. Further changes will be necessary when the private APIs are exposed.