### PR TITLE
fix(android,v10,offline): add pixelRatio(2.0f) to allow offline with …

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/modules/RCTMGLOfflineModule.kt
@@ -287,6 +287,7 @@ class RCTMGLOfflineModule(private val mReactContext: ReactApplicationContext) :
             .minZoom(zoomRange.minZoom)
             .maxZoom(zoomRange.maxZoom)
             .stylePackOptions(stylePackOptions)
+            .pixelRatio(2.0f)
             .build()
         val tilesetDescriptor = offlineManager.createTilesetDescriptor(descriptorOptions)
 


### PR DESCRIPTION
…raster tiles

Fixes: #2790 

See: https://github.com/mapbox/mapbox-maps-android/issues/1460#issuecomment-1311919772