### PR TITLE
fix(v10): type of `children` props from UserLocation.tsx

### DIFF
--- a/docs/UserLocation.md
+++ b/docs/UserLocation.md
@@ -7,7 +7,7 @@
 | ---- | :-- | :----- | :------ | :---------- |
 | androidRenderMode | `'normal' \| 'compass' \| 'gps'` | `none` | `false` | native/android only render mode<br/><br/> - normal: just a circle<br/> - compass: triangle with heading<br/> - gps: large arrow<br/><br/>@platform android |
 | animated | `boolean` | `true` | `false` | Whether location icon is animated between updates |
-| children | `ReactElement` | `none` | `false` | Custom location icon of type mapbox-gl-native components |
+| children | `ReactElement \| ReactElement[]` | `none` | `false` | Custom location icon of type mapbox-gl-native components |
 | minDisplacement | `number` | `0` | `false` | Minimum amount of movement before GPS location is updated in meters |
 | onPress | `func` | `none` | `false` | Callback that is triggered on location icon press<br/>*signature:*`() => void` |
 | onUpdate | `func` | `none` | `false` | Callback that is triggered on location update<br/>*signature:*`(location:Location) => void` |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -6243,7 +6243,7 @@
       {
         "name": "children",
         "required": false,
-        "type": "ReactElement",
+        "type": "ReactElement \\| ReactElement[]",
         "default": "none",
         "description": "Custom location icon of type mapbox-gl-native components"
       },

--- a/javascript/components/UserLocation.tsx
+++ b/javascript/components/UserLocation.tsx
@@ -82,7 +82,7 @@ type Props = {
   /**
    * Custom location icon of type mapbox-gl-native components
    */
-  children?: ReactElement;
+  children?: ReactElement | ReactElement[];
 
   /**
    * Minimum amount of movement before GPS location is updated in meters


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

I updated the type of the `children` props from UserLocation to `ReactElement | ReactElement[]`.
If you need to represent the UserLocation with multiple layers, you must pass them as an array of elements, similar to how the `normalIcon` function does:

```typescript
const normalIcon = (
  showsUserHeadingIndicator?: boolean,
  heading?: number | null,
): ReactElement[] => [
  <CircleLayer
    key="mapboxUserLocationPulseCircle"
    id="mapboxUserLocationPulseCircle"
    style={layerStyles.normal.pulse}
  />,
  <CircleLayer
    key="mapboxUserLocationWhiteCircle"
    id="mapboxUserLocationWhiteCircle"
    style={layerStyles.normal.background}
  />,
  <CircleLayer
    key="mapboxUserLocationBlueCircle"
    id="mapboxUserLocationBlueCircle"
    aboveLayerID="mapboxUserLocationWhiteCircle"
    style={layerStyles.normal.foreground}
  />,
  ...(showsUserHeadingIndicator && typeof heading === 'number'
    ? [HeadingIndicator({ heading, key: 'mapboxUserLocationHeadingIndicator' })]
    : []),
];
```

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
- [x] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
