### PR TITLE
fix!(ios): timestamp returns now milliseconds instead of seconds (v8)

### DIFF
--- a/ios/RCTMGL/RCTMGLLocation.m
+++ b/ios/RCTMGL/RCTMGLLocation.m
@@ -24,7 +24,7 @@
     coords[@"speed"] = @(_location.speed);
     
     json[@"coords"] = coords;
-    json[@"timestamp"] = @([_location.timestamp timeIntervalSince1970]);
+    json[@"timestamp"] = @([_location.timestamp timeIntervalSince1970] * 1000);
     
     return json;
 }


### PR DESCRIPTION
## Description

Same as https://github.com/rnmapbox/maps/pull/2440
But just for `v8` branch.


Description of [2440](https://github.com/rnmapbox/maps/pull/2440)
> Fixes #1693
> ### Example
> #### Before
> 
> Before you receive in position timestamps for
> 
>     * iOS: `1669105653.049532` (sec) 🔴
> 
>     * Android: `1669105653049.532` (ms) 🟢
> 
> 
> #### After
> 
> With this PR you receive in position timestamps for
> 
>     * iOS: `1669105653049.532` (ms) 🟢
> 
>     * Android: `1669105653049.532` (ms) 🟢
> 
> 


## Checklist

- [x] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I updated the typings files - if js interface was changed (`index.d.ts`)
- [ ] I added/ updated a sample - if a new feature was implemented (`/example`)

## Screenshot

<img src="https://user-images.githubusercontent.com/12240405/203525032-0621f6a6-16a1-43eb-9e28-33f221791ad8.png" width="300" />

BREAKING CHANGE: iOS returns timestamp field in location as milliseconds instead of seconds