### PR TITLE
chore: remove unused getOrCalculateVisibleRegion

### DIFF
--- a/javascript/utils/geoUtils.ts
+++ b/javascript/utils/geoUtils.ts
@@ -14,9 +14,6 @@ import {
 } from '@turf/helpers';
 import distance from '@turf/distance';
 import along from '@turf/along';
-import geoViewport from '@mapbox/geo-viewport';
-
-const VECTOR_TILE_SIZE = 512;
 
 export const makePoint = point;
 
@@ -57,35 +54,3 @@ export function addToFeatureCollection(
 export const calculateDistance = distance;
 
 export const pointAlongLine = along;
-
-export function getOrCalculateVisibleRegion(
-  coord: [number, number],
-  zoomLevel: number,
-  width: number,
-  height: number,
-  nativeRegion: {
-    properties: {
-      visibleBounds: number[][];
-    };
-  },
-) {
-  const region = {
-    ne: [0, 0],
-    sw: [0, 0],
-  };
-
-  if (!nativeRegion || !Array.isArray(nativeRegion.properties.visibleBounds)) {
-    const bounds = geoViewport.bounds(
-      coord,
-      zoomLevel,
-      [width, height],
-      VECTOR_TILE_SIZE,
-    );
-    region.ne = [bounds[3], bounds[2]];
-    region.sw = [bounds[1], bounds[0]];
-  } else {
-    [region.ne, region.sw] = nativeRegion.properties.visibleBounds;
-  }
-
-  return region;
-}

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     }
   },
   "dependencies": {
-    "@mapbox/geo-viewport": ">=0.4.0",
     "@turf/along": "6.5.0",
     "@turf/distance": "6.5.0",
     "@turf/helpers": "6.5.0",
@@ -72,7 +71,6 @@
     "@testing-library/react-native": "^11.0.0",
     "@types/debounce": "^1.2.1",
     "@types/mapbox-gl": "^2.7.5",
-    "@types/mapbox__geo-viewport": "^0.4.1",
     "@types/react-native": ">=0.59.9",
     "@typescript-eslint/eslint-plugin": "^5.37.0",
     "@typescript-eslint/parser": "^5.37.0",


### PR DESCRIPTION
## Description

The unused function `getOrCalculateVisibleRegion` and it's dependency on `@mapbox/geo-viewport` gives me missing types errors when using in a project:

```
node_modules/@rnmapbox/maps/javascript/utils/geoUtils.ts:17:25 - error TS7016: Could not find a declaration file for module '@mapbox/geo-viewport'. '/Users/finger/Development/rrph-app/node_modules/@mapbox/geo-viewport/index.js' implicitly has an 'any' type.
```

There fore I would like to get rid of the function and their dependencies. Otherwiese we have to move the `@types/mapbox__geo-viewport` dependency to `dependencies`, so they will be installed when used in a project.

## Checklist

<!-- Check completed item: [X] -->

- [ ] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
