### PR TITLE
fix: remove const enum that is in conflict with isolatedModules

### DIFF
--- a/javascript/components/Camera.tsx
+++ b/javascript/components/Camera.tsx
@@ -14,7 +14,7 @@ import { makeLatLngBounds, makePoint } from '../utils/geoUtils';
 
 const NativeModule = NativeModules.MGLModule;
 
-export const enum UserTrackingMode {
+export enum UserTrackingMode {
   Follow = 'normal',
   FollowWithHeading = 'compass',
   FollowWithCourse = 'course',


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

This only removes `const enum` since it is not compatible with `isolatedModules`. There is not a real need for having const enum as commented here - https://github.com/rnmapbox/maps/issues/2423#issuecomment-1323204764

Related to #2423

**Please note:**
I didn't test it. I only updated the file on GitHub and created this PR. But I don't think there is a need for any deep testing because of this change.

<!-- OR, if you're implementing a new feature: -->

## Checklist

<!-- Check completed item: [X] -->


- [ ] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I updated the typings files - if js interface was changed (`index.d.ts`)
- [ ] I added/ updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
