### PR TITLE
fix(v10, android): allow nil mapView on onEnimationEnd

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/camera/RCTMGLCamera.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/camera/RCTMGLCamera.kt
@@ -93,7 +93,7 @@ class RCTMGLCamera(private val mContext: Context, private val mManager: RCTMGLCa
         override fun onAnimationStart(animator: Animator) {}
         override fun onAnimationEnd(animator: Animator) {
             if (!hasSentFirstRegion) {
-                mMapView!!.sendRegionChangeEvent(false)
+                mMapView?.sendRegionChangeEvent(false)
                 hasSentFirstRegion = true
             }
         }


### PR DESCRIPTION
Fixes: #2563

It seems that onAnimatedEnd might be called after map was disposed, so use optional chaining.