### PR TITLE
fix: don't set filter, unless changed, improve error messages

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLLayer.swift
@@ -232,8 +232,6 @@ class RCTMGLLayer : UIView, RCTMGLMapComponent, RCTMGLSourceConsumer {
       } catch {
         Logger.log(level: .error, message: "parsing filters failed for layer \(optional: id): \(error.localizedDescription)")
       }
-    } else {
-      layer.filter = nil
     }
     
     if let minZoom = minZoomLevel {

--- a/ios/RCTMGL-v10/RCTMGLLogging.swift
+++ b/ios/RCTMGL-v10/RCTMGLLogging.swift
@@ -73,12 +73,20 @@ class Logger {
   }
 }
 
+func errorMessage(_ error: Error) -> String {
+  if case DecodingError.typeMismatch(let type, let context) = error {
+    return "\(error.localizedDescription) \(context.codingPath) \(context.debugDescription)"
+  } else {
+    return "\(error.localizedDescription)"
+  }
+}
+
 func logged<T>(_ msg: String, info: (() -> String)? = nil, level: Logger.LogLevel = .error, rejecter: RCTPromiseRejectBlock? = nil, fn : () throws -> T) -> T? {
   do {
     return try fn()
   } catch {
-    Logger.log(level:level, message: "\(msg) \(info?() ?? "") \(error.localizedDescription)")
-    rejecter?(msg, "\(info?() ?? "") \(error.localizedDescription)", error)
+    Logger.log(level:level, message: "\(msg) \(info?() ?? "") \(errorMessage(error))")
+    rejecter?(msg, "\(info?() ?? "") \(errorMessage(error))", error)
     return nil
   }
 }


### PR DESCRIPTION
Fixes: #2477

2 Improvements:
- better log message
- don't set filter to `nil` on mapbox layer if it was `nil` in RCTMGLLayer. `nil` on RCTMGLLayer only means that the filter was not touched yet. Use something like `['all', 'true']` expression to change an existing filter to nil/all filter.