### PR TITLE
fix(v10,ios) Populate StyleURL enum with correct key

### DIFF
--- a/ios/RCTMGL-v10/MGLModule.swift
+++ b/ios/RCTMGL-v10/MGLModule.swift
@@ -20,7 +20,7 @@ class MGLModule : NSObject {
           "Light": StyleURI.light.rawValue,
           "Dark": StyleURI.dark.rawValue,
           "Satellite": StyleURI.satellite.rawValue,
-          "SatelliteStreets": StyleURI.satelliteStreets.rawValue,
+          "SatelliteStreet": StyleURI.satelliteStreets.rawValue,
         ],
       "OfflinePackDownloadState":
         [


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Using the following snippet rendered the default style on iOS, not `satellite-streets-v11` as expected.
```ts
<MapboxGL.MapView styleURL={MapboxGL.StyleURL.SatelliteStreet} >
```

Logging the `MapboxGL.StyleURL` enum to the console:
```json
{
  "Dark": "mapbox://styles/mapbox/dark-v10",
  "Light": "mapbox://styles/mapbox/light-v10",
  "Outdoors": "mapbox://styles/mapbox/outdoors-v11",
  "Satellite": "mapbox://styles/mapbox/satellite-v9",
  "SatelliteStreets": "mapbox://styles/mapbox/satellite-streets-v11",
  "Street": "mapbox://styles/mapbox/streets-v11"
}
```

[ios/RCTMGL-v10/MGLModule.swift](https://github.com/rnmapbox/maps/blob/894f9a212b060d265e6cbe77748c4417d2d1812d/ios/RCTMGL-v10/MGLModule.swift#L23) exports `SatelliteStreets` - not `SatelliteStreet` like [android/rctmgl/src/main/java-mapboxgl/common/com/mapbox/rctmgl/modules/RCTMGLModule.java](https://github.com/rnmapbox/maps/blob/894f9a212b060d265e6cbe77748c4417d2d1812d/android/rctmgl/src/main/java-mapboxgl/common/com/mapbox/rctmgl/modules/RCTMGLModule.java#L69), which is whats expected in [index.d.td](https://github.com/rnmapbox/maps/blob/894f9a212b060d265e6cbe77748c4417d2d1812d/index.d.ts#L506).  

Changing line 23 to `SatelliteStreet` in the `.swift` file fixed my problem. I could not find any other occurrence of `SatelliteStreets` in this repo. 

## Checklist

<!-- Check completed item: [X] -->

- [X] I have tested this on a device/simulator for each compatible OS 
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I updated the typings files - if js interface was changed (`index.d.ts`)
- [ ] I added/ updated a sample - if a new feature was implemented (`/example`)

