### PR TITLE
fix(expo,ios): add RNMapboxMapsVersion only when defined

### DIFF
--- a/plugin/build/withMapbox.js
+++ b/plugin/build/withMapbox.js
@@ -57,14 +57,17 @@ const addConstantBlock = (src, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapbox
             return modified;
         }
     }
+    const newSrc = [
+        `$RNMapboxMapsImpl = '${RNMapboxMapsImpl}'`,
+        `$RNMapboxMapsDownloadToken = '${RNMapboxMapsDownloadToken}'`,
+    ];
+    if (RNMapboxMapsVersion) {
+        newSrc.push(`$RNMapboxMapsVersion = '${RNMapboxMapsVersion}'`);
+    }
     return (0, generateCode_1.mergeContents)({
         tag,
         src,
-        newSrc: [
-            `$RNMapboxMapsImpl = '${RNMapboxMapsImpl}'`,
-            `$RNMapboxMapsVersion = '${RNMapboxMapsVersion}'`,
-            `$RNMapboxMapsDownloadToken = '${RNMapboxMapsDownloadToken}'`,
-        ].join('\n'),
+        newSrc: newSrc.join('\n'),
         anchor: /target .+ do/,
         // We can't go after the use_react_native block because it might have parameters, causing it to be multi-line (see react-native template).
         offset: 0,

--- a/plugin/src/withMapbox.ts
+++ b/plugin/src/withMapbox.ts
@@ -95,14 +95,19 @@ export const addConstantBlock = (
     }
   }
 
+  const newSrc = [
+    `$RNMapboxMapsImpl = '${RNMapboxMapsImpl}'`,
+    `$RNMapboxMapsDownloadToken = '${RNMapboxMapsDownloadToken}'`,
+  ];
+
+  if (RNMapboxMapsVersion) {
+    newSrc.push(`$RNMapboxMapsVersion = '${RNMapboxMapsVersion}'`);
+  }
+
   return mergeContents({
     tag,
     src,
-    newSrc: [
-      `$RNMapboxMapsImpl = '${RNMapboxMapsImpl}'`,
-      `$RNMapboxMapsVersion = '${RNMapboxMapsVersion}'`,
-      `$RNMapboxMapsDownloadToken = '${RNMapboxMapsDownloadToken}'`,
-    ].join('\n'),
+    newSrc: newSrc.join('\n'),
     anchor: /target .+ do/,
     // We can't go after the use_react_native block because it might have parameters, causing it to be multi-line (see react-native template).
     offset: 0,


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes https://github.com/rnmapbox/maps/pull/2693#issuecomment-1469614936

I've successfully built without supplying RNMapboxMapsVersion.

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
