### PR TITLE
feat(expo,ios): add RNMapboxMapsVersion to Expo Plugin on iOS

### DIFF
--- a/plugin/build/withMapbox.d.ts
+++ b/plugin/build/withMapbox.d.ts
@@ -2,11 +2,12 @@ import { ConfigPlugin, XcodeProject } from 'expo/config-plugins';
 declare type InstallerBlockName = 'pre' | 'post';
 export declare type MapboxPlugProps = {
     RNMapboxMapsImpl?: string;
+    RNMapboxMapsVersion?: string;
     RNMapboxMapsDownloadToken?: string;
 };
 export declare const addInstallerBlock: (src: string, blockName: InstallerBlockName) => string;
-export declare const addConstantBlock: (src: string, RNMapboxMapsImpl?: string, RNMapboxMapsDownloadToken?: string) => string;
-export declare const applyCocoaPodsModifications: (contents: string, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken }: MapboxPlugProps) => string;
+export declare const addConstantBlock: (src: string, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, }: MapboxPlugProps) => string;
+export declare const applyCocoaPodsModifications: (contents: string, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, }: MapboxPlugProps) => string;
 export declare const addMapboxInstallerBlock: (src: string, blockName: InstallerBlockName) => string;
 /**
  * Exclude building for arm64 on simulator devices in the pbxproj project.

--- a/plugin/build/withMapbox.d.ts
+++ b/plugin/build/withMapbox.d.ts
@@ -2,6 +2,9 @@ import { ConfigPlugin, XcodeProject } from 'expo/config-plugins';
 declare type InstallerBlockName = 'pre' | 'post';
 export declare type MapboxPlugProps = {
     RNMapboxMapsImpl?: string;
+    /**
+     * @platform ios
+     */
     RNMapboxMapsVersion?: string;
     RNMapboxMapsDownloadToken?: string;
 };

--- a/plugin/build/withMapbox.d.ts
+++ b/plugin/build/withMapbox.d.ts
@@ -4,16 +4,16 @@ export declare type MapboxPlugProps = {
     RNMapboxMapsImpl?: string;
     RNMapboxMapsDownloadToken?: string;
 };
-export declare function applyCocoaPodsModifications(contents: string, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken }: MapboxPlugProps): string;
-export declare function addConstantBlock(src: string, RNMapboxMapsImpl?: string, RNMapboxMapsDownloadToken?: string): string;
-export declare function addInstallerBlock(src: string, blockName: InstallerBlockName): string;
-export declare function addMapboxInstallerBlock(src: string, blockName: InstallerBlockName): string;
+export declare const addInstallerBlock: (src: string, blockName: InstallerBlockName) => string;
+export declare const addConstantBlock: (src: string, RNMapboxMapsImpl?: string, RNMapboxMapsDownloadToken?: string) => string;
+export declare const applyCocoaPodsModifications: (contents: string, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken }: MapboxPlugProps) => string;
+export declare const addMapboxInstallerBlock: (src: string, blockName: InstallerBlockName) => string;
 /**
  * Exclude building for arm64 on simulator devices in the pbxproj project.
  * Without this, production builds targeting simulators will fail.
  */
-export declare function setExcludedArchitectures(project: XcodeProject): XcodeProject;
-export declare function addMapboxMavenRepo(src: string): string;
+export declare const setExcludedArchitectures: (project: XcodeProject) => XcodeProject;
+export declare const addMapboxMavenRepo: (src: string) => string;
 declare const _default: ConfigPlugin<MapboxPlugProps>;
 export default _default;
 export { addMapboxMavenRepo as _addMapboxMavenRepo, };

--- a/plugin/build/withMapbox.js
+++ b/plugin/build/withMapbox.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports._addMapboxMavenRepo = exports.addMapboxMavenRepo = exports.setExcludedArchitectures = exports.addMapboxInstallerBlock = exports.addInstallerBlock = exports.addConstantBlock = exports.applyCocoaPodsModifications = void 0;
+exports._addMapboxMavenRepo = exports.addMapboxMavenRepo = exports.setExcludedArchitectures = exports.addMapboxInstallerBlock = exports.applyCocoaPodsModifications = exports.addConstantBlock = exports.addInstallerBlock = void 0;
 const fs_1 = require("fs");
 const path_1 = __importDefault(require("path"));
 const config_plugins_1 = require("expo/config-plugins");
@@ -17,66 +17,7 @@ try {
 catch {
     // empty catch block
 }
-/**
- * Dangerously adds the custom installer hooks to the Podfile.
- * In the future this should be removed in favor of some custom hooks provided by Expo autolinking.
- *
- * https://github.com/rnmapbox/maps/blob/main/ios/install.md#react-native--0600
- * @param config
- * @returns
- */
-const withCocoaPodsInstallerBlocks = (c, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken }) => {
-    return (0, config_plugins_1.withDangerousMod)(c, [
-        'ios',
-        async (config) => {
-            const file = path_1.default.join(config.modRequest.platformProjectRoot, 'Podfile');
-            const contents = await fs_1.promises.readFile(file, 'utf8');
-            await fs_1.promises.writeFile(file, applyCocoaPodsModifications(contents, {
-                RNMapboxMapsImpl,
-                RNMapboxMapsDownloadToken,
-            }), 'utf-8');
-            return config;
-        },
-    ]);
-};
-// Only the preinstaller block is required, the post installer block is
-// used for spm (swift package manager) which Expo doesn't currently support.
-function applyCocoaPodsModifications(contents, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken }) {
-    // Ensure installer blocks exist
-    let src = addConstantBlock(contents, RNMapboxMapsImpl, RNMapboxMapsDownloadToken);
-    src = addInstallerBlock(src, 'pre');
-    src = addInstallerBlock(src, 'post');
-    src = addMapboxInstallerBlock(src, 'pre');
-    src = addMapboxInstallerBlock(src, 'post');
-    return src;
-}
-exports.applyCocoaPodsModifications = applyCocoaPodsModifications;
-function addConstantBlock(src, RNMapboxMapsImpl, RNMapboxMapsDownloadToken) {
-    const tag = `@rnmapbox/maps-rnmapboxmapsimpl`;
-    if (RNMapboxMapsImpl == null) {
-        const modified = (0, generateCode_1.removeGeneratedContents)(src, tag);
-        if (!modified) {
-            return src;
-        }
-        else {
-            return modified;
-        }
-    }
-    return (0, generateCode_1.mergeContents)({
-        tag,
-        src,
-        newSrc: [
-            `$RNMapboxMapsImpl = '${RNMapboxMapsImpl}'`,
-            `$RNMapboxMapsDownloadToken = '${RNMapboxMapsDownloadToken}'`,
-        ].join('\n'),
-        anchor: /target .+ do/,
-        // We can't go after the use_react_native block because it might have parameters, causing it to be multi-line (see react-native template).
-        offset: 0,
-        comment: '#',
-    }).contents;
-}
-exports.addConstantBlock = addConstantBlock;
-function addInstallerBlock(src, blockName) {
+const addInstallerBlock = (src, blockName) => {
     const matchBlock = new RegExp(`${blockName}_install do \\|installer\\|`);
     const tag = `${blockName}_installer`;
     for (const line of src.split('\n')) {
@@ -103,27 +44,78 @@ function addInstallerBlock(src, blockName) {
         offset: 0,
         comment: '#',
     }).contents;
-}
+};
 exports.addInstallerBlock = addInstallerBlock;
-function addMapboxInstallerBlock(src, blockName) {
+const addConstantBlock = (src, RNMapboxMapsImpl, RNMapboxMapsDownloadToken) => {
+    const tag = `@rnmapbox/maps-rnmapboxmapsimpl`;
+    if (RNMapboxMapsImpl == null) {
+        const modified = (0, generateCode_1.removeGeneratedContents)(src, tag);
+        if (!modified) {
+            return src;
+        }
+        else {
+            return modified;
+        }
+    }
     return (0, generateCode_1.mergeContents)({
-        tag: `@rnmapbox/maps-${blockName}_installer`,
+        tag,
         src,
-        newSrc: `    $RNMapboxMaps.${blockName}_install(installer)`,
-        anchor: new RegExp(`^\\s*${blockName}_install do \\|installer\\|`),
-        offset: 1,
+        newSrc: [
+            `$RNMapboxMapsImpl = '${RNMapboxMapsImpl}'`,
+            `$RNMapboxMapsDownloadToken = '${RNMapboxMapsDownloadToken}'`,
+        ].join('\n'),
+        anchor: /target .+ do/,
+        // We can't go after the use_react_native block because it might have parameters, causing it to be multi-line (see react-native template).
+        offset: 0,
         comment: '#',
     }).contents;
-}
+};
+exports.addConstantBlock = addConstantBlock;
+// Only the preinstaller block is required, the post installer block is
+// used for spm (swift package manager) which Expo doesn't currently support.
+const applyCocoaPodsModifications = (contents, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken }) => {
+    // Ensure installer blocks exist
+    let src = (0, exports.addConstantBlock)(contents, RNMapboxMapsImpl, RNMapboxMapsDownloadToken);
+    src = (0, exports.addInstallerBlock)(src, 'pre');
+    src = (0, exports.addInstallerBlock)(src, 'post');
+    src = (0, exports.addMapboxInstallerBlock)(src, 'pre');
+    src = (0, exports.addMapboxInstallerBlock)(src, 'post');
+    return src;
+};
+exports.applyCocoaPodsModifications = applyCocoaPodsModifications;
+const addMapboxInstallerBlock = (src, blockName) => (0, generateCode_1.mergeContents)({
+    tag: `@rnmapbox/maps-${blockName}_installer`,
+    src,
+    newSrc: `    $RNMapboxMaps.${blockName}_install(installer)`,
+    anchor: new RegExp(`^\\s*${blockName}_install do \\|installer\\|`),
+    offset: 1,
+    comment: '#',
+}).contents;
 exports.addMapboxInstallerBlock = addMapboxInstallerBlock;
+/**
+ * Dangerously adds the custom installer hooks to the Podfile.
+ * In the future this should be removed in favor of some custom hooks provided by Expo autolinking.
+ *
+ * https://github.com/rnmapbox/maps/blob/main/ios/install.md#react-native--0600
+ */
+const withCocoaPodsInstallerBlocks = (config, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken }) => (0, config_plugins_1.withDangerousMod)(config, [
+    'ios',
+    async (exportedConfig) => {
+        const file = path_1.default.join(exportedConfig.modRequest.platformProjectRoot, 'Podfile');
+        const contents = await fs_1.promises.readFile(file, 'utf8');
+        await fs_1.promises.writeFile(file, (0, exports.applyCocoaPodsModifications)(contents, {
+            RNMapboxMapsImpl,
+            RNMapboxMapsDownloadToken,
+        }), 'utf-8');
+        return exportedConfig;
+    },
+]);
 /**
  * Exclude building for arm64 on simulator devices in the pbxproj project.
  * Without this, production builds targeting simulators will fail.
  */
-function setExcludedArchitectures(project) {
+const setExcludedArchitectures = (project) => {
     const configurations = project.pbxXCBuildConfigurationSection();
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     for (const { buildSettings } of Object.values(configurations || {})) {
         // Guessing that this is the best way to emulate Xcode.
         // Using `project.addToBuildSettings` modifies too many targets.
@@ -132,68 +124,55 @@ function setExcludedArchitectures(project) {
         }
     }
     return project;
-}
-exports.setExcludedArchitectures = setExcludedArchitectures;
-const withExcludedSimulatorArchitectures = (c) => {
-    return (0, config_plugins_1.withXcodeProject)(c, (config) => {
-        config.modResults = setExcludedArchitectures(config.modResults);
-        return config;
-    });
 };
+exports.setExcludedArchitectures = setExcludedArchitectures;
+const withExcludedSimulatorArchitectures = (config) => (0, config_plugins_1.withXcodeProject)(config, (exportedConfig) => {
+    exportedConfig.modResults = (0, exports.setExcludedArchitectures)(exportedConfig.modResults);
+    return exportedConfig;
+});
 const withAndroidPropertiesDownloadToken = (config, { RNMapboxMapsDownloadToken }) => {
     const key = 'MAPBOX_DOWNLOADS_TOKEN';
     if (RNMapboxMapsDownloadToken) {
-        return (0, config_plugins_1.withGradleProperties)(config, (config) => {
-            config.modResults = config.modResults.filter((item) => {
-                if (item.type === 'property' && item.key === key) {
-                    return false;
-                }
-                return true;
-            });
-            config.modResults.push({
+        return (0, config_plugins_1.withGradleProperties)(config, (exportedConfig) => {
+            exportedConfig.modResults = exportedConfig.modResults.filter((item) => !(item.type === 'property' && item.key === key));
+            exportedConfig.modResults.push({
                 type: 'property',
                 key,
                 value: RNMapboxMapsDownloadToken,
             });
-            return config;
+            return exportedConfig;
         });
     }
-    else {
-        return config;
-    }
+    return config;
 };
 const withAndroidPropertiesImpl2 = (config, { RNMapboxMapsImpl }) => {
     const key = 'expoRNMapboxMapsImpl';
     if (RNMapboxMapsImpl) {
-        return (0, config_plugins_1.withGradleProperties)(config, (config) => {
-            config.modResults = config.modResults.filter((item) => {
-                if (item.type === 'property' && item.key === key) {
-                    return false;
-                }
-                return true;
-            });
-            config.modResults.push({
+        return (0, config_plugins_1.withGradleProperties)(config, (exportedConfig) => {
+            exportedConfig.modResults = exportedConfig.modResults.filter((item) => !(item.type === 'property' && item.key === key));
+            exportedConfig.modResults.push({
                 type: 'property',
                 key: key,
                 value: RNMapboxMapsImpl,
             });
-            return config;
+            return exportedConfig;
         });
     }
-    else {
-        return config;
-    }
+    return config;
 };
 const withAndroidProperties = (config, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken }) => {
     config = withAndroidPropertiesDownloadToken(config, {
         RNMapboxMapsDownloadToken,
     });
-    config = withAndroidPropertiesImpl2(config, { RNMapboxMapsImpl });
+    config = withAndroidPropertiesImpl2(config, {
+        RNMapboxMapsImpl,
+    });
     return config;
 };
 const addLibCppFilter = (appBuildGradle) => {
-    if (appBuildGradle.includes("pickFirst 'lib/x86/libc++_shared.so'"))
+    if (appBuildGradle.includes("pickFirst 'lib/x86/libc++_shared.so'")) {
         return appBuildGradle;
+    }
     return (0, generateCode_1.mergeContents)({
         tag: `@rnmapbox/maps-libcpp`,
         src: appBuildGradle,
@@ -226,7 +205,7 @@ allprojects {
 }
 `;
 // Fork of config-plugins mergeContents, but appends the contents to the end of the file.
-function appendContents({ src, newSrc, tag, comment, }) {
+const appendContents = ({ src, newSrc, tag, comment, }) => {
     const header = (0, generateCode_1.createGeneratedHeaderComment)(newSrc, tag, comment);
     if (!src.includes(header)) {
         // Ensure the old generated contents are removed.
@@ -246,37 +225,31 @@ function appendContents({ src, newSrc, tag, comment, }) {
         };
     }
     return { contents: src, didClear: false, didMerge: false };
-}
-function addMapboxMavenRepo(src) {
-    return appendContents({
-        tag: '@rnmapbox/maps-v2-maven',
-        src,
-        newSrc: gradleMaven,
-        comment: '//',
-    }).contents;
-}
+};
+const addMapboxMavenRepo = (src) => appendContents({
+    tag: '@rnmapbox/maps-v2-maven',
+    src,
+    newSrc: gradleMaven,
+    comment: '//',
+}).contents;
 exports.addMapboxMavenRepo = addMapboxMavenRepo;
-exports._addMapboxMavenRepo = addMapboxMavenRepo;
-const withAndroidAppGradle = (config) => {
-    return (0, config_plugins_1.withAppBuildGradle)(config, ({ modResults, ...config }) => {
-        if (modResults.language !== 'groovy') {
-            config_plugins_1.WarningAggregator.addWarningAndroid('withMapbox', `Cannot automatically configure app build.gradle if it's not groovy`);
-            return { modResults, ...config };
-        }
-        modResults.contents = addLibCppFilter(modResults.contents);
-        return { modResults, ...config };
-    });
-};
-const withAndroidProjectGradle = (config) => {
-    return (0, config_plugins_1.withProjectBuildGradle)(config, ({ modResults, ...config }) => {
-        if (modResults.language !== 'groovy') {
-            config_plugins_1.WarningAggregator.addWarningAndroid('withMapbox', `Cannot automatically configure app build.gradle if it's not groovy`);
-            return { modResults, ...config };
-        }
-        modResults.contents = addMapboxMavenRepo(modResults.contents);
-        return { modResults, ...config };
-    });
-};
+exports._addMapboxMavenRepo = exports.addMapboxMavenRepo;
+const withAndroidAppGradle = (config) => (0, config_plugins_1.withAppBuildGradle)(config, ({ modResults, ...exportedConfig }) => {
+    if (modResults.language !== 'groovy') {
+        config_plugins_1.WarningAggregator.addWarningAndroid('withMapbox', `Cannot automatically configure app build.gradle if it's not groovy`);
+        return { modResults, ...exportedConfig };
+    }
+    modResults.contents = addLibCppFilter(modResults.contents);
+    return { modResults, ...exportedConfig };
+});
+const withAndroidProjectGradle = (config) => (0, config_plugins_1.withProjectBuildGradle)(config, ({ modResults, ...exportedConfig }) => {
+    if (modResults.language !== 'groovy') {
+        config_plugins_1.WarningAggregator.addWarningAndroid('withMapbox', `Cannot automatically configure app build.gradle if it's not groovy`);
+        return { modResults, ...exportedConfig };
+    }
+    modResults.contents = (0, exports.addMapboxMavenRepo)(modResults.contents);
+    return { modResults, ...exportedConfig };
+});
 const withMapboxAndroid = (config, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken }) => {
     config = withAndroidProperties(config, {
         RNMapboxMapsImpl,
@@ -292,9 +265,10 @@ const withMapbox = (config, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken }) => 
         RNMapboxMapsImpl,
         RNMapboxMapsDownloadToken,
     });
-    return withCocoaPodsInstallerBlocks(config, {
+    config = withCocoaPodsInstallerBlocks(config, {
         RNMapboxMapsImpl,
         RNMapboxMapsDownloadToken,
     });
+    return config;
 };
 exports.default = (0, config_plugins_1.createRunOncePlugin)(withMapbox, pkg.name, pkg.version);

--- a/plugin/build/withMapbox.js
+++ b/plugin/build/withMapbox.js
@@ -46,7 +46,7 @@ const addInstallerBlock = (src, blockName) => {
     }).contents;
 };
 exports.addInstallerBlock = addInstallerBlock;
-const addConstantBlock = (src, RNMapboxMapsImpl, RNMapboxMapsDownloadToken) => {
+const addConstantBlock = (src, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, }) => {
     const tag = `@rnmapbox/maps-rnmapboxmapsimpl`;
     if (RNMapboxMapsImpl == null) {
         const modified = (0, generateCode_1.removeGeneratedContents)(src, tag);
@@ -62,6 +62,7 @@ const addConstantBlock = (src, RNMapboxMapsImpl, RNMapboxMapsDownloadToken) => {
         src,
         newSrc: [
             `$RNMapboxMapsImpl = '${RNMapboxMapsImpl}'`,
+            `$RNMapboxMapsVersion = '${RNMapboxMapsVersion}'`,
             `$RNMapboxMapsDownloadToken = '${RNMapboxMapsDownloadToken}'`,
         ].join('\n'),
         anchor: /target .+ do/,
@@ -73,9 +74,13 @@ const addConstantBlock = (src, RNMapboxMapsImpl, RNMapboxMapsDownloadToken) => {
 exports.addConstantBlock = addConstantBlock;
 // Only the preinstaller block is required, the post installer block is
 // used for spm (swift package manager) which Expo doesn't currently support.
-const applyCocoaPodsModifications = (contents, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken }) => {
+const applyCocoaPodsModifications = (contents, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, }) => {
     // Ensure installer blocks exist
-    let src = (0, exports.addConstantBlock)(contents, RNMapboxMapsImpl, RNMapboxMapsDownloadToken);
+    let src = (0, exports.addConstantBlock)(contents, {
+        RNMapboxMapsImpl,
+        RNMapboxMapsVersion,
+        RNMapboxMapsDownloadToken,
+    });
     src = (0, exports.addInstallerBlock)(src, 'pre');
     src = (0, exports.addInstallerBlock)(src, 'post');
     src = (0, exports.addMapboxInstallerBlock)(src, 'pre');
@@ -98,13 +103,14 @@ exports.addMapboxInstallerBlock = addMapboxInstallerBlock;
  *
  * https://github.com/rnmapbox/maps/blob/main/ios/install.md#react-native--0600
  */
-const withCocoaPodsInstallerBlocks = (config, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken }) => (0, config_plugins_1.withDangerousMod)(config, [
+const withCocoaPodsInstallerBlocks = (config, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken }) => (0, config_plugins_1.withDangerousMod)(config, [
     'ios',
     async (exportedConfig) => {
         const file = path_1.default.join(exportedConfig.modRequest.platformProjectRoot, 'Podfile');
         const contents = await fs_1.promises.readFile(file, 'utf8');
         await fs_1.promises.writeFile(file, (0, exports.applyCocoaPodsModifications)(contents, {
             RNMapboxMapsImpl,
+            RNMapboxMapsVersion,
             RNMapboxMapsDownloadToken,
         }), 'utf-8');
         return exportedConfig;
@@ -259,14 +265,16 @@ const withMapboxAndroid = (config, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken
     config = withAndroidAppGradle(config, { RNMapboxMapsImpl });
     return config;
 };
-const withMapbox = (config, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken }) => {
+const withMapbox = (config, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken }) => {
     config = withExcludedSimulatorArchitectures(config);
     config = withMapboxAndroid(config, {
         RNMapboxMapsImpl,
+        RNMapboxMapsVersion,
         RNMapboxMapsDownloadToken,
     });
     config = withCocoaPodsInstallerBlocks(config, {
         RNMapboxMapsImpl,
+        RNMapboxMapsVersion,
         RNMapboxMapsDownloadToken,
     });
     return config;

--- a/plugin/install.md
+++ b/plugin/install.md
@@ -52,6 +52,27 @@ For `mapbox` or `mapbox-gl` you'll need to provide `RNMapboxMapsDownloadToken` a
 
 Next, rebuild your app as described in the ["Adding custom native code"](https://docs.expo.io/workflow/customizing/) guide.
 
+### Advanced Configuration
+
+For `mapbox` or `mapbox-gl` on iOS it's possible to overwrite the native SDK version with `RNMapboxMapsVersion`:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "@rnmapbox/maps",
+        {
+          "RNMapboxMapsImpl": "mapbox",
+          "RNMapboxMapsVersion": "10.XX.XX",
+          "RNMapboxMapsDownloadToken": "sk.ey...qg"
+        }
+      ]
+    ]
+  }
+}
+```
+
 ## Manual Setup
 
 For bare workflow projects, you can follow the manual setup guides:

--- a/plugin/src/withMapbox.ts
+++ b/plugin/src/withMapbox.ts
@@ -33,7 +33,12 @@ type InstallerBlockName = 'pre' | 'post';
 
 export type MapboxPlugProps = {
   RNMapboxMapsImpl?: string;
+
+  /**
+   * @platform ios
+   */
   RNMapboxMapsVersion?: string;
+
   RNMapboxMapsDownloadToken?: string;
 };
 

--- a/plugin/src/withMapbox.ts
+++ b/plugin/src/withMapbox.ts
@@ -36,93 +36,13 @@ export type MapboxPlugProps = {
   RNMapboxMapsDownloadToken?: string;
 };
 
-/**
- * Dangerously adds the custom installer hooks to the Podfile.
- * In the future this should be removed in favor of some custom hooks provided by Expo autolinking.
- *
- * https://github.com/rnmapbox/maps/blob/main/ios/install.md#react-native--0600
- * @param config
- * @returns
- */
-const withCocoaPodsInstallerBlocks: ConfigPlugin<MapboxPlugProps> = (
-  c,
-  { RNMapboxMapsImpl, RNMapboxMapsDownloadToken },
-) => {
-  return withDangerousMod(c, [
-    'ios',
-    async (config) => {
-      const file = path.join(config.modRequest.platformProjectRoot, 'Podfile');
-
-      const contents = await promises.readFile(file, 'utf8');
-
-      await promises.writeFile(
-        file,
-        applyCocoaPodsModifications(contents, {
-          RNMapboxMapsImpl,
-          RNMapboxMapsDownloadToken,
-        }),
-        'utf-8',
-      );
-      return config;
-    },
-  ]);
-};
-
-// Only the preinstaller block is required, the post installer block is
-// used for spm (swift package manager) which Expo doesn't currently support.
-export function applyCocoaPodsModifications(
-  contents: string,
-  { RNMapboxMapsImpl, RNMapboxMapsDownloadToken }: MapboxPlugProps,
-): string {
-  // Ensure installer blocks exist
-  let src = addConstantBlock(
-    contents,
-    RNMapboxMapsImpl,
-    RNMapboxMapsDownloadToken,
-  );
-  src = addInstallerBlock(src, 'pre');
-  src = addInstallerBlock(src, 'post');
-  src = addMapboxInstallerBlock(src, 'pre');
-  src = addMapboxInstallerBlock(src, 'post');
-  return src;
-}
-
-export function addConstantBlock(
-  src: string,
-  RNMapboxMapsImpl?: string,
-  RNMapboxMapsDownloadToken?: string,
-): string {
-  const tag = `@rnmapbox/maps-rnmapboxmapsimpl`;
-
-  if (RNMapboxMapsImpl == null) {
-    const modified = removeGeneratedContents(src, tag);
-    if (!modified) {
-      return src;
-    } else {
-      return modified;
-    }
-  }
-
-  return mergeContents({
-    tag,
-    src,
-    newSrc: [
-      `$RNMapboxMapsImpl = '${RNMapboxMapsImpl}'`,
-      `$RNMapboxMapsDownloadToken = '${RNMapboxMapsDownloadToken}'`,
-    ].join('\n'),
-    anchor: /target .+ do/,
-    // We can't go after the use_react_native block because it might have parameters, causing it to be multi-line (see react-native template).
-    offset: 0,
-    comment: '#',
-  }).contents;
-}
-
-export function addInstallerBlock(
+export const addInstallerBlock = (
   src: string,
   blockName: InstallerBlockName,
-): string {
+): string => {
   const matchBlock = new RegExp(`${blockName}_install do \\|installer\\|`);
   const tag = `${blockName}_installer`;
+
   for (const line of src.split('\n')) {
     const contents = line.trim();
     // Ignore comments
@@ -148,13 +68,63 @@ export function addInstallerBlock(
     offset: 0,
     comment: '#',
   }).contents;
-}
+};
 
-export function addMapboxInstallerBlock(
+export const addConstantBlock = (
+  src: string,
+  RNMapboxMapsImpl?: string,
+  RNMapboxMapsDownloadToken?: string,
+): string => {
+  const tag = `@rnmapbox/maps-rnmapboxmapsimpl`;
+
+  if (RNMapboxMapsImpl == null) {
+    const modified = removeGeneratedContents(src, tag);
+    if (!modified) {
+      return src;
+    } else {
+      return modified;
+    }
+  }
+
+  return mergeContents({
+    tag,
+    src,
+    newSrc: [
+      `$RNMapboxMapsImpl = '${RNMapboxMapsImpl}'`,
+      `$RNMapboxMapsDownloadToken = '${RNMapboxMapsDownloadToken}'`,
+    ].join('\n'),
+    anchor: /target .+ do/,
+    // We can't go after the use_react_native block because it might have parameters, causing it to be multi-line (see react-native template).
+    offset: 0,
+    comment: '#',
+  }).contents;
+};
+
+// Only the preinstaller block is required, the post installer block is
+// used for spm (swift package manager) which Expo doesn't currently support.
+export const applyCocoaPodsModifications = (
+  contents: string,
+  { RNMapboxMapsImpl, RNMapboxMapsDownloadToken }: MapboxPlugProps,
+): string => {
+  // Ensure installer blocks exist
+  let src = addConstantBlock(
+    contents,
+    RNMapboxMapsImpl,
+    RNMapboxMapsDownloadToken,
+  );
+  src = addInstallerBlock(src, 'pre');
+  src = addInstallerBlock(src, 'post');
+  src = addMapboxInstallerBlock(src, 'pre');
+  src = addMapboxInstallerBlock(src, 'post');
+
+  return src;
+};
+
+export const addMapboxInstallerBlock = (
   src: string,
   blockName: InstallerBlockName,
-): string {
-  return mergeContents({
+): string =>
+  mergeContents({
     tag: `@rnmapbox/maps-${blockName}_installer`,
     src,
     newSrc: `    $RNMapboxMaps.${blockName}_install(installer)`,
@@ -162,16 +132,48 @@ export function addMapboxInstallerBlock(
     offset: 1,
     comment: '#',
   }).contents;
-}
+
+/**
+ * Dangerously adds the custom installer hooks to the Podfile.
+ * In the future this should be removed in favor of some custom hooks provided by Expo autolinking.
+ *
+ * https://github.com/rnmapbox/maps/blob/main/ios/install.md#react-native--0600
+ */
+const withCocoaPodsInstallerBlocks: ConfigPlugin<MapboxPlugProps> = (
+  config,
+  { RNMapboxMapsImpl, RNMapboxMapsDownloadToken },
+) =>
+  withDangerousMod(config, [
+    'ios',
+    async (exportedConfig) => {
+      const file = path.join(
+        exportedConfig.modRequest.platformProjectRoot,
+        'Podfile',
+      );
+
+      const contents = await promises.readFile(file, 'utf8');
+      await promises.writeFile(
+        file,
+        applyCocoaPodsModifications(contents, {
+          RNMapboxMapsImpl,
+          RNMapboxMapsDownloadToken,
+        }),
+        'utf-8',
+      );
+
+      return exportedConfig;
+    },
+  ]);
 
 /**
  * Exclude building for arm64 on simulator devices in the pbxproj project.
  * Without this, production builds targeting simulators will fail.
  */
-export function setExcludedArchitectures(project: XcodeProject): XcodeProject {
-  const configurations = project.pbxXCBuildConfigurationSection();
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+export const setExcludedArchitectures: (
+  project: XcodeProject,
+) => XcodeProject = (project: XcodeProject): XcodeProject => {
+  const configurations: { buildSettings: Record<string, string> }[] =
+    project.pbxXCBuildConfigurationSection();
   for (const { buildSettings } of Object.values(configurations || {})) {
     // Guessing that this is the best way to emulate Xcode.
     // Using `project.addToBuildSettings` modifies too many targets.
@@ -181,39 +183,39 @@ export function setExcludedArchitectures(project: XcodeProject): XcodeProject {
   }
 
   return project;
-}
-
-const withExcludedSimulatorArchitectures: ConfigPlugin = (c) => {
-  return withXcodeProject(c, (config) => {
-    config.modResults = setExcludedArchitectures(config.modResults);
-    return config;
-  });
 };
+
+const withExcludedSimulatorArchitectures: ConfigPlugin = (config) =>
+  withXcodeProject(config, (exportedConfig) => {
+    exportedConfig.modResults = setExcludedArchitectures(
+      exportedConfig.modResults,
+    );
+
+    return exportedConfig;
+  });
 
 const withAndroidPropertiesDownloadToken: ConfigPlugin<MapboxPlugProps> = (
   config,
   { RNMapboxMapsDownloadToken },
 ) => {
   const key = 'MAPBOX_DOWNLOADS_TOKEN';
+
   if (RNMapboxMapsDownloadToken) {
-    return withGradleProperties(config, (config) => {
-      config.modResults = config.modResults.filter((item) => {
-        if (item.type === 'property' && item.key === key) {
-          return false;
-        }
-        return true;
-      });
-      config.modResults.push({
+    return withGradleProperties(config, (exportedConfig) => {
+      exportedConfig.modResults = exportedConfig.modResults.filter(
+        (item) => !(item.type === 'property' && item.key === key),
+      );
+      exportedConfig.modResults.push({
         type: 'property',
         key,
         value: RNMapboxMapsDownloadToken,
       });
 
-      return config;
+      return exportedConfig;
     });
-  } else {
-    return config;
   }
+
+  return config;
 };
 
 const withAndroidPropertiesImpl2: ConfigPlugin<MapboxPlugProps> = (
@@ -221,25 +223,23 @@ const withAndroidPropertiesImpl2: ConfigPlugin<MapboxPlugProps> = (
   { RNMapboxMapsImpl },
 ) => {
   const key = 'expoRNMapboxMapsImpl';
+
   if (RNMapboxMapsImpl) {
-    return withGradleProperties(config, (config) => {
-      config.modResults = config.modResults.filter((item) => {
-        if (item.type === 'property' && item.key === key) {
-          return false;
-        }
-        return true;
-      });
-      config.modResults.push({
+    return withGradleProperties(config, (exportedConfig) => {
+      exportedConfig.modResults = exportedConfig.modResults.filter(
+        (item) => !(item.type === 'property' && item.key === key),
+      );
+      exportedConfig.modResults.push({
         type: 'property',
         key: key,
         value: RNMapboxMapsImpl,
       });
 
-      return config;
+      return exportedConfig;
     });
-  } else {
-    return config;
   }
+
+  return config;
 };
 
 const withAndroidProperties: ConfigPlugin<MapboxPlugProps> = (
@@ -249,13 +249,18 @@ const withAndroidProperties: ConfigPlugin<MapboxPlugProps> = (
   config = withAndroidPropertiesDownloadToken(config, {
     RNMapboxMapsDownloadToken,
   });
-  config = withAndroidPropertiesImpl2(config, { RNMapboxMapsImpl });
+  config = withAndroidPropertiesImpl2(config, {
+    RNMapboxMapsImpl,
+  });
+
   return config;
 };
 
 const addLibCppFilter = (appBuildGradle: string): string => {
-  if (appBuildGradle.includes("pickFirst 'lib/x86/libc++_shared.so'"))
+  if (appBuildGradle.includes("pickFirst 'lib/x86/libc++_shared.so'")) {
     return appBuildGradle;
+  }
+
   return mergeContents({
     tag: `@rnmapbox/maps-libcpp`,
     src: appBuildGradle,
@@ -290,7 +295,7 @@ allprojects {
 `;
 
 // Fork of config-plugins mergeContents, but appends the contents to the end of the file.
-function appendContents({
+const appendContents = ({
   src,
   newSrc,
   tag,
@@ -300,8 +305,9 @@ function appendContents({
   newSrc: string;
   tag: string;
   comment: string;
-}): MergeResults {
+}): MergeResults => {
   const header = createGeneratedHeaderComment(newSrc, tag, comment);
+
   if (!src.includes(header)) {
     // Ensure the old generated contents are removed.
     const sanitizedTarget = removeGeneratedContents(src, tag);
@@ -320,47 +326,49 @@ function appendContents({
       didClear: !!sanitizedTarget,
     };
   }
-  return { contents: src, didClear: false, didMerge: false };
-}
 
-export function addMapboxMavenRepo(src: string): string {
-  return appendContents({
+  return { contents: src, didClear: false, didMerge: false };
+};
+
+export const addMapboxMavenRepo = (src: string): string =>
+  appendContents({
     tag: '@rnmapbox/maps-v2-maven',
     src,
     newSrc: gradleMaven,
     comment: '//',
   }).contents;
-}
 
-const withAndroidAppGradle: ConfigPlugin<MapboxPlugProps> = (config) => {
-  return withAppBuildGradle(config, ({ modResults, ...config }) => {
+const withAndroidAppGradle: ConfigPlugin<MapboxPlugProps> = (config) =>
+  withAppBuildGradle(config, ({ modResults, ...exportedConfig }) => {
     if (modResults.language !== 'groovy') {
       WarningAggregator.addWarningAndroid(
         'withMapbox',
         `Cannot automatically configure app build.gradle if it's not groovy`,
       );
-      return { modResults, ...config };
+
+      return { modResults, ...exportedConfig };
     }
 
     modResults.contents = addLibCppFilter(modResults.contents);
-    return { modResults, ...config };
-  });
-};
 
-const withAndroidProjectGradle: ConfigPlugin<MapboxPlugProps> = (config) => {
-  return withProjectBuildGradle(config, ({ modResults, ...config }) => {
+    return { modResults, ...exportedConfig };
+  });
+
+const withAndroidProjectGradle: ConfigPlugin<MapboxPlugProps> = (config) =>
+  withProjectBuildGradle(config, ({ modResults, ...exportedConfig }) => {
     if (modResults.language !== 'groovy') {
       WarningAggregator.addWarningAndroid(
         'withMapbox',
         `Cannot automatically configure app build.gradle if it's not groovy`,
       );
-      return { modResults, ...config };
+
+      return { modResults, ...exportedConfig };
     }
 
     modResults.contents = addMapboxMavenRepo(modResults.contents);
-    return { modResults, ...config };
+
+    return { modResults, ...exportedConfig };
   });
-};
 
 const withMapboxAndroid: ConfigPlugin<MapboxPlugProps> = (
   config,
@@ -372,6 +380,7 @@ const withMapboxAndroid: ConfigPlugin<MapboxPlugProps> = (
   });
   config = withAndroidProjectGradle(config, { RNMapboxMapsImpl });
   config = withAndroidAppGradle(config, { RNMapboxMapsImpl });
+
   return config;
 };
 
@@ -384,10 +393,12 @@ const withMapbox: ConfigPlugin<MapboxPlugProps> = (
     RNMapboxMapsImpl,
     RNMapboxMapsDownloadToken,
   });
-  return withCocoaPodsInstallerBlocks(config, {
+  config = withCocoaPodsInstallerBlocks(config, {
     RNMapboxMapsImpl,
     RNMapboxMapsDownloadToken,
   });
+
+  return config;
 };
 
 export default createRunOncePlugin(withMapbox, pkg.name, pkg.version);

--- a/plugin/src/withMapbox.ts
+++ b/plugin/src/withMapbox.ts
@@ -33,6 +33,7 @@ type InstallerBlockName = 'pre' | 'post';
 
 export type MapboxPlugProps = {
   RNMapboxMapsImpl?: string;
+  RNMapboxMapsVersion?: string;
   RNMapboxMapsDownloadToken?: string;
 };
 
@@ -72,8 +73,11 @@ export const addInstallerBlock = (
 
 export const addConstantBlock = (
   src: string,
-  RNMapboxMapsImpl?: string,
-  RNMapboxMapsDownloadToken?: string,
+  {
+    RNMapboxMapsImpl,
+    RNMapboxMapsVersion,
+    RNMapboxMapsDownloadToken,
+  }: MapboxPlugProps,
 ): string => {
   const tag = `@rnmapbox/maps-rnmapboxmapsimpl`;
 
@@ -91,6 +95,7 @@ export const addConstantBlock = (
     src,
     newSrc: [
       `$RNMapboxMapsImpl = '${RNMapboxMapsImpl}'`,
+      `$RNMapboxMapsVersion = '${RNMapboxMapsVersion}'`,
       `$RNMapboxMapsDownloadToken = '${RNMapboxMapsDownloadToken}'`,
     ].join('\n'),
     anchor: /target .+ do/,
@@ -104,14 +109,18 @@ export const addConstantBlock = (
 // used for spm (swift package manager) which Expo doesn't currently support.
 export const applyCocoaPodsModifications = (
   contents: string,
-  { RNMapboxMapsImpl, RNMapboxMapsDownloadToken }: MapboxPlugProps,
+  {
+    RNMapboxMapsImpl,
+    RNMapboxMapsVersion,
+    RNMapboxMapsDownloadToken,
+  }: MapboxPlugProps,
 ): string => {
   // Ensure installer blocks exist
-  let src = addConstantBlock(
-    contents,
+  let src = addConstantBlock(contents, {
     RNMapboxMapsImpl,
+    RNMapboxMapsVersion,
     RNMapboxMapsDownloadToken,
-  );
+  });
   src = addInstallerBlock(src, 'pre');
   src = addInstallerBlock(src, 'post');
   src = addMapboxInstallerBlock(src, 'pre');
@@ -141,7 +150,7 @@ export const addMapboxInstallerBlock = (
  */
 const withCocoaPodsInstallerBlocks: ConfigPlugin<MapboxPlugProps> = (
   config,
-  { RNMapboxMapsImpl, RNMapboxMapsDownloadToken },
+  { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken },
 ) =>
   withDangerousMod(config, [
     'ios',
@@ -156,6 +165,7 @@ const withCocoaPodsInstallerBlocks: ConfigPlugin<MapboxPlugProps> = (
         file,
         applyCocoaPodsModifications(contents, {
           RNMapboxMapsImpl,
+          RNMapboxMapsVersion,
           RNMapboxMapsDownloadToken,
         }),
         'utf-8',
@@ -386,15 +396,17 @@ const withMapboxAndroid: ConfigPlugin<MapboxPlugProps> = (
 
 const withMapbox: ConfigPlugin<MapboxPlugProps> = (
   config,
-  { RNMapboxMapsImpl, RNMapboxMapsDownloadToken },
+  { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken },
 ) => {
   config = withExcludedSimulatorArchitectures(config);
   config = withMapboxAndroid(config, {
     RNMapboxMapsImpl,
+    RNMapboxMapsVersion,
     RNMapboxMapsDownloadToken,
   });
   config = withCocoaPodsInstallerBlocks(config, {
     RNMapboxMapsImpl,
+    RNMapboxMapsVersion,
     RNMapboxMapsDownloadToken,
   });
 


### PR DESCRIPTION
## Description

Fixes: #2618 (iOS only, as RNMapboxMapsVersion not yet implemented on Android)

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
