### PR TITLE
fix: export MapView interface

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -97,7 +97,7 @@ type LocalizeLabels =
     }
   | true;
 
-type Props = ViewProps & {
+export type Props = ViewProps & {
   /**
    * The distance from the edges of the map view’s frame to the edges of the map view’s logical viewport.
    */


### PR DESCRIPTION
## Description

- Make it easy to reuse official types.

```tsx
import { MapView } from '@rnmapbox/maps';

const MyComponent = ({ projection }: { projection: MapView['props']['projection'] }) => (
  <MapView projection={projection}>
    ...
  </MapView>
)
```

## Checklist

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
- [x] I added/updated a sample - if a new feature was implemented (`/example`)
