### PR TITLE
fix(v10, android): fix android ornaments

### DIFF
--- a/example/android/app/src/main/java/com/rnmapboxglexample/MainActivity.java
+++ b/example/android/app/src/main/java/com/rnmapboxglexample/MainActivity.java
@@ -3,8 +3,15 @@ package com.rnmapboxglexample;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
+import android.os.Bundle;
 
 public class MainActivity extends ReactActivity {
+
+  //react-native-screens override
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(null);
+  }
 
   /**
    * Returns the name of the main component registered from JavaScript. This is used to schedule

--- a/example/package.json
+++ b/example/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@mapbox/geo-viewport": "^0.5.0",
     "@mapbox/mapbox-sdk": "^0.13.0",
+    "@react-native-async-storage/async-storage": "^1.17.11",
     "@react-navigation/compat": "^5.3.20",
     "@react-navigation/native": "^6.0.11",
     "@react-navigation/native-stack": "^6.7.0",


### PR DESCRIPTION
- fix(v10, android): force relayout of chllderns so ornaments can be updated (uses an ugly hack  - see`workaroundToRelayoutChildOfMapView`, but seems to work)
- feat(example): save last example, and show as first item
- feat(example): added `//react-native-screens override` so layout inspector can be used.

![image](https://user-images.githubusercontent.com/52435/202900679-81272257-235c-455c-a3b5-f224f516deaa.png)

![image](https://user-images.githubusercontent.com/52435/202900558-fec197fe-4994-4ac6-b33e-46f2d68b61c8.png)
![image](https://user-images.githubusercontent.com/52435/202900564-ced24e86-7836-4c06-84a2-65c3cb0d3c1d.png)


Closes: #2421 
Fixes: #2403