### PR TITLE
fix: requireNativeComponent types

### DIFF
--- a/javascript/components/Atmosphere.tsx
+++ b/javascript/components/Atmosphere.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useMemo } from 'react';
-import { HostComponent, requireNativeComponent } from 'react-native';
+import { requireNativeComponent } from 'react-native';
 
 import type { AtmosphereLayerStyleProps } from '../utils/MapboxStyles';
 import { StyleValue, transformStyle } from '../utils/StyleValue';
@@ -22,7 +22,10 @@ export const Atmosphere = memo((props: Props) => {
   return <RCTMGLAtmosphere {...baseProps} />;
 });
 
-const RCTMGLAtmosphere: HostComponent<{
+type NativeProps = {
   reactStyle?: { [key: string]: StyleValue };
   style?: undefined;
-}> = requireNativeComponent(NATIVE_MODULE_NAME);
+};
+
+const RCTMGLAtmosphere =
+  requireNativeComponent<NativeProps>(NATIVE_MODULE_NAME);

--- a/javascript/components/MarkerView.tsx
+++ b/javascript/components/MarkerView.tsx
@@ -146,7 +146,7 @@ type NativeProps = ViewProps & {
   isSelected: boolean;
 };
 
-const RCTMGLMarkerView: HostComponent<NativeProps> =
-  requireNativeComponent(NATIVE_MODULE_NAME);
+const RCTMGLMarkerView =
+  requireNativeComponent<NativeProps>(NATIVE_MODULE_NAME);
 
 export default MarkerView;

--- a/javascript/components/MarkerView.tsx
+++ b/javascript/components/MarkerView.tsx
@@ -3,7 +3,6 @@ import {
   Platform,
   NativeModules,
   requireNativeComponent,
-  HostComponent,
   type ViewProps,
   View,
 } from 'react-native';

--- a/javascript/components/PointAnnotation.tsx
+++ b/javascript/components/PointAnnotation.tsx
@@ -3,7 +3,6 @@ import {
   requireNativeComponent,
   StyleSheet,
   Platform,
-  type HostComponent,
   type ViewProps,
 } from 'react-native';
 import { type Feature } from 'geojson';
@@ -27,7 +26,7 @@ type FeaturePayload = {
   feature: Feature;
 };
 
-type PointAnnotationProps = {
+type Props = {
   /**
    * A string that uniquely identifies the annotation
    */
@@ -119,7 +118,7 @@ type PointAnnotationProps = {
  * as with PointAnnotation child views are rendered onto a bitmap
  */
 class PointAnnotation extends NativeBridgeComponent(
-  React.PureComponent<PointAnnotationProps>,
+  React.PureComponent<Props>,
   NATIVE_MODULE_NAME,
 ) {
   static defaultProps = {
@@ -129,7 +128,7 @@ class PointAnnotation extends NativeBridgeComponent(
 
   _nativeRef: NativePointAnnotationRef | null = null;
 
-  constructor(props: PointAnnotationProps) {
+  constructor(props: Props) {
     super(props);
     this._onSelected = this._onSelected.bind(this);
     this._onDeselected = this._onDeselected.bind(this);
@@ -219,14 +218,13 @@ class PointAnnotation extends NativeBridgeComponent(
     );
   }
 }
-type NativePointAnnotationProps = Omit<PointAnnotationProps, 'coordinate'> & {
+type NativeProps = Omit<Props, 'coordinate'> & {
   coordinate: string | undefined;
 };
 
-type NativePointAnnotationRef = Component<NativePointAnnotationProps>;
-type NativePointAnnotation = HostComponent<NativePointAnnotationProps>;
+type NativePointAnnotationRef = Component<NativeProps>;
 
-const RCTMGLPointAnnotation: NativePointAnnotation =
-  requireNativeComponent(NATIVE_MODULE_NAME);
+const RCTMGLPointAnnotation =
+  requireNativeComponent<NativeProps>(NATIVE_MODULE_NAME);
 
 export default PointAnnotation;

--- a/javascript/components/ShapeSource.tsx
+++ b/javascript/components/ShapeSource.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  HostComponent,
   NativeMethods,
   NativeModules,
   NativeSyntheticEvent,
@@ -407,6 +406,5 @@ type NativeProps = {
   shape?: string;
 };
 
-type NativeShapeSource = HostComponent<NativeProps>;
-const RCTMGLShapeSource: NativeShapeSource =
-  requireNativeComponent(NATIVE_MODULE_NAME);
+const RCTMGLShapeSource =
+  requireNativeComponent<NativeProps>(NATIVE_MODULE_NAME);


### PR DESCRIPTION
## Description

Fixes #2391

I only changed the typings from the variables over to the generic of the function. I still don't know why this behaves different after an Expo Upgrade because I couldn't find changes to the typings in `@types/react-native` but it fixes the problem anyway.


## Checklist

<!-- Check completed item: [X] -->

- [ ] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I updated the typings files - if js interface was changed (`index.d.ts`)
- [ ] I added/ updated a sample - if a new feature was implemented (`/example`)

