### PR TITLE
fix(ts): PointAnnotation FeaturePayload type

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/events/PointAnnotationDragEvent.java
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/events/PointAnnotationDragEvent.java
@@ -43,9 +43,11 @@ public class PointAnnotationDragEvent extends MapClickEvent {
     @Override
     public WritableMap getPayload() {
         WritableMap properties = new WritableNativeMap();
-        properties.putString("id", mView.getID());
         properties.putDouble("screenPointX", mScreenPoint.x);
         properties.putDouble("screenPointY", mScreenPoint.y);
-        return GeoJSONUtils.toPointFeature(mTouchedLatLng, properties);
+        WritableMap feature = GeoJSONUtils.toPointFeature(mTouchedLatLng, properties);
+        feature.putString("id", mView.getID());
+        
+        return feature;
     }
 }

--- a/docs/PointAnnotation.md
+++ b/docs/PointAnnotation.md
@@ -20,11 +20,11 @@ as with PointAnnotation child views are rendered onto a bitmap
 | anchor | `shape` | `{ x: 0.5, y: 0.5 }` | `false` | Specifies the anchor being set on a particular point of the annotation.<br/>The anchor point is specified in the continuous space [0.0, 1.0] x [0.0, 1.0],<br/>where (0, 0) is the top-left corner of the image, and (1, 1) is the bottom-right corner.<br/>Note this is only for custom annotations not the default pin view.<br/>Defaults to the center of the view. |
 | &nbsp;&nbsp;x | `number` | `none` | `true` | See anchor |
 | &nbsp;&nbsp;y | `number` | `none` | `true` | See anchor |
-| onSelected | `func` | `none` | `false` | This callback is fired once this annotation is selected. Returns a Feature as the first param.<br/>*signature:*`(payload:{feature: Feature}) => void` |
-| onDeselected | `func` | `none` | `false` | This callback is fired once this annotation is deselected.<br/>*signature:*`(payload:{feature: Feature}) => void` |
-| onDragStart | `func` | `none` | `false` | This callback is fired once this annotation has started being dragged.<br/>*signature:*`(payload:{feature: Feature}) => void` |
-| onDragEnd | `func` | `none` | `false` | This callback is fired once this annotation has stopped being dragged.<br/>*signature:*`(payload:{feature: Feature}) => void` |
-| onDrag | `func` | `none` | `false` | This callback is fired while this annotation is being dragged.<br/>*signature:*`(payload:{feature: Feature}) => void` |
+| onSelected | `func` | `none` | `false` | This callback is fired once this annotation is selected. Returns a Feature as the first param.<br/>*signature:*`(payload:Feature) => void` |
+| onDeselected | `func` | `none` | `false` | This callback is fired once this annotation is deselected.<br/>*signature:*`(payload:Feature) => void` |
+| onDragStart | `func` | `none` | `false` | This callback is fired once this annotation has started being dragged.<br/>*signature:*`(payload:Feature) => void` |
+| onDragEnd | `func` | `none` | `false` | This callback is fired once this annotation has stopped being dragged.<br/>*signature:*`(payload:Feature) => void` |
+| onDrag | `func` | `none` | `false` | This callback is fired while this annotation is being dragged.<br/>*signature:*`(payload:Feature) => void` |
 | children | `React.ReactElement \| [React.ReactElement, React.ReactElement]` | `none` | `true` | Expects one child, and an optional callout can be added as well |
 | style | `ViewProps['style']` | `none` | `false` | FIX ME NO DESCRIPTION |
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3604,50 +3604,50 @@
         "required": false,
         "type": {
           "name": "func",
-          "funcSignature": "(payload:{feature: Feature}) => void"
+          "funcSignature": "(payload:Feature) => void"
         },
         "default": "none",
-        "description": "This callback is fired once this annotation is selected. Returns a Feature as the first param.\n*signature:*`(payload:{feature: Feature}) => void`"
+        "description": "This callback is fired once this annotation is selected. Returns a Feature as the first param.\n*signature:*`(payload:Feature) => void`"
       },
       {
         "name": "onDeselected",
         "required": false,
         "type": {
           "name": "func",
-          "funcSignature": "(payload:{feature: Feature}) => void"
+          "funcSignature": "(payload:Feature) => void"
         },
         "default": "none",
-        "description": "This callback is fired once this annotation is deselected.\n*signature:*`(payload:{feature: Feature}) => void`"
+        "description": "This callback is fired once this annotation is deselected.\n*signature:*`(payload:Feature) => void`"
       },
       {
         "name": "onDragStart",
         "required": false,
         "type": {
           "name": "func",
-          "funcSignature": "(payload:{feature: Feature}) => void"
+          "funcSignature": "(payload:Feature) => void"
         },
         "default": "none",
-        "description": "This callback is fired once this annotation has started being dragged.\n*signature:*`(payload:{feature: Feature}) => void`"
+        "description": "This callback is fired once this annotation has started being dragged.\n*signature:*`(payload:Feature) => void`"
       },
       {
         "name": "onDragEnd",
         "required": false,
         "type": {
           "name": "func",
-          "funcSignature": "(payload:{feature: Feature}) => void"
+          "funcSignature": "(payload:Feature) => void"
         },
         "default": "none",
-        "description": "This callback is fired once this annotation has stopped being dragged.\n*signature:*`(payload:{feature: Feature}) => void`"
+        "description": "This callback is fired once this annotation has stopped being dragged.\n*signature:*`(payload:Feature) => void`"
       },
       {
         "name": "onDrag",
         "required": false,
         "type": {
           "name": "func",
-          "funcSignature": "(payload:{feature: Feature}) => void"
+          "funcSignature": "(payload:Feature) => void"
         },
         "default": "none",
-        "description": "This callback is fired while this annotation is being dragged.\n*signature:*`(payload:{feature: Feature}) => void`"
+        "description": "This callback is fired while this annotation is being dragged.\n*signature:*`(payload:Feature) => void`"
       },
       {
         "name": "children",

--- a/example/src/examples/Annotations/ShowPointAnnotation.tsx
+++ b/example/src/examples/Annotations/ShowPointAnnotation.tsx
@@ -9,7 +9,7 @@ import {
   ShapeSource,
   getAnnotationsLayerID,
 } from '@rnmapbox/maps';
-import { Feature, Point, Position } from 'geojson';
+import { Point, Position } from 'geojson';
 import { Button } from '@rneui/base';
 
 import sheet from '../../styles/sheet';
@@ -39,8 +39,6 @@ type AnnotationWithRemoteImageProps = {
   coordinate: Position;
 };
 
-type PointFeature = Feature<GeoJSON.Point, { id: string }>;
-
 const AnnotationWithRemoteImage = ({
   id,
   coordinate,
@@ -54,25 +52,25 @@ const AnnotationWithRemoteImage = ({
       coordinate={coordinate}
       title={title}
       draggable
-      onDrag={(payload: { feature: PointFeature }) =>
+      onDrag={(feature) =>
         console.log(
           'onDrag:',
-          payload.feature.properties.id,
-          payload.feature.geometry.coordinates,
+          feature.properties.id,
+          feature.geometry.coordinates,
         )
       }
-      onDragStart={(payload: { feature: PointFeature }) =>
+      onDragStart={(feature) =>
         console.log(
           'onDragStart:',
-          payload.feature.properties.id,
-          payload.feature.geometry.coordinates,
+          feature.properties.id,
+          feature.geometry.coordinates,
         )
       }
-      onDragEnd={(payload: { feature: PointFeature }) =>
+      onDragEnd={(feature) =>
         console.log(
           'onDragEnd:',
-          payload.feature.properties.id,
-          payload.feature.geometry.coordinates,
+          feature.properties.id,
+          feature.geometry.coordinates,
         )
       }
       ref={pointAnnotation}

--- a/example/src/examples/Annotations/ShowPointAnnotation.tsx
+++ b/example/src/examples/Annotations/ShowPointAnnotation.tsx
@@ -52,26 +52,17 @@ const AnnotationWithRemoteImage = ({
       coordinate={coordinate}
       title={title}
       draggable
+      onSelected={(feature) =>
+        console.log('onSelected:', feature.id, feature.geometry.coordinates)
+      }
       onDrag={(feature) =>
-        console.log(
-          'onDrag:',
-          feature.properties.id,
-          feature.geometry.coordinates,
-        )
+        console.log('onDrag:', feature.id, feature.geometry.coordinates)
       }
       onDragStart={(feature) =>
-        console.log(
-          'onDragStart:',
-          feature.properties.id,
-          feature.geometry.coordinates,
-        )
+        console.log('onDragStart:', feature.id, feature.geometry.coordinates)
       }
       onDragEnd={(feature) =>
-        console.log(
-          'onDragEnd:',
-          feature.properties.id,
-          feature.geometry.coordinates,
-        )
+        console.log('onDragEnd:', feature.id, feature.geometry.coordinates)
       }
       ref={pointAnnotation}
     >

--- a/ios/RCTMGL-v10/RCTMGLMapView.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapView.swift
@@ -859,7 +859,8 @@ class PointAnnotationManager : AnnotationInteractionDelegate {
           if let pt = rctmglPointAnnotation.object {
             let position = pt.superview?.convert(pt.layer.position, to: nil)
             let location = pt.map?.mapboxMap.coordinate(for: position!)
-            var geojson = Feature(geometry: .point(Point(location!)));
+            var geojson = Feature(geometry: .point(Point(location!)))
+            geojson.identifier = .string(pt.id)
             geojson.properties = [
               "screenPointX": .number(Double(position!.x)),
               "screenPointY": .number(Double(position!.y))
@@ -947,7 +948,8 @@ class PointAnnotationManager : AnnotationInteractionDelegate {
         if let rctmglPointAnnotation = userInfo[RCTMGLPointAnnotation.key] as? WeakRef<RCTMGLPointAnnotation> {
           if let pt = rctmglPointAnnotation.object {
             let position = pt.superview?.convert(pt.layer.position, to: nil)
-            var geojson = Feature(geometry: .point(Point(targetPoint)));
+            var geojson = Feature(geometry: .point(Point(targetPoint)))
+            geojson.identifier = .string(pt.id)
             geojson.properties = [
               "screenPointX": .number(Double(position!.x)),
               "screenPointY": .number(Double(position!.y))

--- a/javascript/components/PointAnnotation.tsx
+++ b/javascript/components/PointAnnotation.tsx
@@ -27,11 +27,6 @@ const styles = StyleSheet.create({
 type FeaturePayload = Feature<
   Point,
   {
-    /**
-     * @platform android
-     */
-    id?: string;
-
     screenPointX: number;
     screenPointY: number;
   }

--- a/javascript/components/PointAnnotation.tsx
+++ b/javascript/components/PointAnnotation.tsx
@@ -5,7 +5,7 @@ import {
   Platform,
   type ViewProps,
 } from 'react-native';
-import { type Feature } from 'geojson';
+import { Feature, Point } from 'geojson';
 
 import { toJSONString, isFunction } from '../utils';
 import { makePoint } from '../utils/geoUtils';
@@ -24,9 +24,18 @@ const styles = StyleSheet.create({
   },
 });
 
-type FeaturePayload = {
-  feature: Feature<GeoJSON.Point, { id: string }>;
-};
+type FeaturePayload = Feature<
+  Point,
+  {
+    /**
+     * @platform android
+     */
+    id?: string;
+
+    screenPointX: number;
+    screenPointY: number;
+  }
+>;
 
 type Props = BaseProps & {
   /**


### PR DESCRIPTION
## Description

`PointAnnotation` events are currently falsy typed, see also "Show Point Annotation" example is currently logging `undefined` on drag events. `id` was not yet implemented on iOS. I moved it on booth platforms to `feature.id` instead of `feature.properties.id` as that's part of the GeoJson spec.

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
- [x] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
