### PR TITLE
fix(ios) Fix getPacks method returning an a array of empty object 

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLOfflineModule.swift
+++ b/ios/RCTMGL-v10/RCTMGLOfflineModule.swift
@@ -486,7 +486,8 @@ class RCTMGLOfflineModule: RCTEventEmitter {
       if let expires = region.expires {
         result["expires"] = expires.toJSONString()
       }
-      
+
+      return result
     }
     return [:]
   }


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

This pull request addresses an issue with the getPacks method, where the nativeOfflinePacks array on the React Native side contained an empty object, even though the corresponding self.tileRegionPacks[region.id] on the iOS side had a valid value.

The issue was traced back to the convertRegionToJSON function, which incorrectly returned an empty dictionary [:] at the end, instead of the expected result object.

## Checklist

<!-- Check completed item: [X] -->

- [ ] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
