### PR TITLE
fix: remove console.log from Terrain.tsx

### DIFF
--- a/src/components/Terrain.tsx
+++ b/src/components/Terrain.tsx
@@ -45,7 +45,6 @@ export const Terrain = memo((props: Props) => {
       style: undefined,
     };
   }, [props, style]);
-  console.log('BASE PROPS', baseProps);
 
   return <RCTMGLTerrain {...baseProps} />;
 });


### PR DESCRIPTION
## Description

Removes a `console.log` that I think was left in the code by mistake. It clutters the logs of any project using the `Terrain` component.

## Checklist

- [ ] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

I did none of the things above because the PR is so simple.
