### PR TITLE
improve `Position` type

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,5 @@
 module.exports = {
   singleQuote: true,
   trailingComma: 'all',
+  endOfLine: 'auto',
 };

--- a/src/components/Camera.tsx
+++ b/src/components/Camera.tsx
@@ -9,12 +9,11 @@ import React, {
 import { NativeModules, requireNativeComponent } from 'react-native';
 
 import { MapboxGLEvent } from '../types';
+import { Position } from '../types/Position';
 import { makeLatLngBounds, makePoint } from '../utils/geoUtils';
 import { type NativeRefType } from '../utils/nativeRef';
 
 const NativeModule = NativeModules.MGLModule;
-
-type Position = number[] | [number, number];
 
 export enum UserTrackingMode {
   Follow = 'normal',

--- a/src/components/ImageSource.tsx
+++ b/src/components/ImageSource.tsx
@@ -7,12 +7,11 @@ import {
   resolveImagePath,
 } from '../utils';
 import { BaseProps } from '../types/BaseProps';
+import { Position } from '../types/Position';
 
 import AbstractSource from './AbstractSource';
 
 export const NATIVE_MODULE_NAME = 'RCTMGLImageSource';
-
-type Position = [number, number];
 
 type Props = BaseProps & {
   /**

--- a/src/components/Style.tsx
+++ b/src/components/Style.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState, useEffect } from 'react';
 
 import { FilterExpression } from '../utils/MapboxStyles';
+import { Position } from '../types/Position';
 
 import CircleLayer from './CircleLayer';
 import RasterLayer from './RasterLayer';
@@ -252,12 +253,7 @@ type MapboxJSONSource = {
   attribution?: string;
   scheme?: string;
   tileSize?: number;
-  coordinates?: [
-    [number, number],
-    [number, number],
-    [number, number],
-    [number, number],
-  ];
+  coordinates?: [Position, Position, Position, Position];
   data?: string | object;
 
   buffer: number;

--- a/src/types/Position.ts
+++ b/src/types/Position.ts
@@ -1,1 +1,10 @@
-export type Position = [number, number] | number[];
+declare const __brand: unique symbol;
+
+type CreateBrandType<InputType, BrandName extends string> = InputType & {
+  [__brand]?: BrandName;
+};
+
+type Longitude = CreateBrandType<number, 'Longitude'>;
+type Latitude = CreateBrandType<number, 'Latitude'>;
+
+export type Position = [Longitude, Latitude];

--- a/src/web/components/Camera.tsx
+++ b/src/web/components/Camera.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
+import { Position } from '../../types/Position';
 import MapContext from '../MapContext';
 
 class Camera extends React.Component<{
-  centerCoordinate: [number, number] | null;
+  centerCoordinate: Position | null;
 }> {
   context!: React.ContextType<typeof MapContext>;
 
@@ -19,8 +20,8 @@ class Camera extends React.Component<{
   }
 
   fitBounds(
-    northEastCoordinates: [number, number],
-    southWestCoordinates: [number, number],
+    northEastCoordinates: Position,
+    southWestCoordinates: Position,
     padding = 0,
     animationDuration = 0.0,
   ) {


### PR DESCRIPTION
## Description

- Improve the `Position` type which currently only shows as `[number, number]` meaning that developers can easily input longitude and latitude the wrong way around (explanation tweet about how / why this works: https://twitter.com/bruno_crosier/status/1641859092204630016)
- Update the Prettier config to allow Windows users to contribute without <code>Delete `␍`</code> showing up on every line

