### PR TITLE
fix(ios,v10): fix offline download, thread issue

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLOfflineModule.swift
+++ b/ios/RCTMGL-v10/RCTMGLOfflineModule.swift
@@ -364,13 +364,17 @@ class RCTMGLOfflineModule: RCTEventEmitter {
         }) { result in
           switch result {
           case .success(let value):
-            if let progess = lastProgress {
-              self.offlinePackProgressDidChange(progress: progess, metadata: metadata, state: .complete)
+            DispatchQueue.main.async {
+              if let progess = lastProgress {
+                self.offlinePackProgressDidChange(progress: progess, metadata: metadata, state: .complete)
+              }
+              self.tileRegionPacks[id]!.state = .complete
             }
-            self.tileRegionPacks[id]!.state = .complete
           case .failure(let error):
-            self.tileRegionPacks[id]!.state = .inactive
-            self.offlinePackDidReceiveError(name: id, error: error)
+            DispatchQueue.main.async {
+              self.tileRegionPacks[id]!.state = .inactive
+              self.offlinePackDidReceiveError(name: id, error: error)
+            }
           }
         }
 


### PR DESCRIPTION
Fixes: #2516 

It sounds like `loadTileRegion` callbacks not always called on main thread, causing multiple thread to access Dictionary at the same time. And although we only read from the `tileRegionPacks` it seems that it still causes race condition. 

https://docs.mapbox.com/ios/maps/api/10.10.1/Extensions/TileStore.html#/s:So12MBXTileStoreC10MapboxMapsE14loadTileRegion5forId0E7Options8progress10completionAC10Cancelable_pSS_So0ag4LoadJ0CySo0agN8ProgressCcSgys6ResultOySo0aG0Cs5Error_pGctF

> The user-provided callbacks will be executed on a TileStore-controlled worker thread; it is the responsibility of the user to dispatch to a user-controlled thread.