### PR TITLE
fix(iOS,v10): fix minDisplacement /distanceFilter on UserLocation

### DIFF
--- a/__tests__/components/UserLocation.test.js
+++ b/__tests__/components/UserLocation.test.js
@@ -29,6 +29,9 @@ describe('UserLocation', () => {
     jest.spyOn(locationManager, 'addListener');
 
     jest.spyOn(locationManager, 'removeListener');
+    jest
+      .spyOn(locationManager, 'setMinDisplacement')
+      .mockImplementation(jest.fn());
 
     beforeEach(() => {
       jest.clearAllMocks();

--- a/ios/RCTMGL-v10/RCTMGLLocationModule.swift
+++ b/ios/RCTMGL-v10/RCTMGLLocationModule.swift
@@ -57,7 +57,9 @@ class RCTMGLLocationManager : LocationProviderDelegate {
   }
   
   func setDistanceFilter(_ distanceFilter: CLLocationDistance) {
-    provider.locationProviderOptions.distanceFilter = distanceFilter
+    var options = provider.locationProviderOptions
+    options.distanceFilter = distanceFilter
+    provider.locationProviderOptions = options
   }
   
   func start() {
@@ -242,8 +244,8 @@ class RCTMGLLocationModule: RCTEventEmitter, RCTMGLLocationManagerDelegate {
   }
   
   @objc func start(_ minDisplacement: CLLocationDistance) {
+    if minDisplacement >= 0.0 { locationManager.setDistanceFilter(minDisplacement) }
     locationManager.start()
-    locationManager.setDistanceFilter(minDisplacement)
   }
   
   @objc func stop() {

--- a/javascript/components/UserLocation.js
+++ b/javascript/components/UserLocation.js
@@ -142,6 +142,8 @@ class UserLocation extends React.Component {
   async componentDidMount() {
     this._isMounted = true;
 
+    locationManager.setMinDisplacement(this.props.minDisplacement);
+
     await this.setLocationManager({
       running: this.needsLocationManagerRunning(),
     });
@@ -149,8 +151,6 @@ class UserLocation extends React.Component {
     if (this.renderMode === UserLocation.RenderMode.Native) {
       return;
     }
-
-    locationManager.setMinDisplacement(this.props.minDisplacement);
   }
 
   async componentDidUpdate(prevProps) {

--- a/javascript/modules/location/locationManager.js
+++ b/javascript/modules/location/locationManager.js
@@ -64,7 +64,18 @@ class LocationManager {
     this.stop();
   }
 
-  start(displacement = 0) {
+  start(displacement = -1) {
+    if (
+      displacement === -1 ||
+      displacement === null ||
+      displacement === undefined
+    ) {
+      displacement = this._minDisplacement;
+    }
+    if (displacement == null) {
+      displacement = -1;
+    }
+
     if (!this._isListening) {
       MapboxGLLocationManager.start(displacement);
 
@@ -88,6 +99,7 @@ class LocationManager {
   }
 
   setMinDisplacement(minDisplacement) {
+    this._minDisplacement = minDisplacement;
     MapboxGLLocationManager.setMinDisplacement(minDisplacement);
   }
 


### PR DESCRIPTION

We're now setting distanceFilter correctly on iOS but I still receive updates

```jsx
import { Camera, MapView, PointAnnotation, UserLocation } from '@rnmapbox/maps';
import { Feature, Point } from 'geojson';
import React, { useState } from 'react';
import { View, Text } from 'react-native';

const BugReportExample = () => {
  const [count, setCount] = useState(0);

  return (
    <View style={{ flex: 1 }}>
      <View>
        <Text>Count: {count}</Text>
      </View>
      <MapView style={{ flex: 1 }}>
        <UserLocation
          visible
          minDisplacement={1000}
          onUpdate={(location) => {
            setCount(count+1);
            console.log('#=>', location);
          }}
        />
        <Camera
          zoomLevel={16}
          followUserMode={'normal'}
          followZoomLevel={16}
          followUserLocation
        />
      </MapView>
    </View>
  );
};

export default BugReportExample;
```