### PR TITLE
fix queryRenderedFeaturesAtPoint iOS

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLMapViewManager.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapViewManager.swift
@@ -29,7 +29,7 @@ extension RCTMGLMapViewManager {
       self.bridge.uiManager.addUIBlock { (manager, viewRegistry) in
         let view = viewRegistry![reactTag]
 
-        guard let view = view! as? RCTMGLMapView else {
+        guard let view, let view = view as? RCTMGLMapView else {
           RCTMGLLogError("Invalid react tag, could not find RCTMGLMapView");
           rejecter(name, "Unknown find reactTag: \(reactTag)", nil)
           return;
@@ -188,7 +188,7 @@ extension RCTMGLMapViewManager {
         let point = CGPoint(x: CGFloat(point[0].floatValue), y: CGFloat(point[1].floatValue))
 
         logged("queryRenderedFeaturesAtPoint.option", rejecter: rejecter) {
-          let options = try RenderedQueryOptions(layerIds: layerIDs, filter: filter?.asExpression())
+          let options = try RenderedQueryOptions(layerIds: (layerIDs ?? []).isEmpty ? nil : layerIDs, filter: filter?.asExpression())
           
           mapboxMap.queryRenderedFeatures(with: point, options: options) { result in
             switch result {

--- a/ios/RCTMGL-v10/RCTMGLMapViewManager.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapViewManager.swift
@@ -29,7 +29,7 @@ extension RCTMGLMapViewManager {
       self.bridge.uiManager.addUIBlock { (manager, viewRegistry) in
         let view = viewRegistry![reactTag]
 
-        guard let view, let view = view as? RCTMGLMapView else {
+        guard let view = view, let view = view as? RCTMGLMapView else {
           RCTMGLLogError("Invalid react tag, could not find RCTMGLMapView");
           rejecter(name, "Unknown find reactTag: \(reactTag)", nil)
           return;

--- a/javascript/components/MapView.js
+++ b/javascript/components/MapView.js
@@ -523,7 +523,7 @@ class MapView extends NativeBridgeComponent(
    * @param  {Array=} layerIDs -  A array of layer id's to filter the features by
    * @return {FeatureCollection}
    */
-  async queryRenderedFeaturesInRect(bbox, filter = [], layerIDs = []) {
+  async queryRenderedFeaturesInRect(bbox, filter = [], layerIDs = null) {
     if (
       bbox != null &&
       (bbox.length === 4 || (MapboxGL.MapboxV10 && bbox.length === 0))


### PR DESCRIPTION
This merge request only applies to iOS-specific codebase. Makes sure that the features list returned by the queryRenderedFeatureAtPoint method is not empty, if the user doesn't provide any value into the layerIDs parameter.

The withMapView method makes no more any force unwrap to prevent the application from crashing by checking the view existence and type casting performed safely

## Description

Fixes no known issue

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I updated the typings files - if js interface was changed (`index.d.ts`)
- [ ] I added/ updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

This MR doesn't require any screenshot or video, because it simply makes sure that the data returned by the native method implementation is not an empty list, also when the expected result is not empty.
