### PR TITLE
fix!(ios): timestamp returns now milliseconds instead of seconds

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLLocationModule.swift
+++ b/ios/RCTMGL-v10/RCTMGLLocationModule.swift
@@ -18,7 +18,7 @@ class RCTMGLLocation: NSObject {
         "course": location.course,
         "speed": location.speed,
       ],
-      "timestamp": location.timestamp.timeIntervalSince1970
+      "timestamp": location.timestamp.timeIntervalSince1970 * 1000
     ]
   }
 }

--- a/ios/RCTMGL/RCTMGLLocation.m
+++ b/ios/RCTMGL/RCTMGLLocation.m
@@ -24,7 +24,7 @@
     coords[@"speed"] = @(_location.speed);
     
     json[@"coords"] = coords;
-    json[@"timestamp"] = @([_location.timestamp timeIntervalSince1970]);
+    json[@"timestamp"] = @([_location.timestamp timeIntervalSince1970] * 1000);
     
     return json;
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/rnmapbox/maps/issues/1693

### Example
#### Before
Before you receive in position timestamps for
* iOS: `1669105653.049532` (sec) 🔴 
* Android: `1669105653049.532` (ms) 🟢 

#### After
With this PR you receive in position timestamps for
* iOS: `1669105653049.532` (ms) 🟢 
* Android: `1669105653049.532` (ms) 🟢 


## Checklist

- [x] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I updated the typings files - if js interface was changed (`index.d.ts`)
- [ ] I added/ updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

### iOS
<img src="https://user-images.githubusercontent.com/12240405/203266124-07f1a4af-6211-4ebc-881f-291664adac9a.png" width="385" />

Timestamp is `1669105653049.532`.

Using this in the JS console, results in:
```Javascript
new Date(1669105653049.532)
`Date Tue Nov 22 2022 09:27:33 GMT+0100 (Central European Standard Time)` 
```


BREAKING CHANGE: iOS returns timestamp field in location as milliseconds instead of seconds
