### PR TITLE
fix(v10,android): fix crash on view annotation removal

### DIFF
--- a/android/rctmgl/build.gradle
+++ b/android/rctmgl/build.gradle
@@ -132,6 +132,7 @@ dependencies {
         else if (safeExtGet("RNMapboxMapsImpl", defaultMapboxMapsImpl) == "mapbox") {
             implementation 'com.mapbox.maps:android:10.9.0'
             implementation 'com.mapbox.mapboxsdk:mapbox-sdk-turf:6.8.0'
+            implementation 'androidx.asynclayoutinflater:asynclayoutinflater:1.0.0'
         }
     }
 

--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/annotation/RCTMGLMarkerView.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/annotation/RCTMGLMarkerView.kt
@@ -5,6 +5,7 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import android.view.View
+import android.view.ViewGroup
 import android.widget.FrameLayout
 import com.mapbox.geojson.Point
 import com.mapbox.maps.ViewAnnotationAnchor
@@ -142,7 +143,10 @@ class RCTMGLMarkerView(context: Context?, private val mManager: RCTMGLMarkerView
         this.removeOnLayoutChangeListener(this)
 
         mView?.let { view ->
-            mapView.endViewTransition(view) // https://github.com/mapbox/mapbox-maps-android/issues/1723
+            val parent = view.parent
+            if (parent is ViewGroup) {
+                parent.endViewTransition(view) // https://github.com/mapbox/mapbox-maps-android/issues/1723
+            }
             val removed = mapView.viewAnnotationManager?.removeViewAnnotation(view)
             if (removed == false) {
                 Logger.w("RCTMGLMarkerView", "Unable to remove view")

--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.kt
@@ -1187,12 +1187,14 @@ open class RCTMGLMapView(private val mContext: Context, var mManager: RCTMGLMapV
 
     override fun onDestroy() {
         removeAllFeatures()
+        viewAnnotationManager.removeAllViewAnnotations()
         lifecycleOwner?.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
         super.onDestroy()
     }
 
     fun onDropViewInstance() {
         removeAllFeatures()
+        viewAnnotationManager.removeAllViewAnnotations()
         lifecycleOwner?.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
     }
 


### PR DESCRIPTION
With 10.9 or later views are no longer directly added to the mapView but a annotationViewLayout subview. And our workaround one endViewTransition needs to be called on `annotationViewLayout` for the 10.9+ versions