### PR TITLE
Add `requestsAlwaysUse` prop to the UserLocation

### DIFF
--- a/__tests__/modules/location/locationManager.test.js
+++ b/__tests__/modules/location/locationManager.test.js
@@ -237,6 +237,16 @@ describe('LocationManager', () => {
       });
     });
 
+    describe('#setRequestsAlwaysUse', () => {
+      test('calls native "setRequestsAlwaysUse"', () => {
+        MapboxGLLocationManager.setRequestsAlwaysUse = jest.fn();
+        locationManager.setRequestsAlwaysUse(true);
+        expect(
+          MapboxGLLocationManager.setRequestsAlwaysUse,
+        ).toHaveBeenCalledWith(true);
+      });
+    });
+
     describe('#onUpdate', () => {
       beforeEach(() => {
         locationManager._lastKnownLocation = null;

--- a/android/rctmgl/.settings/org.eclipse.buildship.core.prefs
+++ b/android/rctmgl/.settings/org.eclipse.buildship.core.prefs
@@ -1,2 +1,13 @@
-connection.project.dir=../../example/android
+arguments=--init-script /var/folders/nf/xt27lc4j4sv73tqskhkd_8xc0000gn/T/d146c9752a26f79b52047fb6dc6ed385d064e120494f96f08ca63a317c41f94c.gradle --init-script /var/folders/nf/xt27lc4j4sv73tqskhkd_8xc0000gn/T/52cde0cfcf3e28b8b7510e992210d9614505e0911af0c190bd590d7158574963.gradle
+auto.sync=false
+build.scans.enabled=false
+connection.gradle.distribution=GRADLE_DISTRIBUTION(VERSION(7.4.2))
+connection.project.dir=
 eclipse.preferences.version=1
+gradle.user.home=
+java.home=/Library/Java/JavaVirtualMachines/jdk-11.0.14.jdk/Contents/Home
+jvm.arguments=
+offline.mode=false
+override.workspace.settings=true
+show.console.view=true
+show.executions.view=true

--- a/android/rctmgl/src/main/java-mapboxgl/common/com/mapbox/rctmgl/modules/RCTMGLLocationModule.java
+++ b/android/rctmgl/src/main/java-mapboxgl/common/com/mapbox/rctmgl/modules/RCTMGLLocationModule.java
@@ -95,6 +95,11 @@ public class RCTMGLLocationModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void setRequestsAlwaysUse(boolean requestsAlwaysUse) {
+        // IOS only. Ignored on Android.
+    }
+
+    @ReactMethod
     public void stop() {
         stopLocationManager();
     }

--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/modules/RCTMGLLocationModule.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/modules/RCTMGLLocationModule.kt
@@ -88,6 +88,11 @@ class RCTMGLLocationModule(reactContext: ReactApplicationContext) :
     }
 
     @ReactMethod
+    fun setRequestsAlwaysUse(requestsAlwaysUse: Bool) {
+        // IOS only. Ignored on Android.
+    }
+
+    @ReactMethod
     fun stop() {
         stopLocationManager()
     }

--- a/docs/UserLocation.md
+++ b/docs/UserLocation.md
@@ -12,7 +12,7 @@
 | onPress | `func` | `none` | `false` | Callback that is triggered on location icon press |
 | onUpdate | `func` | `none` | `false` | Callback that is triggered on location update |
 | showsUserHeadingIndicator | `bool` | `false` | `false` | Show or hide small arrow which indicates direction the device is pointing relative to north. |
-| listensToLocationInBackground | `bool` | `false` | `false` | Request the always location permission, and listen to the location even when the app is in background |
+| requestsAlwaysUse | `bool` | `false` | `false` | Request the always location permission, and listen to the location even when the app is in background<br/><br/>@platform ios |
 | minDisplacement | `number` | `0` | `false` | Minimum amount of movement before GPS location is updated in meters |
 | children | `any` | `none` | `false` | Custom location icon of type mapbox-gl-native components |
 

--- a/docs/UserLocation.md
+++ b/docs/UserLocation.md
@@ -12,6 +12,7 @@
 | onPress | `func` | `none` | `false` | Callback that is triggered on location icon press |
 | onUpdate | `func` | `none` | `false` | Callback that is triggered on location update |
 | showsUserHeadingIndicator | `bool` | `false` | `false` | Show or hide small arrow which indicates direction the device is pointing relative to north. |
+| listensToLocationInBackground | `bool` | `false` | `false` | Request the always location permission, and listen to the location even when the app is in background |
 | minDisplacement | `number` | `0` | `false` | Minimum amount of movement before GPS location is updated in meters |
 | children | `any` | `none` | `false` | Custom location icon of type mapbox-gl-native components |
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -5994,11 +5994,11 @@
         "description": "Show or hide small arrow which indicates direction the device is pointing relative to north."
       },
       {
-        "name": "listensToLocationInBackground",
+        "name": "requestsAlwaysUse",
         "required": false,
         "type": "bool",
         "default": "false",
-        "description": "Request the always location permission, and listen to the location even when the app is in background"
+        "description": "Request the always location permission, and listen to the location even when the app is in background\n\n@platform ios"
       },
       {
         "name": "minDisplacement",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -5994,6 +5994,13 @@
         "description": "Show or hide small arrow which indicates direction the device is pointing relative to north."
       },
       {
+        "name": "listensToLocationInBackground",
+        "required": false,
+        "type": "bool",
+        "default": "false",
+        "description": "Request the always location permission, and listen to the location even when the app is in background"
+      },
+      {
         "name": "minDisplacement",
         "required": false,
         "type": "number",

--- a/example/src/utils/index.js
+++ b/example/src/utils/index.js
@@ -1,6 +1,7 @@
 import { Platform } from 'react-native';
 
 export const IS_ANDROID = Platform.OS === 'android';
+export const IS_IOS = Platform.OS === 'ios';
 export const DEFAULT_CENTER_COORDINATE = [-77.036086, 38.910233];
 export const SF_OFFICE_COORDINATE = [-122.400021, 37.789085];
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -612,6 +612,7 @@ export interface UserLocationProps {
   animated?: boolean;
   children?: ReactNode;
   minDisplacement?: number;
+  listensToLocationInBackground?: boolean;
   onPress?: () => void;
   onUpdate?: (location: MapboxGL.Location) => void;
   renderMode?: 'normal' | 'native';

--- a/index.d.ts
+++ b/index.d.ts
@@ -612,7 +612,7 @@ export interface UserLocationProps {
   animated?: boolean;
   children?: ReactNode;
   minDisplacement?: number;
-  listensToLocationInBackground?: boolean;
+  requestsAlwaysUse?: boolean;
   onPress?: () => void;
   onUpdate?: (location: MapboxGL.Location) => void;
   renderMode?: 'normal' | 'native';

--- a/ios/RCTMGL-v10/RCTMGLLocationModule.m
+++ b/ios/RCTMGL-v10/RCTMGLLocationModule.m
@@ -10,7 +10,7 @@ RCT_EXTERN_METHOD(stop)
 RCT_EXTERN_METHOD(getLastKnownLocation)
 
 RCT_EXTERN_METHOD(setMinDisplacement:(CLLocationDistance)minDisplacement)
-RCT_EXTERN_METHOD(setListensToLocationInBackground:(BOOL)listensToLocationInBackground)
+RCT_EXTERN_METHOD(setRequestsAlwaysUse:(BOOL)requestsAlwaysUse)
 
 
 @end

--- a/ios/RCTMGL-v10/RCTMGLLocationModule.m
+++ b/ios/RCTMGL-v10/RCTMGLLocationModule.m
@@ -10,6 +10,7 @@ RCT_EXTERN_METHOD(stop)
 RCT_EXTERN_METHOD(getLastKnownLocation)
 
 RCT_EXTERN_METHOD(setMinDisplacement:(CLLocationDistance)minDisplacement)
+RCT_EXTERN_METHOD(setListensToLocationInBackground:(BOOL)listensToLocationInBackground)
 
 
 @end

--- a/ios/RCTMGL-v10/RCTMGLLocationModule.swift
+++ b/ios/RCTMGL-v10/RCTMGLLocationModule.swift
@@ -68,8 +68,8 @@ class RCTMGLLocationManager : LocationProviderDelegate {
     provider.locationProviderOptions = options
   }
   
-  func setListensToLocationInBackground(_ listensToLocationInBackground: Bool) {
-    shouldRequestAlwaysAuthorization = listensToLocationInBackground;
+  func setRequestsAlwaysUse(_ requestsAlwaysUse: Bool) {
+    shouldRequestAlwaysAuthorization = requestsAlwaysUse;
   }
 
   func start() {
@@ -273,8 +273,8 @@ class RCTMGLLocationModule: RCTEventEmitter, RCTMGLLocationManagerDelegate {
     locationManager.setDistanceFilter(minDisplacement)
   }
   
-  @objc func setListensToLocationInBackground(_ listensToLocationInBackground: Bool) {
-    locationManager.setListensToLocationInBackground(listensToLocationInBackground);
+  @objc func setRequestsAlwaysUse(_ requestsAlwaysUse: Bool) {
+    locationManager.setRequestsAlwaysUse(requestsAlwaysUse);
   }
 
   @objc

--- a/ios/RCTMGL-v10/RCTMGLLocationModule.swift
+++ b/ios/RCTMGL-v10/RCTMGLLocationModule.swift
@@ -289,7 +289,6 @@ class RCTMGLLocationModule: RCTEventEmitter, RCTMGLLocationManagerDelegate {
     hasListener = false
   }
   
-  
   func locationManager(_ locationManager: RCTMGLLocationManager, didUpdateLocation location: RCTMGLLocation) {
     guard hasListener else {
       return
@@ -301,5 +300,4 @@ class RCTMGLLocationModule: RCTEventEmitter, RCTMGLLocationManagerDelegate {
 
     self.sendEvent(withName: RCT_MAPBOX_USER_LOCATION_UPDATE, body: location.toJSON())
   }
-
 }

--- a/ios/RCTMGL-v10/RCTMGLLocationModule.swift
+++ b/ios/RCTMGL-v10/RCTMGLLocationModule.swift
@@ -52,6 +52,7 @@ class RCTMGLLocationManager : LocationProviderDelegate {
   
   var lastKnownLocation : CLLocation?
   var lastKnownHeading : CLHeading?
+  var shouldRequestAlwaysAuthorization: Bool?
   
   weak var delegate: RCTMGLLocationManagerDelegate?
   weak var locationProviderDelage: LocationProviderDelegate?
@@ -67,8 +68,14 @@ class RCTMGLLocationManager : LocationProviderDelegate {
     provider.locationProviderOptions = options
   }
   
+  func setListensToLocationInBackground(_ listensToLocationInBackground: Bool) {
+    shouldRequestAlwaysAuthorization = listensToLocationInBackground;
+  }
+
   func start() {
-    provider.requestAlwaysAuthorization()
+    if shouldRequestAlwaysAuthorization == true {
+      provider.requestAlwaysAuthorization()
+    }
     provider.requestWhenInUseAuthorization()
     provider.setDelegate(self)
     provider.startUpdatingHeading()
@@ -266,6 +273,10 @@ class RCTMGLLocationModule: RCTEventEmitter, RCTMGLLocationManagerDelegate {
     locationManager.setDistanceFilter(minDisplacement)
   }
   
+  @objc func setListensToLocationInBackground(_ listensToLocationInBackground: Bool) {
+    locationManager.setListensToLocationInBackground(listensToLocationInBackground);
+  }
+
   @objc
   override func startObserving() {
     super.startObserving()

--- a/javascript/components/UserLocation.js
+++ b/javascript/components/UserLocation.js
@@ -98,6 +98,11 @@ class UserLocation extends React.Component {
     showsUserHeadingIndicator: PropTypes.bool,
 
     /**
+     * Request the always location permission, and listen to the location even when the app is in background
+     */
+    listensToLocationInBackground: PropTypes.bool,
+
+    /**
      * Minimum amount of movement before GPS location is updated in meters
      */
     minDisplacement: PropTypes.number,
@@ -112,6 +117,7 @@ class UserLocation extends React.Component {
     animated: true,
     visible: true,
     showsUserHeadingIndicator: false,
+    listensToLocationInBackground: false,
     minDisplacement: 0,
     renderMode: 'normal',
   };
@@ -160,6 +166,9 @@ class UserLocation extends React.Component {
 
     if (this.props.minDisplacement !== prevProps.minDisplacement) {
       locationManager.setMinDisplacement(this.props.minDisplacement);
+    }
+    if (this.props.listensToLocationInBackground !== prevProps.listensToLocationInBackground) {
+      locationManager.setListensToLocationInBackground(this.props.listensToLocationInBackground);
     }
   }
 

--- a/javascript/components/UserLocation.js
+++ b/javascript/components/UserLocation.js
@@ -99,8 +99,10 @@ class UserLocation extends React.Component {
 
     /**
      * Request the always location permission, and listen to the location even when the app is in background
+     *
+     * @platform ios
      */
-    listensToLocationInBackground: PropTypes.bool,
+    requestsAlwaysUse: PropTypes.bool,
 
     /**
      * Minimum amount of movement before GPS location is updated in meters
@@ -117,7 +119,7 @@ class UserLocation extends React.Component {
     animated: true,
     visible: true,
     showsUserHeadingIndicator: false,
-    listensToLocationInBackground: false,
+    requestsAlwaysUse: false,
     minDisplacement: 0,
     renderMode: 'normal',
   };
@@ -167,8 +169,8 @@ class UserLocation extends React.Component {
     if (this.props.minDisplacement !== prevProps.minDisplacement) {
       locationManager.setMinDisplacement(this.props.minDisplacement);
     }
-    if (this.props.listensToLocationInBackground !== prevProps.listensToLocationInBackground) {
-      locationManager.setListensToLocationInBackground(this.props.listensToLocationInBackground);
+    if (this.props.requestsAlwaysUse !== prevProps.requestsAlwaysUse) {
+      locationManager.setRequestsAlwaysUse(this.props.requestsAlwaysUse);
     }
   }
 

--- a/javascript/modules/location/locationManager.js
+++ b/javascript/modules/location/locationManager.js
@@ -1,4 +1,4 @@
-import { NativeModules, NativeEventEmitter } from 'react-native';
+import { NativeModules, NativeEventEmitter, AppState } from 'react-native';
 
 const MapboxGL = NativeModules.MGLModule;
 const MapboxGLLocationManager = NativeModules.MGLLocationModule;
@@ -14,6 +14,11 @@ class LocationManager {
     this._isListening = false;
     this.onUpdate = this.onUpdate.bind(this);
     this.subscription = null;
+
+    this._appStateListener = AppState.addEventListener(
+      'change',
+      this._handleAppStateChange.bind(this),
+    );
   }
 
   async getLastKnownLocation() {
@@ -64,6 +69,14 @@ class LocationManager {
     this.stop();
   }
 
+  _handleAppStateChange(appState) {
+    if (appState === 'background') {
+      this.stop();
+    } else if (appState === 'active') {
+      this.start();
+    }
+  }
+
   start(displacement = -1) {
     if (
       displacement === -1 ||
@@ -101,6 +114,10 @@ class LocationManager {
   setMinDisplacement(minDisplacement) {
     this._minDisplacement = minDisplacement;
     MapboxGLLocationManager.setMinDisplacement(minDisplacement);
+  }
+
+  setListensToLocationInBackground(listensToLocationInBackground) {
+    MapboxGLLocationManager.setListensToLocationInBackground(listensToLocationInBackground);
   }
 
   onUpdate(location) {

--- a/javascript/modules/location/locationManager.js
+++ b/javascript/modules/location/locationManager.js
@@ -12,17 +12,14 @@ class LocationManager {
     this._listeners = [];
     this._lastKnownLocation = null;
     this._isListening = false;
+    this._requestsAlwaysUse = false;
     this.onUpdate = this.onUpdate.bind(this);
     this.subscription = null;
-
-    this._requestsAlwaysUse = false;
 
     this._appStateListener = AppState.addEventListener(
       'change',
       this._handleAppStateChange.bind(this),
     );
-
-    this.setRequestsAlwaysUse = this.setRequestsAlwaysUse.bind(this);
   }
 
   async getLastKnownLocation() {

--- a/javascript/modules/location/locationManager.js
+++ b/javascript/modules/location/locationManager.js
@@ -15,10 +15,15 @@ class LocationManager {
     this.onUpdate = this.onUpdate.bind(this);
     this.subscription = null;
 
+    this._listensToLocationInBackground = false;
+
     this._appStateListener = AppState.addEventListener(
       'change',
       this._handleAppStateChange.bind(this),
     );
+
+    this.setListensToLocationInBackground =
+      this.setListensToLocationInBackground.bind(this);
   }
 
   async getLastKnownLocation() {
@@ -33,7 +38,7 @@ class LocationManager {
         lastKnownLocation =
           await MapboxGLLocationManager.getLastKnownLocation();
       } catch (error) {
-        console.log('locationManager Error: ', error);
+        console.warn('locationManager Error: ', error);
       }
 
       if (!this._lastKnownLocation && lastKnownLocation) {
@@ -70,10 +75,12 @@ class LocationManager {
   }
 
   _handleAppStateChange(appState) {
-    if (appState === 'background') {
-      this.stop();
-    } else if (appState === 'active') {
-      this.start();
+    if (!this._listensToLocationInBackground) {
+      if (appState === 'background') {
+        this.stop();
+      } else if (appState === 'active') {
+        this.start();
+      }
     }
   }
 
@@ -117,7 +124,10 @@ class LocationManager {
   }
 
   setListensToLocationInBackground(listensToLocationInBackground) {
-    MapboxGLLocationManager.setListensToLocationInBackground(listensToLocationInBackground);
+    MapboxGLLocationManager.setListensToLocationInBackground(
+      listensToLocationInBackground,
+    );
+    this._listensToLocationInBackground = listensToLocationInBackground;
   }
 
   onUpdate(location) {

--- a/javascript/modules/location/locationManager.js
+++ b/javascript/modules/location/locationManager.js
@@ -15,15 +15,14 @@ class LocationManager {
     this.onUpdate = this.onUpdate.bind(this);
     this.subscription = null;
 
-    this._listensToLocationInBackground = false;
+    this._requestsAlwaysUse = false;
 
     this._appStateListener = AppState.addEventListener(
       'change',
       this._handleAppStateChange.bind(this),
     );
 
-    this.setListensToLocationInBackground =
-      this.setListensToLocationInBackground.bind(this);
+    this.setRequestsAlwaysUse = this.setRequestsAlwaysUse.bind(this);
   }
 
   async getLastKnownLocation() {
@@ -75,7 +74,7 @@ class LocationManager {
   }
 
   _handleAppStateChange(appState) {
-    if (!this._listensToLocationInBackground) {
+    if (!this._requestsAlwaysUse) {
       if (appState === 'background') {
         this.stop();
       } else if (appState === 'active') {
@@ -123,11 +122,9 @@ class LocationManager {
     MapboxGLLocationManager.setMinDisplacement(minDisplacement);
   }
 
-  setListensToLocationInBackground(listensToLocationInBackground) {
-    MapboxGLLocationManager.setListensToLocationInBackground(
-      listensToLocationInBackground,
-    );
-    this._listensToLocationInBackground = listensToLocationInBackground;
+  setRequestsAlwaysUse(requestsAlwaysUse) {
+    MapboxGLLocationManager.setRequestsAlwaysUse(requestsAlwaysUse);
+    this._requestsAlwaysUse = requestsAlwaysUse;
   }
 
   onUpdate(location) {


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

<!-- OR, if you're implementing a new feature: -->

Added `requestsAlwaysUse` prop to the UserLocation component that allows choosing if we want to listen for the user location in the background or not.
It allows us to not ask for background location permission when we don't need it and still use the UserLocation component.

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
- [x] I updated the typings files - if js interface was changed (`index.d.ts`)
- [ ] I added/ updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

None for now.
