### PR TITLE
feat(ios,v10): Add internal function to simulate heading updates in i…

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLAtmosphere.swift
+++ b/ios/RCTMGL-v10/RCTMGLAtmosphere.swift
@@ -56,6 +56,7 @@ class RCTMGLAtmosphere : RCTMGLSingletonLayer, RCTMGLMapComponent, RCTMGLSourceC
         styler.atmosphereLayer(
           layer: &atmosphere,
           reactStyle: reactStyle,
+          oldReactStyle: oldReactStyle,
           applyUpdater: { (updater) in fatalError("Atmosphere: TODO - implement apply updater")},
           isValid: { fatalError("Atmosphere: TODO - no isValid") }
         )

--- a/ios/RCTMGL-v10/RCTMGLBackgroundLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLBackgroundLayer.swift
@@ -33,6 +33,7 @@ class RCTMGLBackgroundLayer: RCTMGLLayer {
         styler.backgroundLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
+          oldReactStyle: oldReatStyle,
           applyUpdater: { (updater) in logged("RCTMGLBackgroundLayer.addStyles") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
           }},

--- a/ios/RCTMGL-v10/RCTMGLCircleLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLCircleLayer.swift
@@ -34,6 +34,7 @@ class RCTMGLCircleLayer: RCTMGLVectorLayer {
         styler.circleLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
+          oldReactStyle: oldReatStyle,
           applyUpdater: { (updater) in logged("RCTMGLCircleLayer.updateLayer") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
           }},

--- a/ios/RCTMGL-v10/RCTMGLFillExtrustionLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLFillExtrustionLayer.swift
@@ -33,6 +33,7 @@ class RCTMGLFillExtrusionLayer: RCTMGLVectorLayer {
         styler.fillExtrusionLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
+          oldReactStyle: oldReatStyle,
           applyUpdater: { (updater) in logged("RCTMGLFillExtrusionLayer.updateLayer") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
           }},

--- a/ios/RCTMGL-v10/RCTMGLFillLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLFillLayer.swift
@@ -35,6 +35,7 @@ class RCTMGLFillLayer: RCTMGLVectorLayer {
         styler.fillLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
+          oldReactStyle: oldReatStyle,
           applyUpdater: { (updater) in logged("RCTMGLFillLayer.updateLayer") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout FillLayer) in updater(&layer) }
           }},

--- a/ios/RCTMGL-v10/RCTMGLHeatmapLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLHeatmapLayer.swift
@@ -35,6 +35,7 @@ class RCTMGLHeatmapLayer: RCTMGLVectorLayer {
         styler.heatmapLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
+          oldReactStyle: oldReatStyle,
           applyUpdater: { (updater) in logged("RCTMGLHeatmapLayer.updateLayer") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout HeatmapLayer) in updater(&layer) }
           }},

--- a/ios/RCTMGL-v10/RCTMGLLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLLayer.swift
@@ -13,7 +13,11 @@ class RCTMGLLayer : UIView, RCTMGLMapComponent, RCTMGLSourceConsumer {
     didSet { self.optionsChanged() }
   }
 
+  var oldReatStyle: Dictionary<String, Any>? = nil
   @objc var reactStyle : Dictionary<String, Any>? = nil {
+    willSet {
+      oldReatStyle = reactStyle
+    }
     didSet {
       DispatchQueue.main.async {
         self.addStylesAndUpdate()

--- a/ios/RCTMGL-v10/RCTMGLLight.swift
+++ b/ios/RCTMGL-v10/RCTMGLLight.swift
@@ -4,7 +4,11 @@ import MapboxMaps
 class RCTMGLLight: UIView, RCTMGLMapComponent {
   weak var bridge : RCTBridge! = nil
   weak var map: MapboxMap! = nil
+  var oldReactStyle: [String:Any]?
   @objc var reactStyle : [String:Any]! = nil {
+    willSet {
+      oldReactStyle = reactStyle
+    }
     didSet {
       if map != nil {
         addStyles()
@@ -13,17 +17,15 @@ class RCTMGLLight: UIView, RCTMGLMapComponent {
   }
   
   func apply(light: Light) {
-    self.map.style
     let lightData = try! JSONEncoder().encode(light)
     let lightDictionary = try! JSONSerialization.jsonObject(with: lightData)
-    print("=> lightDictionary \(lightDictionary)")
     try! self.map.style.setLight(properties: lightDictionary as! [String:Any])
   }
 
   func addStyles() {
     var light = Light()
     let style = RCTMGLStyle(style: map.style)
-    style.lightLayer(layer: &light, reactStyle: reactStyle, applyUpdater: { (updater) in
+    style.lightLayer(layer: &light, reactStyle: reactStyle, oldReactStyle: oldReactStyle, applyUpdater: { (updater) in
       updater(&light)
       self.apply(light: light)
     }, isValid: {

--- a/ios/RCTMGL-v10/RCTMGLLineLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLLineLayer.swift
@@ -37,6 +37,7 @@ class RCTMGLLineLayer: RCTMGLVectorLayer {
         styler.lineLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
+          oldReactStyle: oldReatStyle,
           applyUpdater: { (updater) in logged("RCTMGLLineLayer.updateLayer") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
           }},

--- a/ios/RCTMGL-v10/RCTMGLLocationModule.m
+++ b/ios/RCTMGL-v10/RCTMGLLocationModule.m
@@ -12,5 +12,7 @@ RCT_EXTERN_METHOD(getLastKnownLocation)
 RCT_EXTERN_METHOD(setMinDisplacement:(CLLocationDistance)minDisplacement)
 RCT_EXTERN_METHOD(setRequestsAlwaysUse:(BOOL)requestsAlwaysUse)
 
+RCT_EXTERN_METHOD(simulateHeading:(nonnull NSNumber)changesPerSecond increment:(nonnull NSNumber))
+
 
 @end

--- a/ios/RCTMGL-v10/RCTMGLRasterLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLRasterLayer.swift
@@ -29,6 +29,7 @@ class RCTMGLRasterLayer: RCTMGLLayer {
         styler.rasterLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
+          oldReactStyle: oldReatStyle,
           applyUpdater:{ (updater) in logged("RCTMGLRasterLayer.updateLayer") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
           }},

--- a/ios/RCTMGL-v10/RCTMGLSingletonLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLSingletonLayer.swift
@@ -7,7 +7,11 @@ class RCTMGLSingletonLayer : UIView {
   weak var map : RCTMGLMapView? = nil
   var style: Style? = nil
   
+  var oldReactStyle: [String:Any]?
   @objc var reactStyle : Dictionary<String, Any>? = nil {
+    willSet {
+      oldReactStyle = reactStyle
+    }
     didSet {
       DispatchQueue.main.async {
         self.addStylesAndUpdate()

--- a/ios/RCTMGL-v10/RCTMGLSkyLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLSkyLayer.swift
@@ -32,6 +32,7 @@ class RCTMGLSkyLayer: RCTMGLLayer {
         styler.skyLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
+          oldReactStyle: oldReatStyle,
           applyUpdater: { (updater) in logged("RCTMGLSkyLayer.addStyles") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
           }},

--- a/ios/RCTMGL-v10/RCTMGLStyle.swift
+++ b/ios/RCTMGL-v10/RCTMGLStyle.swift
@@ -12,7 +12,7 @@ class RCTMGLStyle {
   }
 
 
-func fillLayer(layer: inout FillLayer, reactStyle:Dictionary<String, Any>, applyUpdater: @escaping  ((inout FillLayer)->Void)->Void, isValid: @escaping () -> Bool)
+func fillLayer(layer: inout FillLayer, reactStyle:Dictionary<String, Any>, oldReactStyle:Dictionary<String, Any>?, applyUpdater: @escaping  ((inout FillLayer)->Void)->Void, isValid: @escaping () -> Bool)
 {
   guard self._hasReactStyle(reactStyle) else {
     Logger.log(level:.error, message: "Invalid style: \(reactStyle)")
@@ -52,35 +52,22 @@ func fillLayer(layer: inout FillLayer, reactStyle:Dictionary<String, Any>, apply
     } else if (prop == "fillTranslateAnchor") {
       self.setFillTranslateAnchor(&layer, styleValue:styleValue);
     } else if (prop == "fillPattern") {
-      if (!styleValue.shouldAddImage()) {
-        self.setFillPattern(&layer, styleValue:styleValue);
-      } else {
-        let imageURI = styleValue.getImageURI()
-
-        RCTMGLUtils.fetchImage(bridge!, url:imageURI, scale:styleValue.getImageScale(), callback:{ (error, image) in
-          if let image = image {
-            DispatchQueue.main.sync {
-              if (isValid()) {
-                logged("Fill.FillPattern.addImage") {
-                  try self.style.addImage(image, id:imageURI!, stretchX: [], stretchY: []);
-                  applyUpdater { (layer: inout FillLayer) in
-                    self.setFillPattern(&layer, styleValue:styleValue);
-                  }
-                }
-              }
-            }
-          } else {
-            Logger.log(level: .error, message: "Error during fetchImage: \(optional: error)")
-          }
-        });
-      }
+      styleValue.setImage(
+        bridge: bridge!,
+        style: style,
+        oldValue: oldReactStyle?[prop],
+        setImageOnLayer: { (_) in self.setFillPattern(&layer, styleValue:styleValue) },
+        isLayerStillValid: isValid,
+        setImageOnLayerLater: { (_) in applyUpdater { (layer: inout FillLayer) in self.setFillPattern(&layer, styleValue: styleValue) } },
+        name: "Fill.\(prop)"
+      )
     } else {
       Logger.log(level:.error, message: "Unexpected property \(prop) for layer: fill")
     }
   }
 }
 
-func lineLayer(layer: inout LineLayer, reactStyle:Dictionary<String, Any>, applyUpdater: @escaping  ((inout LineLayer)->Void)->Void, isValid: @escaping () -> Bool)
+func lineLayer(layer: inout LineLayer, reactStyle:Dictionary<String, Any>, oldReactStyle:Dictionary<String, Any>?, applyUpdater: @escaping  ((inout LineLayer)->Void)->Void, isValid: @escaping () -> Bool)
 {
   guard self._hasReactStyle(reactStyle) else {
     Logger.log(level:.error, message: "Invalid style: \(reactStyle)")
@@ -140,28 +127,15 @@ func lineLayer(layer: inout LineLayer, reactStyle:Dictionary<String, Any>, apply
     } else if (prop == "lineDasharray") {
       self.setLineDasharray(&layer, styleValue:styleValue);
     } else if (prop == "linePattern") {
-      if (!styleValue.shouldAddImage()) {
-        self.setLinePattern(&layer, styleValue:styleValue);
-      } else {
-        let imageURI = styleValue.getImageURI()
-
-        RCTMGLUtils.fetchImage(bridge!, url:imageURI, scale:styleValue.getImageScale(), callback:{ (error, image) in
-          if let image = image {
-            DispatchQueue.main.sync {
-              if (isValid()) {
-                logged("Line.LinePattern.addImage") {
-                  try self.style.addImage(image, id:imageURI!, stretchX: [], stretchY: []);
-                  applyUpdater { (layer: inout LineLayer) in
-                    self.setLinePattern(&layer, styleValue:styleValue);
-                  }
-                }
-              }
-            }
-          } else {
-            Logger.log(level: .error, message: "Error during fetchImage: \(optional: error)")
-          }
-        });
-      }
+      styleValue.setImage(
+        bridge: bridge!,
+        style: style,
+        oldValue: oldReactStyle?[prop],
+        setImageOnLayer: { (_) in self.setLinePattern(&layer, styleValue:styleValue) },
+        isLayerStillValid: isValid,
+        setImageOnLayerLater: { (_) in applyUpdater { (layer: inout LineLayer) in self.setLinePattern(&layer, styleValue: styleValue) } },
+        name: "Line.\(prop)"
+      )
     } else if (prop == "lineGradient") {
       self.setLineGradient(&layer, styleValue:styleValue);
     } else if (prop == "lineTrimOffset") {
@@ -172,7 +146,7 @@ func lineLayer(layer: inout LineLayer, reactStyle:Dictionary<String, Any>, apply
   }
 }
 
-func symbolLayer(layer: inout SymbolLayer, reactStyle:Dictionary<String, Any>, applyUpdater: @escaping  ((inout SymbolLayer)->Void)->Void, isValid: @escaping () -> Bool)
+func symbolLayer(layer: inout SymbolLayer, reactStyle:Dictionary<String, Any>, oldReactStyle:Dictionary<String, Any>?, applyUpdater: @escaping  ((inout SymbolLayer)->Void)->Void, isValid: @escaping () -> Bool)
 {
   guard self._hasReactStyle(reactStyle) else {
     Logger.log(level:.error, message: "Invalid style: \(reactStyle)")
@@ -212,28 +186,15 @@ func symbolLayer(layer: inout SymbolLayer, reactStyle:Dictionary<String, Any>, a
     } else if (prop == "iconTextFitPadding") {
       self.setIconTextFitPadding(&layer, styleValue:styleValue);
     } else if (prop == "iconImage") {
-      if (!styleValue.shouldAddImage()) {
-        self.setIconImage(&layer, styleValue:styleValue);
-      } else {
-        let imageURI = styleValue.getImageURI()
-
-        RCTMGLUtils.fetchImage(bridge!, url:imageURI, scale:styleValue.getImageScale(), callback:{ (error, image) in
-          if let image = image {
-            DispatchQueue.main.sync {
-              if (isValid()) {
-                logged("Symbol.IconImage.addImage") {
-                  try self.style.addImage(image, id:imageURI!, stretchX: [], stretchY: []);
-                  applyUpdater { (layer: inout SymbolLayer) in
-                    self.setIconImage(&layer, styleValue:styleValue);
-                  }
-                }
-              }
-            }
-          } else {
-            Logger.log(level: .error, message: "Error during fetchImage: \(optional: error)")
-          }
-        });
-      }
+      styleValue.setImage(
+        bridge: bridge!,
+        style: style,
+        oldValue: oldReactStyle?[prop],
+        setImageOnLayer: { (_) in self.setIconImage(&layer, styleValue:styleValue) },
+        isLayerStillValid: isValid,
+        setImageOnLayerLater: { (_) in applyUpdater { (layer: inout SymbolLayer) in self.setIconImage(&layer, styleValue: styleValue) } },
+        name: "Symbol.\(prop)"
+      )
     } else if (prop == "iconRotate") {
       self.setIconRotate(&layer, styleValue:styleValue);
     } else if (prop == "iconPadding") {
@@ -350,7 +311,7 @@ func symbolLayer(layer: inout SymbolLayer, reactStyle:Dictionary<String, Any>, a
   }
 }
 
-func circleLayer(layer: inout CircleLayer, reactStyle:Dictionary<String, Any>, applyUpdater: @escaping  ((inout CircleLayer)->Void)->Void, isValid: @escaping () -> Bool)
+func circleLayer(layer: inout CircleLayer, reactStyle:Dictionary<String, Any>, oldReactStyle:Dictionary<String, Any>?, applyUpdater: @escaping  ((inout CircleLayer)->Void)->Void, isValid: @escaping () -> Bool)
 {
   guard self._hasReactStyle(reactStyle) else {
     Logger.log(level:.error, message: "Invalid style: \(reactStyle)")
@@ -413,7 +374,7 @@ func circleLayer(layer: inout CircleLayer, reactStyle:Dictionary<String, Any>, a
   }
 }
 
-func heatmapLayer(layer: inout HeatmapLayer, reactStyle:Dictionary<String, Any>, applyUpdater: @escaping  ((inout HeatmapLayer)->Void)->Void, isValid: @escaping () -> Bool)
+func heatmapLayer(layer: inout HeatmapLayer, reactStyle:Dictionary<String, Any>, oldReactStyle:Dictionary<String, Any>?, applyUpdater: @escaping  ((inout HeatmapLayer)->Void)->Void, isValid: @escaping () -> Bool)
 {
   guard self._hasReactStyle(reactStyle) else {
     Logger.log(level:.error, message: "Invalid style: \(reactStyle)")
@@ -452,7 +413,7 @@ func heatmapLayer(layer: inout HeatmapLayer, reactStyle:Dictionary<String, Any>,
   }
 }
 
-func fillExtrusionLayer(layer: inout FillExtrusionLayer, reactStyle:Dictionary<String, Any>, applyUpdater: @escaping  ((inout FillExtrusionLayer)->Void)->Void, isValid: @escaping () -> Bool)
+func fillExtrusionLayer(layer: inout FillExtrusionLayer, reactStyle:Dictionary<String, Any>, oldReactStyle:Dictionary<String, Any>?, applyUpdater: @escaping  ((inout FillExtrusionLayer)->Void)->Void, isValid: @escaping () -> Bool)
 {
   guard self._hasReactStyle(reactStyle) else {
     Logger.log(level:.error, message: "Invalid style: \(reactStyle)")
@@ -484,28 +445,15 @@ func fillExtrusionLayer(layer: inout FillExtrusionLayer, reactStyle:Dictionary<S
     } else if (prop == "fillExtrusionTranslateAnchor") {
       self.setFillExtrusionTranslateAnchor(&layer, styleValue:styleValue);
     } else if (prop == "fillExtrusionPattern") {
-      if (!styleValue.shouldAddImage()) {
-        self.setFillExtrusionPattern(&layer, styleValue:styleValue);
-      } else {
-        let imageURI = styleValue.getImageURI()
-
-        RCTMGLUtils.fetchImage(bridge!, url:imageURI, scale:styleValue.getImageScale(), callback:{ (error, image) in
-          if let image = image {
-            DispatchQueue.main.sync {
-              if (isValid()) {
-                logged("FillExtrusion.FillExtrusionPattern.addImage") {
-                  try self.style.addImage(image, id:imageURI!, stretchX: [], stretchY: []);
-                  applyUpdater { (layer: inout FillExtrusionLayer) in
-                    self.setFillExtrusionPattern(&layer, styleValue:styleValue);
-                  }
-                }
-              }
-            }
-          } else {
-            Logger.log(level: .error, message: "Error during fetchImage: \(optional: error)")
-          }
-        });
-      }
+      styleValue.setImage(
+        bridge: bridge!,
+        style: style,
+        oldValue: oldReactStyle?[prop],
+        setImageOnLayer: { (_) in self.setFillExtrusionPattern(&layer, styleValue:styleValue) },
+        isLayerStillValid: isValid,
+        setImageOnLayerLater: { (_) in applyUpdater { (layer: inout FillExtrusionLayer) in self.setFillExtrusionPattern(&layer, styleValue: styleValue) } },
+        name: "FillExtrusion.\(prop)"
+      )
     } else if (prop == "fillExtrusionHeight") {
       self.setFillExtrusionHeight(&layer, styleValue:styleValue);
     } else if (prop == "fillExtrusionHeightTransition") {
@@ -522,7 +470,7 @@ func fillExtrusionLayer(layer: inout FillExtrusionLayer, reactStyle:Dictionary<S
   }
 }
 
-func rasterLayer(layer: inout RasterLayer, reactStyle:Dictionary<String, Any>, applyUpdater: @escaping  ((inout RasterLayer)->Void)->Void, isValid: @escaping () -> Bool)
+func rasterLayer(layer: inout RasterLayer, reactStyle:Dictionary<String, Any>, oldReactStyle:Dictionary<String, Any>?, applyUpdater: @escaping  ((inout RasterLayer)->Void)->Void, isValid: @escaping () -> Bool)
 {
   guard self._hasReactStyle(reactStyle) else {
     Logger.log(level:.error, message: "Invalid style: \(reactStyle)")
@@ -573,7 +521,7 @@ func rasterLayer(layer: inout RasterLayer, reactStyle:Dictionary<String, Any>, a
   }
 }
 
-func hillshadeLayer(layer: inout HillshadeLayer, reactStyle:Dictionary<String, Any>, applyUpdater: @escaping  ((inout HillshadeLayer)->Void)->Void, isValid: @escaping () -> Bool)
+func hillshadeLayer(layer: inout HillshadeLayer, reactStyle:Dictionary<String, Any>, oldReactStyle:Dictionary<String, Any>?, applyUpdater: @escaping  ((inout HillshadeLayer)->Void)->Void, isValid: @escaping () -> Bool)
 {
   guard self._hasReactStyle(reactStyle) else {
     Logger.log(level:.error, message: "Invalid style: \(reactStyle)")
@@ -616,7 +564,7 @@ func hillshadeLayer(layer: inout HillshadeLayer, reactStyle:Dictionary<String, A
   }
 }
 
-func backgroundLayer(layer: inout BackgroundLayer, reactStyle:Dictionary<String, Any>, applyUpdater: @escaping  ((inout BackgroundLayer)->Void)->Void, isValid: @escaping () -> Bool)
+func backgroundLayer(layer: inout BackgroundLayer, reactStyle:Dictionary<String, Any>, oldReactStyle:Dictionary<String, Any>?, applyUpdater: @escaping  ((inout BackgroundLayer)->Void)->Void, isValid: @escaping () -> Bool)
 {
   guard self._hasReactStyle(reactStyle) else {
     Logger.log(level:.error, message: "Invalid style: \(reactStyle)")
@@ -638,28 +586,15 @@ func backgroundLayer(layer: inout BackgroundLayer, reactStyle:Dictionary<String,
     } else if (prop == "backgroundColorTransition") {
       self.setBackgroundColorTransition(&layer, styleValue:styleValue);
     } else if (prop == "backgroundPattern") {
-      if (!styleValue.shouldAddImage()) {
-        self.setBackgroundPattern(&layer, styleValue:styleValue);
-      } else {
-        let imageURI = styleValue.getImageURI()
-
-        RCTMGLUtils.fetchImage(bridge!, url:imageURI, scale:styleValue.getImageScale(), callback:{ (error, image) in
-          if let image = image {
-            DispatchQueue.main.sync {
-              if (isValid()) {
-                logged("Background.BackgroundPattern.addImage") {
-                  try self.style.addImage(image, id:imageURI!, stretchX: [], stretchY: []);
-                  applyUpdater { (layer: inout BackgroundLayer) in
-                    self.setBackgroundPattern(&layer, styleValue:styleValue);
-                  }
-                }
-              }
-            }
-          } else {
-            Logger.log(level: .error, message: "Error during fetchImage: \(optional: error)")
-          }
-        });
-      }
+      styleValue.setImage(
+        bridge: bridge!,
+        style: style,
+        oldValue: oldReactStyle?[prop],
+        setImageOnLayer: { (_) in self.setBackgroundPattern(&layer, styleValue:styleValue) },
+        isLayerStillValid: isValid,
+        setImageOnLayerLater: { (_) in applyUpdater { (layer: inout BackgroundLayer) in self.setBackgroundPattern(&layer, styleValue: styleValue) } },
+        name: "Background.\(prop)"
+      )
     } else if (prop == "backgroundOpacity") {
       self.setBackgroundOpacity(&layer, styleValue:styleValue);
     } else if (prop == "backgroundOpacityTransition") {
@@ -670,7 +605,7 @@ func backgroundLayer(layer: inout BackgroundLayer, reactStyle:Dictionary<String,
   }
 }
 
-func skyLayer(layer: inout SkyLayer, reactStyle:Dictionary<String, Any>, applyUpdater: @escaping  ((inout SkyLayer)->Void)->Void, isValid: @escaping () -> Bool)
+func skyLayer(layer: inout SkyLayer, reactStyle:Dictionary<String, Any>, oldReactStyle:Dictionary<String, Any>?, applyUpdater: @escaping  ((inout SkyLayer)->Void)->Void, isValid: @escaping () -> Bool)
 {
   guard self._hasReactStyle(reactStyle) else {
     Logger.log(level:.error, message: "Invalid style: \(reactStyle)")
@@ -713,7 +648,7 @@ func skyLayer(layer: inout SkyLayer, reactStyle:Dictionary<String, Any>, applyUp
   }
 }
 
-func lightLayer(layer: inout Light, reactStyle:Dictionary<String, Any>, applyUpdater: @escaping  ((inout Light)->Void)->Void, isValid: @escaping () -> Bool)
+func lightLayer(layer: inout Light, reactStyle:Dictionary<String, Any>, oldReactStyle:Dictionary<String, Any>?, applyUpdater: @escaping  ((inout Light)->Void)->Void, isValid: @escaping () -> Bool)
 {
   guard self._hasReactStyle(reactStyle) else {
     Logger.log(level:.error, message: "Invalid style: \(reactStyle)")
@@ -748,7 +683,7 @@ func lightLayer(layer: inout Light, reactStyle:Dictionary<String, Any>, applyUpd
   }
 }
 
-func atmosphereLayer(layer: inout Atmosphere, reactStyle:Dictionary<String, Any>, applyUpdater: @escaping  ((inout Atmosphere)->Void)->Void, isValid: @escaping () -> Bool)
+func atmosphereLayer(layer: inout Atmosphere, reactStyle:Dictionary<String, Any>, oldReactStyle:Dictionary<String, Any>?, applyUpdater: @escaping  ((inout Atmosphere)->Void)->Void, isValid: @escaping () -> Bool)
 {
   guard self._hasReactStyle(reactStyle) else {
     Logger.log(level:.error, message: "Invalid style: \(reactStyle)")
@@ -793,7 +728,7 @@ func atmosphereLayer(layer: inout Atmosphere, reactStyle:Dictionary<String, Any>
   }
 }
 
-func terrainLayer(layer: inout Terrain, reactStyle:Dictionary<String, Any>, applyUpdater: @escaping  ((inout Terrain)->Void)->Void, isValid: @escaping () -> Bool)
+func terrainLayer(layer: inout Terrain, reactStyle:Dictionary<String, Any>, oldReactStyle:Dictionary<String, Any>?, applyUpdater: @escaping  ((inout Terrain)->Void)->Void, isValid: @escaping () -> Bool)
 {
   guard self._hasReactStyle(reactStyle) else {
     Logger.log(level:.error, message: "Invalid style: \(reactStyle)")

--- a/ios/RCTMGL-v10/RCTMGLSymbolLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLSymbolLayer.swift
@@ -35,6 +35,7 @@ class RCTMGLSymbolLayer: RCTMGLVectorLayer {
         styler.symbolLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
+          oldReactStyle: oldReatStyle,
           applyUpdater: { (updater) in logged("RCTMGLSymbolLayer.updateLayer") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
           }},

--- a/ios/RCTMGL-v10/RCTMGLTerrain.swift
+++ b/ios/RCTMGL-v10/RCTMGLTerrain.swift
@@ -73,6 +73,7 @@ class RCTMGLTerrain : RCTMGLSingletonLayer, RCTMGLMapComponent, RCTMGLSourceCons
         styler.terrainLayer(
           layer: &terrain,
           reactStyle: reactStyle,
+          oldReactStyle: oldReactStyle,
           applyUpdater: { (updater) in fatalError("Terrain: TODO - implement apply updater")},
           isValid: { fatalError("Terrain: TODO - no isValid") }
         )

--- a/javascript/modules/location/locationManager.js
+++ b/javascript/modules/location/locationManager.js
@@ -131,6 +131,10 @@ class LocationManager {
 
     this._listeners.forEach((l) => l(location));
   }
+
+  _simulateHeading(changesPerSecond, increment) {
+    MapboxGLLocationManager.simulateHeading(changesPerSecond, increment);
+  }
 }
 
 export default new LocationManager();

--- a/scripts/templates/RCTMGLStyle.swift.ejs
+++ b/scripts/templates/RCTMGLStyle.swift.ejs
@@ -15,7 +15,7 @@ class RCTMGLStyle {
   }
 
 <% for (const layer of layers) { %>
-func <%- setLayerMethodName(layer, 'ios') -%>(layer: inout <%- getLayerType(layer, 'ios-v10') -%>, reactStyle:Dictionary<String, Any>, applyUpdater: @escaping  ((inout <%- getLayerType(layer, 'ios-v10') -%>)->Void)->Void, isValid: @escaping () -> Bool)
+func <%- setLayerMethodName(layer, 'ios') -%>(layer: inout <%- getLayerType(layer, 'ios-v10') -%>, reactStyle:Dictionary<String, Any>, oldReactStyle:Dictionary<String, Any>?, applyUpdater: @escaping  ((inout <%- getLayerType(layer, 'ios-v10') -%>)->Void)->Void, isValid: @escaping () -> Bool)
 {
   guard self._hasReactStyle(reactStyle) else {
     Logger.log(level:.error, message: "Invalid style: \(reactStyle)")
@@ -33,28 +33,15 @@ func <%- setLayerMethodName(layer, 'ios') -%>(layer: inout <%- getLayerType(laye
   <% for (let i = 0; i < layer.properties.length; i++) { -%>
   <%- ifOrElseIf(i) -%> (prop == "<%= layer.properties[i].name %>") {
   <%_ if (layer.properties[i].image) { _%>
-      if (!styleValue.shouldAddImage()) {
-        self.set<%- iosPropMethodName(layer, pascelCase(layer.properties[i].name)) -%>(&layer, styleValue:styleValue);
-      } else {
-        let imageURI = styleValue.getImageURI()
-
-        RCTMGLUtils.fetchImage(bridge!, url:imageURI, scale:styleValue.getImageScale(), callback:{ (error, image) in
-          if let image = image {
-            DispatchQueue.main.sync {
-              if (isValid()) {
-                logged("<%- pascelCase(layer.name) %>.<%- pascelCase(layer.properties[i].name) %>.addImage") {
-                  try self.style.addImage(image, id:imageURI!, stretchX: [], stretchY: []);
-                  applyUpdater { (layer: inout <%- getLayerType(layer, 'ios-v10') -%>) in
-                    self.set<%- iosPropMethodName(layer, pascelCase(layer.properties[i].name)) -%>(&layer, styleValue:styleValue);
-                  }
-                }
-              }
-            }
-          } else {
-            Logger.log(level: .error, message: "Error during fetchImage: \(optional: error)")
-          }
-        });
-      }
+      styleValue.setImage(
+        bridge: bridge!,
+        style: style,
+        oldValue: oldReactStyle?[prop],
+        setImageOnLayer: { (_) in self.set<%- iosPropMethodName(layer, pascelCase(layer.properties[i].name)) -%>(&layer, styleValue:styleValue) },
+        isLayerStillValid: isValid,
+        setImageOnLayerLater: { (_) in applyUpdater { (layer: inout <%- getLayerType(layer, 'ios-v10') -%>) in self.set<%- iosPropMethodName(layer, pascelCase(layer.properties[i].name)) -%>(&layer, styleValue: styleValue) } },
+        name: "<%- pascelCase(layer.name) %>.\(prop)"
+      )
   <%_ } else { _%>
       self.set<%- iosPropMethodName(layer, pascelCase(layer.properties[i].name)) -%>(&layer, styleValue:styleValue);
   <%_ } _%>


### PR DESCRIPTION
…OS simulator, improve adding images in styles

- added private `_simulateHeading(changesPerSec, increment)` to locationManager so heading can be simulated on the iOS simulator. ChangesPerSec = 0 means stop. increment is increment in degrees.
- images on layers are now only updated when the url changed, this should improve uneccesary download, and also remove some flickering. This has happened for code like this:
```
import headingIcon from '../assets/heading.png';
...
<SymbolLayer style={{iconImage:require('icon.png'), iconRotate: heading}} />
```

every time heading changed RN sent over the full style dict as updated and we were regrabbing, and reset the image even if not changed. On iOS we now detect that it's the same image and we'll not reload the image.
