### PR TITLE
#2557 - fix Android VectorSource.features call returning empty featur…

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/styles/sources/RCTMGLVectorSource.java
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/styles/sources/RCTMGLVectorSource.java
@@ -73,9 +73,6 @@ public class RCTMGLVectorSource extends RCTMGLTileSource<VectorSource> {
             return;
         }
 
-
-        WritableMap payload = new WritableNativeMap();
-
         mMap.querySourceFeatures(
                 getID(),
                 new SourceQueryOptions(layerIDs, filter),
@@ -83,6 +80,7 @@ public class RCTMGLVectorSource extends RCTMGLTileSource<VectorSource> {
                 new QueryFeaturesCallback() {
                     @Override
                     public void run(@NonNull Expected<String, List<QueriedFeature>> queriedFeatures) {
+                        WritableMap payload = new WritableNativeMap();
                         if (queriedFeatures.isError()) {
                             //V10todo
                             payload.putString("error", queriedFeatures.getError());
@@ -93,11 +91,10 @@ public class RCTMGLVectorSource extends RCTMGLTileSource<VectorSource> {
                             }
                             payload.putString("data", FeatureCollection.fromFeatures(features).toJson());
                         }
+                        AndroidCallbackEvent event = new AndroidCallbackEvent(RCTMGLVectorSource.this, callbackID, payload);
+                        mManager.handleEvent(event);
                     }
                 }
         );
-
-        AndroidCallbackEvent event = new AndroidCallbackEvent(this, callbackID, payload);
-        mManager.handleEvent(event);
     }
 }


### PR DESCRIPTION
fix Android VectorSource.features call returning empty features result - note that previously the AndroidCallbackEvent was being handled before the async QueryFeaturesCallback had completed so the payload would always be empty

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes #2557

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
- [x] I updated the typings files - if js interface was changed (`index.d.ts`)
- [x] I added/ updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
