### PR TITLE
fix(v10): change in style layer can cause crash in image properties

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/styles/RCTMGLStyleFactory.java
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/styles/RCTMGLStyleFactory.java
@@ -24,6 +24,7 @@ import com.mapbox.maps.extension.style.types.StyleTransition;
 import com.mapbox.maps.extension.style.light.generated.Light;
 import com.mapbox.maps.extension.style.light.LightPosition;
 import com.mapbox.rctmgl.utils.DownloadMapImageTask;
+import com.mapbox.rctmgl.utils.Logger;
 
 import java.util.List;
 
@@ -82,7 +83,11 @@ public class RCTMGLStyleFactory {
               style.addImage(styleValue, new DownloadMapImageTask.OnAllImagesLoaded() {
                   @Override
                   public void onAllImagesLoaded() {
-                      RCTMGLStyleFactory.setFillPattern(layer, styleValue);
+                      try {
+                          RCTMGLStyleFactory.setFillPattern(layer, styleValue);
+                      } catch (RuntimeException exception) {
+                          Logger.INSTANCE.e("RCTMGLFill",String.format("Exception failed during setFillPattern: %s", exception.getMessage()));
+                      }
                   }
               });
               break;
@@ -176,7 +181,11 @@ public class RCTMGLStyleFactory {
               style.addImage(styleValue, new DownloadMapImageTask.OnAllImagesLoaded() {
                   @Override
                   public void onAllImagesLoaded() {
-                      RCTMGLStyleFactory.setLinePattern(layer, styleValue);
+                      try {
+                          RCTMGLStyleFactory.setLinePattern(layer, styleValue);
+                      } catch (RuntimeException exception) {
+                          Logger.INSTANCE.e("RCTMGLLine",String.format("Exception failed during setLinePattern: %s", exception.getMessage()));
+                      }
                   }
               });
               break;
@@ -243,7 +252,11 @@ public class RCTMGLStyleFactory {
               style.addImage(styleValue, new DownloadMapImageTask.OnAllImagesLoaded() {
                   @Override
                   public void onAllImagesLoaded() {
-                      RCTMGLStyleFactory.setIconImage(layer, styleValue);
+                      try {
+                          RCTMGLStyleFactory.setIconImage(layer, styleValue);
+                      } catch (RuntimeException exception) {
+                          Logger.INSTANCE.e("RCTMGLSymbol",String.format("Exception failed during setIconImage: %s", exception.getMessage()));
+                      }
                   }
               });
               break;
@@ -572,7 +585,11 @@ public class RCTMGLStyleFactory {
               style.addImage(styleValue, new DownloadMapImageTask.OnAllImagesLoaded() {
                   @Override
                   public void onAllImagesLoaded() {
-                      RCTMGLStyleFactory.setFillExtrusionPattern(layer, styleValue);
+                      try {
+                          RCTMGLStyleFactory.setFillExtrusionPattern(layer, styleValue);
+                      } catch (RuntimeException exception) {
+                          Logger.INSTANCE.e("RCTMGLFillExtrusion",String.format("Exception failed during setFillExtrusionPattern: %s", exception.getMessage()));
+                      }
                   }
               });
               break;
@@ -727,7 +744,11 @@ public class RCTMGLStyleFactory {
               style.addImage(styleValue, new DownloadMapImageTask.OnAllImagesLoaded() {
                   @Override
                   public void onAllImagesLoaded() {
-                      RCTMGLStyleFactory.setBackgroundPattern(layer, styleValue);
+                      try {
+                          RCTMGLStyleFactory.setBackgroundPattern(layer, styleValue);
+                      } catch (RuntimeException exception) {
+                          Logger.INSTANCE.e("RCTMGLBackground",String.format("Exception failed during setBackgroundPattern: %s", exception.getMessage()));
+                      }
                   }
               });
               break;

--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/styles/layers/RCTLayer.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/styles/layers/RCTLayer.kt
@@ -21,8 +21,6 @@ import com.mapbox.rctmgl.utils.ExpressionParser
 import java.lang.ClassCastException
 import com.mapbox.rctmgl.utils.Logger
 
-
-// import com.mapbox.rctmgl.utils.ExpressionParser;
 abstract class RCTLayer<T : Layer?>(protected var mContext: Context) : AbstractSourceConsumer(
     mContext
 ) {
@@ -253,15 +251,12 @@ abstract class RCTLayer<T : Layer?>(protected var mContext: Context) : AbstractS
         super.removeFromMap(mapView)
     }
 
-    // v10TOOD: adding anything seems to make getStyle null
-    //        return mMap.getStyle();
     private val style: Style?
-        private get() =// v10TOOD: adding anything seems to make getStyle null
+        private get() =
             if (mMap == null) {
                 null
-            } else mMapView!!.savedStyle
+            } else mMapView?.savedStyle
 
-    //        return mMap.getStyle();
     abstract fun makeLayer(): T
     abstract fun addStyles()
     private fun hasInitialized(): Boolean {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -365,13 +365,15 @@ PODS:
     - React-jsi (= 0.69.7)
     - React-logger (= 0.69.7)
     - React-perflogger (= 0.69.7)
-  - rnmapbox-maps (10.0.0-beta.57):
+  - RNCAsyncStorage (1.17.11):
+    - React-Core
+  - rnmapbox-maps (10.0.0-beta.58):
     - MapboxMaps (~> 10.9.1)
     - React
     - React-Core
-    - rnmapbox-maps/DynamicLibrary (= 10.0.0-beta.57)
+    - rnmapbox-maps/DynamicLibrary (= 10.0.0-beta.58)
     - Turf
-  - rnmapbox-maps/DynamicLibrary (10.0.0-beta.57):
+  - rnmapbox-maps/DynamicLibrary (10.0.0-beta.58):
     - MapboxMaps (~> 10.9.1)
     - React
     - React-Core
@@ -446,6 +448,7 @@ DEPENDENCIES:
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - React-runtimeexecutor (from `../node_modules/react-native/ReactCommon/runtimeexecutor`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
+  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - rnmapbox-maps (from `../../`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
@@ -540,6 +543,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/runtimeexecutor"
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
+  RNCAsyncStorage:
+    :path: "../node_modules/@react-native-async-storage/async-storage"
   rnmapbox-maps:
     :path: "../../"
   RNScreens:
@@ -601,7 +606,8 @@ SPEC CHECKSUMS:
   React-RCTVibration: 600a9f8b3537db360563d50fab3d040c262567d4
   React-runtimeexecutor: 65cd2782a57e1d59a68aa5d504edf94278578e41
   ReactCommon: 1e783348b9aa73ae68236271df972ba898560a95
-  rnmapbox-maps: 77e5a8a74550a7288620886b5b466dc6b9d7421f
+  RNCAsyncStorage: 8616bd5a58af409453ea4e1b246521bb76578d60
+  rnmapbox-maps: e756b5660cca186975efa6406e28485f836c1baf
   RNScreens: 0df01424e9e0ed7827200d6ed1087ddd06c493f9
   RNSVG: ecd661f380a07ba690c9c5929c475a44f432d674
   RNVectorIcons: fcc2f6cb32f5735b586e66d14103a74ce6ad61f8

--- a/ios/RCTMGL-v10/RCTMGLBackgroundLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLBackgroundLayer.swift
@@ -33,7 +33,9 @@ class RCTMGLBackgroundLayer: RCTMGLLayer {
         styler.backgroundLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
-          applyUpdater: { (updater) in try! style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }},
+          applyUpdater: { (updater) in logged("RCTMGLBackgroundLayer.addStyles") {
+            try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
+          }},
           isValid: { return self.isAddedToMap() })
         self.styleLayer = styleLayer
       }

--- a/ios/RCTMGL-v10/RCTMGLCircleLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLCircleLayer.swift
@@ -34,7 +34,9 @@ class RCTMGLCircleLayer: RCTMGLVectorLayer {
         styler.circleLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
-          applyUpdater: { (updater) in try! style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }},
+          applyUpdater: { (updater) in logged("RCTMGLCircleLayer.updateLayer") {
+            try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
+          }},
           isValid: { return self.isAddedToMap() })
         self.styleLayer = styleLayer
       }

--- a/ios/RCTMGL-v10/RCTMGLFillExtrustionLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLFillExtrustionLayer.swift
@@ -33,7 +33,9 @@ class RCTMGLFillExtrusionLayer: RCTMGLVectorLayer {
         styler.fillExtrusionLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
-          applyUpdater: { (updater) in try! style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }},
+          applyUpdater: { (updater) in logged("RCTMGLFillExtrusionLayer.updateLayer") {
+            try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
+          }},
           isValid: { return self.isAddedToMap() })
         self.styleLayer = styleLayer
       }

--- a/ios/RCTMGL-v10/RCTMGLFillLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLFillLayer.swift
@@ -34,7 +34,9 @@ class RCTMGLFillLayer: RCTMGLVectorLayer {
         styler.fillLayer(
           layer: &styleLayer,
           reactStyle: reactStyle ?? [:],
-          applyUpdater: { (updater) in try! style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout FillLayer) in updater(&layer) }},
+          applyUpdater: { (updater) in logged("RCTMGLFillLayer.updateLayer") {
+            try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout FillLayer) in updater(&layer) }
+          }},
           isValid: { return self.isAddedToMap() }
         )
         self.styleLayer = styleLayer

--- a/ios/RCTMGL-v10/RCTMGLHeatmapLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLHeatmapLayer.swift
@@ -34,7 +34,9 @@ class RCTMGLHeatmapLayer: RCTMGLVectorLayer {
         styler.heatmapLayer(
           layer: &styleLayer,
           reactStyle: reactStyle!,
-          applyUpdater: { (updater) in try! style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout HeatmapLayer) in updater(&layer) }},
+          applyUpdater: { (updater) in logged("RCTMGLHeatmapLayer.updateLayer") {
+            try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout HeatmapLayer) in updater(&layer) }
+          }},
           isValid: { return self.isAddedToMap() }
         )
         self.styleLayer = styleLayer

--- a/ios/RCTMGL-v10/RCTMGLLineLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLLineLayer.swift
@@ -37,7 +37,9 @@ class RCTMGLLineLayer: RCTMGLVectorLayer {
         styler.lineLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
-          applyUpdater: { (updater) in try! style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }},
+          applyUpdater: { (updater) in logged("RCTMGLLineLayer.updateLayer") {
+            try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
+          }},
           isValid: {
             return self.isAddedToMap()
           })

--- a/ios/RCTMGL-v10/RCTMGLRasterLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLRasterLayer.swift
@@ -28,7 +28,9 @@ class RCTMGLRasterLayer: RCTMGLLayer {
         styler.rasterLayer(
           layer: &styleLayer,
           reactStyle: reactStyle!,
-          applyUpdater:{ (updater) in try! style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }},
+          applyUpdater:{ (updater) in logged("RCTMGLRasterLayer.updateLayer") {
+            try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
+          }},
           isValid: { return self.isAddedToMap() }
         )
         self.styleLayer = styleLayer

--- a/ios/RCTMGL-v10/RCTMGLSkyLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLSkyLayer.swift
@@ -32,7 +32,9 @@ class RCTMGLSkyLayer: RCTMGLLayer {
         styler.skyLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
-          applyUpdater: { (updater) in try! style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }},
+          applyUpdater: { (updater) in logged("RCTMGLSkyLayer.addStyles") {
+            try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
+          }},
           isValid: {
             return self.isAddedToMap()
           }

--- a/ios/RCTMGL-v10/RCTMGLSymbolLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLSymbolLayer.swift
@@ -35,7 +35,9 @@ class RCTMGLSymbolLayer: RCTMGLVectorLayer {
         styler.symbolLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
-          applyUpdater: { (updater) in try! style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }},
+          applyUpdater: { (updater) in logged("RCTMGLSymbolLayer.updateLayer") {
+            try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
+          }},
           isValid: {
             return self.isAddedToMap()
           }

--- a/scripts/templates/RCTMGLStyleFactoryv10.java.ejs
+++ b/scripts/templates/RCTMGLStyleFactoryv10.java.ejs
@@ -27,6 +27,7 @@ import com.mapbox.maps.extension.style.types.StyleTransition;
 import com.mapbox.maps.extension.style.light.generated.Light;
 import com.mapbox.maps.extension.style.light.LightPosition;
 import com.mapbox.rctmgl.utils.DownloadMapImageTask;
+import com.mapbox.rctmgl.utils.Logger;
 
 import java.util.List;
 
@@ -52,7 +53,11 @@ public class RCTMGLStyleFactory {
               style.addImage(styleValue, new DownloadMapImageTask.OnAllImagesLoaded() {
                   @Override
                   public void onAllImagesLoaded() {
-                      RCTMGLStyleFactory.set<%- pascelCase(prop.name) -%>(layer, styleValue);
+                      try {
+                          RCTMGLStyleFactory.set<%- pascelCase(prop.name) -%>(layer, styleValue);
+                      } catch (RuntimeException exception) {
+                          Logger.INSTANCE.e("RCTMGL<%- pascelCase(layer.name) %>",String.format("Exception failed during set<%- pascelCase(prop.name) -%>: %s", exception.getMessage()));
+                      }
                   }
               });
               <%_ } else { _%>


### PR DESCRIPTION
Fixes: #2432 

The cause of the issue is that UserLocation images in StyleLayer, and apply images in async manner first we get the image then we add to the map style, and finally we apple the resolved image to StyleLayer. Its possible that StyleLayer was disposed in the meantime. We now log those errors but they are no longer crashes