### PR TITLE
fix: add image refs

### DIFF
--- a/example/src/examples/BugReportExample.js
+++ b/example/src/examples/BugReportExample.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Button } from 'react-native';
 import {
+  Images,
   MapView,
   ShapeSource,
   SymbolLayer,
@@ -75,6 +76,7 @@ class BugReportExample extends React.Component {
         />
         <MapView style={styles.mapView}>
           <Camera centerCoordinate={[-74.00597, 40.71427]} zoomLevel={14} />
+          <Images images={{ example: require('../assets/example.png') }} />
           <ShapeSource id={'shape-source-id-0'} shape={features}>
             <CircleLayer id={'circle-layer'} style={circleLayerStyle} />
             <SymbolLayer

--- a/example/src/examples/BugReportExampleTS.tsx
+++ b/example/src/examples/BugReportExampleTS.tsx
@@ -1,6 +1,7 @@
 import {
   Camera,
   CircleLayer,
+  Images,
   MapView,
   ShapeSource,
   SymbolLayer,
@@ -70,6 +71,7 @@ const BugReportExample = () => {
       <Button title="Grow" onPress={() => setRadius(radius + 20)} />
       <MapView style={styles.mapView}>
         <Camera centerCoordinate={[-74.00597, 40.71427]} zoomLevel={14} />
+        <Images images={{ example: require('../assets/example.png') }} />
         <ShapeSource id={'shape-source-id-0'} shape={features}>
           <CircleLayer id={'circle-layer'} style={circleLayerStyle} />
           <SymbolLayer


### PR DESCRIPTION
## Description

- Images were not showing on the bug report examples (JS/TS)

## Checklist

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
- [x] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
![Screenshot 2023-04-17 at 09 08 50](https://user-images.githubusercontent.com/937328/232438919-b947b8e6-b88d-4d50-a960-b6034bb357ea.png)
