### PR TITLE
fix: update GeoJSONSource when updating url

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLShapeSource.swift
+++ b/ios/RCTMGL-v10/RCTMGLShapeSource.swift
@@ -11,7 +11,7 @@ class RCTMGLShapeSource : RCTMGLSource {
 
           switch result {
             case .success(let obj):
-              doUpdate { (style) in
+              self.doUpdate { (style) in
                 logged("RCTMGLShapeSource.setUrl") {
                   try style.updateGeoJSONSource(withId: self.id, geoJSON: obj)
                 }

--- a/ios/RCTMGL-v10/RCTMGLShapeSource.swift
+++ b/ios/RCTMGL-v10/RCTMGLShapeSource.swift
@@ -5,21 +5,19 @@ import Turf
 class RCTMGLShapeSource : RCTMGLSource {
   @objc var url : String? {
     didSet {
-      logged("RCTMGLShapeSource.updateUrl") {
-        parseJSON(url) { [weak self] result in
-          guard let self = self else { return }
+      parseJSON(url) { [weak self] result in
+        guard let self = self else { return }
 
-          switch result {
-            case .success(let obj):
-              self.doUpdate { (style) in
-                logged("RCTMGLShapeSource.setUrl") {
-                  try style.updateGeoJSONSource(withId: self.id, geoJSON: obj)
-                }
+        switch result {
+          case .success(let obj):
+            self.doUpdate { (style) in
+              logged("RCTMGLShapeSource.setUrl") {
+                try style.updateGeoJSONSource(withId: self.id, geoJSON: obj)
               }
+            }
 
-            case .failure(let error):
-              Logger.log(level: .error, message: ":: Error - update url failed \(error) \(error.localizedDescription)")
-          }
+          case .failure(let error):
+            Logger.log(level: .error, message: ":: Error - update url failed \(error) \(error.localizedDescription)")
         }
       }
     }


### PR DESCRIPTION
## Description

This is a "funny" one. I created an issue for the exact same error ~4 years ago on the previous Mapbox GL impletementation. (Ref: https://github.com/rnmapbox/maps/issues/541)

So here we go again. When updating an url dynamically to a `ShapeSource`, the layer is not refreshed and the data is stale.

I must be the only one using the url prop 😅 

## Checklist

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
- [x] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

Without the patch (You can notice for the first loading it works but not for the updates afterward):

https://user-images.githubusercontent.com/937328/232230718-6afa3acf-38ee-4488-bc60-1e6c60ad8b76.mov




After the patch:

https://user-images.githubusercontent.com/937328/232230731-5e0fcc0f-90e6-4ff3-b0c0-8e79667dcf16.mov
