### PR TITLE
Fix expo being unable to resolve config plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+// Placeholder file to fix Expo not resolving config plugin


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes an issue where Expo is unable to resolve the config plugin when following the installation instructions. The following error was thrown when trying to build with expo:

```
Failed to resolve plugin for module "@rnmapbox/maps" relative to "<PROJECT-PATH>"
```

The fix is based on [this PR](https://github.com/includable/react-native-email-link/pull/100), fixing the same issue.

## Checklist

- [ ] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I updated the typings files - if js interface was changed (`index.d.ts`)
- [ ] I added/ updated a sample - if a new feature was implemented (`/example`)
