### PR TITLE
fix(android) Fix React Native build errors

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -35,7 +35,7 @@
     "moment": "^2.24.0",
     "prop-types": "^15.7.2",
     "react": "18.0.0",
-    "react-native": "0.69.4",
+    "react-native": "0.69.7",
     "react-native-safe-area-context": "^4.3.3",
     "react-native-screens": "^3.0.0",
     "react-native-svg": "^12.1.0",


### PR DESCRIPTION
At the end of last week, React Native [broke](https://github.com/facebook/react-native/issues/35210). This PR resolves the build error on Android.