### PR TITLE
fix(android,v10): fix leak

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/camera/CameraUpdateQueue.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/camera/CameraUpdateQueue.kt
@@ -55,9 +55,7 @@ class CameraUpdateQueue {
 
     fun execute(map: RCTMGLMapView?) {
         if (mQueue.isEmpty()) {
-            if (mCompleteListener != null) {
-                mCompleteListener!!.onCompleteAll()
-            }
+            mCompleteListener?.let { it.onCompleteAll() }
             return
         }
         val stop = mQueue.poll() ?: return

--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/camera/RCTMGLCamera.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/camera/RCTMGLCamera.kt
@@ -39,7 +39,7 @@ class RCTMGLCamera(private val mContext: Context, private val mManager: RCTMGLCa
     private var hasSentFirstRegion = false
     private var mDefaultStop: CameraStop? = null
     private var mCameraStop: CameraStop? = null
-    private val mCameraUpdateQueue: CameraUpdateQueue
+    private val mCameraUpdateQueue = CameraUpdateQueue()
 
     /*
     // private LocationComponent mLocationComponent;
@@ -66,17 +66,6 @@ class RCTMGLCamera(private val mContext: Context, private val mManager: RCTMGLCa
     private var mMaxBounds: LatLngBounds? = null
 
 
-    private val mLocationBearingChangedListener = OnIndicatorBearingChangedListener { v ->
-        if (mFollowUserLocation) {
-            mMapView!!.getMapboxMap().setCamera(CameraOptions.Builder().bearing(v).build())
-        }
-    }
-    private val mLocationPositionChangeListener = OnIndicatorPositionChangedListener { point ->
-        if (mFollowUserLocation) {
-            mMapView!!.getMapboxMap().setCamera(CameraOptions.Builder().center(point).build())
-            mMapView!!.gestures.focalPoint = mMapView!!.getMapboxMap().pixelForCoordinate(point)
-        }
-    }
     private val mCameraCallback: Animator.AnimatorListener = object : Animator.AnimatorListener {
         override fun onAnimationStart(animator: Animator) {}
         override fun onAnimationEnd(animator: Animator) {
@@ -110,9 +99,9 @@ class RCTMGLCamera(private val mContext: Context, private val mManager: RCTMGLCa
     }
     fun setStop(stop: CameraStop) {
         mCameraStop = stop
-        mCameraStop!!.setCallback(mCameraCallback)
+        stop.setCallback(mCameraCallback)
         if (mMapView != null) {
-            mCameraStop?.let { updateCamera(it) }
+            stop.let { updateCamera(it) }
         }
     }
 
@@ -221,7 +210,6 @@ class RCTMGLCamera(private val mContext: Context, private val mManager: RCTMGLCa
     }
 
     init {
-        mCameraUpdateQueue = CameraUpdateQueue()
         mLocationManager = getInstance(mContext)
     }
 

--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.kt
@@ -59,7 +59,7 @@ open class RCTMGLMapViewManager(context: ReactApplicationContext?) :
     }
 
     override fun removeViewAt(mapView: RCTMGLMapView?, index: Int) {
-        mapView!!.removeFeature(index)
+        mapView!!.removeFeatureAt(index)
     }
 
     override fun createViewInstance(themedReactContext: ThemedReactContext): RCTMGLMapView {


### PR DESCRIPTION
Fixes: #2591

The issue was that onDestroy we've removed all children, but RN needs the childrens to be reported correctly for correct cleanup, otherwise children such as Camera would be still kept in RN-s tagToView map, that prevented GC from freeing them. See:

https://github.com/facebook/react-native/blob/0a3c55562b5ba43b00c21ca4d7b2cba0c8eb6206/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.java#L74-L98

Example used:
```jsx
import React from 'react';
import { MapView, ShapeSource, LineLayer, Camera } from '@rnmapbox/maps';

const aLine = {
  type: 'LineString',
  coordinates: [
    [-74.00597, 40.71427],
    [-74.00697, 40.71527],
  ],
};

class BugReportExample extends React.Component {
  render() {
    return (
      <MapView style={{ flex: 1 }}>
        <Camera centerCoordinate={[-74.00597, 40.71427]} zoomLevel={14} />
        <ShapeSource id="idStreetLayer" shape={aLine}>
          <LineLayer id="idStreetLayer" />
        </ShapeSource>
      </MapView>
    );
  }
}

export default BugReportExample;
```

Opened example a few times:
![image](https://user-images.githubusercontent.com/52435/225531278-b5394e75-9615-4a75-80f9-3539f09fd973.png)

Also checked heat dump for objects with RCTMGL, only manager:
![image](https://user-images.githubusercontent.com/52435/225531595-eb20eea7-f5d8-42f9-bb91-e0f54f0389b3.png)
