### PR TITLE
fix(v10,android): update ornament layout on mapView

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.kt
@@ -1021,6 +1021,21 @@ open class RCTMGLMapView(private val mContext: Context, var mManager: RCTMGLMapV
         }
     }
 
+    fun updateOrnaments() {
+        (0..this.childCount - 1).map {
+            val view = this.getChildAt(it)
+            if (view.javaClass.toString().contains(".maps.plugin.")) {
+                view.invalidate()
+                view.forceLayout()
+            }
+        }
+    }
+
+    override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
+        updateOrnaments()
+        super.onLayout(changed, left, top, right, bottom)
+    }
+
     // endregion
 
     private fun getGravityAndMargin (position:ReadableMap): Pair<Int, IntArray> {


### PR DESCRIPTION
Implemented a hack to update ornament layout on change of mapView 

Fixes: #2403

This fixes scalebar, but it still cannot be repositioned:

<img width="434" alt="image" src="https://user-images.githubusercontent.com/52435/202263727-e33578d3-7afd-41a2-ac55-8614598e1d5f.png">
