### PR TITLE
fix: two lint issues causing downstream build failures

### DIFF
--- a/android/rctmgl/src/main/AndroidManifest.xml
+++ b/android/rctmgl/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.mapbox.rctmgl">
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 </manifest>

--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/AbstractEventEmitter.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/AbstractEventEmitter.kt
@@ -46,7 +46,7 @@ abstract class AbstractEventEmitter<T : ViewGroup?>(reactApplicationContext: Rea
         )
     }
 
-    override fun addEventEmitters(context: ThemedReactContext, @Nonnull view: T) {
+    override fun addEventEmitters(context: ThemedReactContext, view: T) {
         mEventDispatcher = context.getNativeModule(UIManagerModule::class.java)!!.eventDispatcher
     }
 


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes a couple lint issues that were causing downstream build failures:

- Android builds could fail because only the `ACCESS_FINE_LOCATION` permission was granted in `AndroidManifest.xml`. I added the `ACCESS_COARSE_LOCATION` permission as well, which is required as described in the documentation here: https://developer.android.com/training/location/permissions#foreground
- Android builds could fail due to an erroneous use of the `@Nonnull` tag in Kotlin code

See the following failing builds, & one passing one using the code from this PR:
- https://github.com/techmatters/terraso-mobile-client/actions/runs/4681503761/jobs/8294181904
- https://github.com/techmatters/terraso-mobile-client/actions/runs/4681627748/jobs/8294453587
- https://github.com/techmatters/terraso-mobile-client/actions/runs/4682086212/jobs/8295876284

## Checklist

- [x] I have tested this on a device/simulator for each compatible OS