### PR TITLE
feat: add MapView.clearData

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.kt
@@ -980,16 +980,30 @@ open class RCTMGLMapView(private val mContext: Context, var mManager: RCTMGLMapV
     fun queryTerrainElevation(callbackID: String?, longitude: Double, latitude: Double) {
         val result = mMap?.getElevation(Point.fromLngLat(longitude, latitude))
 
-        sendResponse(callbackID, {
+        sendResponse(callbackID, {response ->
             if (result != null) {
-                it.putDouble("data", result)
+                response.putDouble("data", result)
             } else {
                 Logger.e("queryTerrainElevation", "no elevation data")
 
-                it.putNull("data")
-                it.putString("error", "no elevation")
+                response.putNull("data")
+                response.putString("error", "no elevation")
             }
         })
+    }
+
+    fun clearData(callbackID: String?) {
+        mapView.getMapboxMap().clearData { expected ->
+            sendResponse(callbackID) { response ->
+                if (expected.isError()) {
+                    response.putNull("data")
+                    response.putString("error", expected.error!!.toString())
+                }   else {
+                    response.putBoolean("data", true)
+                }
+            }
+
+        }
     }
 
     fun match(layer: Layer, sourceId:String, sourceLayerId: String?) : Boolean {

--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapViewManager.kt
@@ -20,7 +20,9 @@ import com.mapbox.maps.plugin.logo.logo
 import com.mapbox.rctmgl.utils.ConvertUtils
 import com.mapbox.rctmgl.utils.ExpressionParser
 import com.mapbox.rctmgl.utils.GeoJSONUtils
+import com.mapbox.rctmgl.utils.Logger
 import com.mapbox.rctmgl.utils.extensions.toCoordinate
+import com.mapbox.rctmgl.utils.extensions.toReadableArray
 import com.mapbox.rctmgl.utils.extensions.toScreenCoordinate
 import java.lang.Exception
 import java.util.HashMap
@@ -252,29 +254,18 @@ open class RCTMGLMapViewManager(context: ReactApplicationContext) :
     }
 
     override fun getCommandsMap(): Map<String, Int>? {
-        return MapBuilder.builder<String, Int>()
-            .put("queryRenderedFeaturesAtPoint", METHOD_QUERY_FEATURES_POINT)
-            .put("queryRenderedFeaturesInRect", METHOD_QUERY_FEATURES_RECT)
-            .put("getVisibleBounds", METHOD_VISIBLE_BOUNDS)
-            .put("getPointInView", METHOD_GET_POINT_IN_VIEW)
-            .put("getCoordinateFromView", METHOD_GET_COORDINATE_FROM_VIEW)
-            .put("takeSnap", METHOD_TAKE_SNAP)
-            .put("getZoom", METHOD_GET_ZOOM)
-            .put("getCenter", METHOD_GET_CENTER)
-            .put("setHandledMapChangedEvents", METHOD_SET_HANDLED_MAP_EVENTS)
-            .put("showAttribution", METHOD_SHOW_ATTRIBUTION)
-            .put("setSourceVisibility", METHOD_SET_SOURCE_VISIBILITY)
-            .put("queryTerrainElevation", METHOD_QUERY_TERRAIN_ELEVATION)
-            .build()
+        return mapOf(
+            "_useCommandName" to 1
+        );
     }
 
-    override fun receiveCommand(mapView: RCTMGLMapView, commandID: Int, args: ReadableArray?) {
+    override fun receiveCommand(mapView: RCTMGLMapView, command: String, args: ReadableArray?) {
         // allows method calls to work with componentDidMount
         val mapboxMap = mapView.getMapboxMap()
             ?: //            mapView.enqueuePreRenderMapMethod(commandID, args);
             return
-        when (commandID) {
-            METHOD_QUERY_TERRAIN_ELEVATION -> {
+        when (command) {
+            "queryTerrainElevation" -> {
                 val coords = args!!.getArray(1)
                 mapView.queryTerrainElevation(
                     args.getString(0),
@@ -282,26 +273,26 @@ open class RCTMGLMapViewManager(context: ReactApplicationContext) :
                     coords.getDouble(1)
                 )
             }
-            METHOD_GET_ZOOM -> {
+            "getZoom" -> {
                 mapView.getZoom(args!!.getString(0));
             }
-            METHOD_GET_CENTER -> {
+            "getCenter" -> {
                 mapView.getCenter(args!!.getString(0));
             }
-            METHOD_GET_POINT_IN_VIEW -> {
+            "getPointInView" -> {
                 mapView.getPointInView(args!!.getString(0), args.getArray(1).toCoordinate())
             }
-            METHOD_GET_COORDINATE_FROM_VIEW -> {
+            "getCoordinateFromView" -> {
                 mapView.getCoordinateFromView(args!!.getString(0), args.getArray(1).toScreenCoordinate());
             }
-            METHOD_SET_SOURCE_VISIBILITY -> {
+            "setSourceVisibility" -> {
                 mapView!!.setSourceVisibility(
                     args!!.getBoolean(1),
                     args!!.getString(2),
                     args!!.getString(3)
                 );
             }
-            METHOD_QUERY_FEATURES_POINT -> {
+            "queryRenderedFeaturesAtPoint" -> {
                 mapView.queryRenderedFeaturesAtPoint(
                     args!!.getString(0),
                     ConvertUtils.toPointF(args!!.getArray(1)),
@@ -309,7 +300,7 @@ open class RCTMGLMapViewManager(context: ReactApplicationContext) :
                     ConvertUtils.toStringList(args!!.getArray(3))
                 );
             }
-            METHOD_QUERY_FEATURES_RECT -> {
+            "queryRenderedFeaturesInRect" -> {
                 val layerIds = ConvertUtils.toStringList(args!!.getArray(3))
                 mapView.queryRenderedFeaturesInRect(
                         args!!.getString(0),
@@ -318,16 +309,22 @@ open class RCTMGLMapViewManager(context: ReactApplicationContext) :
                         if (layerIds.size == 0) null else layerIds
                 );
             }
-            METHOD_VISIBLE_BOUNDS -> {
+            "getVisibleBounds" -> {
                 mapView.getVisibleBounds(args!!.getString(0));
             }
-            METHOD_TAKE_SNAP -> {
+            "takeSnap" -> {
                 mapView.takeSnap(args!!.getString(0), args!!.getBoolean(1))
             }
-            METHOD_SET_HANDLED_MAP_EVENTS -> {
+            "setHandledMapChangedEvents" -> {
                 args?.let {
                     mapView.setHandledMapChangedEvents(it.getArray(1).asArrayString());
                 }
+            }
+            "clearData" -> {
+                mapView.clearData(args!!.getString(0))
+            }
+            else -> {
+                Logger.w("RCTMGLMapView.receiveCommand", "unexpected command: ${command}")
             }
         }
         /*
@@ -381,21 +378,6 @@ open class RCTMGLMapViewManager(context: ReactApplicationContext) :
     companion object {
         const val LOG_TAG = "RCTMGLMapViewManager"
         const val REACT_CLASS = "RCTMGLMapView"
-
-        //endregion
-        //region React Methods
-        const val METHOD_QUERY_FEATURES_POINT = 2
-        const val METHOD_QUERY_FEATURES_RECT = 3
-        const val METHOD_VISIBLE_BOUNDS = 4
-        const val METHOD_GET_POINT_IN_VIEW = 5
-        const val METHOD_GET_COORDINATE_FROM_VIEW = 6
-        const val METHOD_TAKE_SNAP = 7
-        const val METHOD_GET_ZOOM = 8
-        const val METHOD_GET_CENTER = 9
-        const val METHOD_SET_HANDLED_MAP_EVENTS = 10
-        const val METHOD_SHOW_ATTRIBUTION = 11
-        const val METHOD_SET_SOURCE_VISIBILITY = 12
-        const val METHOD_QUERY_TERRAIN_ELEVATION = 13
     }
 
     init {

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -627,6 +627,16 @@ const center = await this._map.getCenter();
 ```
 
 
+### clearData()
+
+Clears temporary map data from the data path defined in the given resource<br/>options. Useful to reduce the disk usage or in case the disk cache contains<br/>invalid data.<br/><br/>v10 only
+
+#### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+
+
+
 ### queryTerrainElevation(coordinate)
 
 Queries the currently loaded data for elevation at a geographical location.<br/>The elevation is returned in meters relative to mean sea-level.<br/>Returns null if terrain is disabled or if terrain data for the location hasn't been loaded yet.

--- a/docs/OfflineManager.md
+++ b/docs/OfflineManager.md
@@ -29,7 +29,7 @@ Creates and registers an offline pack that downloads the resources needed to use
 const progressListener = (offlineRegion, status) => console.log(offlineRegion, status);
 const errorListener = (offlineRegion, err) => console.log(offlineRegion, err);
 
-await MapboxGL.offlineManager.createPack({
+await Mapbox.offlineManager.createPack({
   name: 'offlinePack',
   styleURL: 'mapbox://...',
   minZoom: 14,
@@ -51,7 +51,7 @@ Invalidates the specified offline pack. This method checks that the tiles in the
 
 
 ```javascript
-await MapboxGL.offlineManager.invalidatePack('packName')
+await Mapbox.offlineManager.invalidatePack('packName')
 ```
 
 
@@ -67,7 +67,7 @@ Unregisters the given offline pack and allows resources that are no longer requi
 
 
 ```javascript
-await MapboxGL.offlineManager.deletePack('packName')
+await Mapbox.offlineManager.deletePack('packName')
 ```
 
 
@@ -83,7 +83,7 @@ Forces a revalidation of the tiles in the ambient cache and downloads a fresh ve
 
 
 ```javascript
-await MapboxGL.offlineManager.invalidateAmbientCache();
+await Mapbox.offlineManager.invalidateAmbientCache();
 ```
 
 
@@ -99,7 +99,7 @@ Erases resources from the ambient cache.<br/>This method clears the cache and de
 
 
 ```javascript
-await MapboxGL.offlineManager.clearAmbientCache();
+await Mapbox.offlineManager.clearAmbientCache();
 ```
 
 
@@ -115,7 +115,7 @@ Migrates the offline cache from pre-v10 SDKs to the new v10 cache location
 
 
 ```javascript
-await MapboxGL.offlineManager.migrateOfflineCache()
+await Mapbox.offlineManager.migrateOfflineCache()
 ```
 
 
@@ -131,7 +131,7 @@ Sets the maximum size of the ambient cache in bytes. Disables the ambient cache 
 
 
 ```javascript
-await MapboxGL.offlineManager.setMaximumAmbientCacheSize(5000000);
+await Mapbox.offlineManager.setMaximumAmbientCacheSize(5000000);
 ```
 
 
@@ -147,7 +147,7 @@ Deletes the existing database, which includes both the ambient cache and offline
 
 
 ```javascript
-await MapboxGL.offlineManager.resetDatabase();
+await Mapbox.offlineManager.resetDatabase();
 ```
 
 
@@ -163,7 +163,7 @@ Retrieves all the current offline packs that are stored in the database.
 
 
 ```javascript
-const offlinePacks = await MapboxGL.offlineManager.getPacks();
+const offlinePacks = await Mapbox.offlineManager.getPacks();
 ```
 
 
@@ -179,7 +179,7 @@ Retrieves an offline pack that is stored in the database by name.
 
 
 ```javascript
-const offlinePack = await MapboxGL.offlineManager.getPack();
+const offlinePack = await Mapbox.offlineManager.getPack();
 ```
 
 
@@ -195,7 +195,7 @@ Sideloads offline db
 
 
 ```javascript
-await MapboxGL.offlineManager.mergeOfflineRegions(path);
+await Mapbox.offlineManager.mergeOfflineRegions(path);
 ```
 
 
@@ -211,7 +211,7 @@ Sets the maximum number of Mapbox-hosted tiles that may be downloaded and stored
 
 
 ```javascript
-MapboxGL.offlineManager.setTileCountLimit(1000);
+Mapbox.offlineManager.setTileCountLimit(1000);
 ```
 
 
@@ -227,7 +227,7 @@ Sets the period at which download status events will be sent over the React Nati
 
 
 ```javascript
-MapboxGL.offlineManager.setProgressEventThrottle(500);
+Mapbox.offlineManager.setProgressEventThrottle(500);
 ```
 
 
@@ -247,7 +247,7 @@ Subscribe to download status/error events for the requested offline pack.<br/>No
 ```javascript
 const progressListener = (offlinePack, status) => console.log(offlinePack, status)
 const errorListener = (offlinePack, err) => console.log(offlinePack, err)
-MapboxGL.offlineManager.subscribe('packName', progressListener, errorListener)
+Mapbox.offlineManager.subscribe('packName', progressListener, errorListener)
 ```
 
 
@@ -263,7 +263,7 @@ Unsubscribes any listeners associated with the offline pack.<br/>It's a good ide
 
 
 ```javascript
-MapboxGL.offlineManager.unsubscribe('packName')
+Mapbox.offlineManager.unsubscribe('packName')
 ```
 
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3010,6 +3010,27 @@
         ]
       },
       {
+        "name": "clearData",
+        "docblock": "Clears temporary map data from the data path defined in the given resource\noptions. Useful to reduce the disk usage or in case the disk cache contains\ninvalid data.\n\nv10 only",
+        "modifiers": [
+          "async"
+        ],
+        "params": [],
+        "returns": {
+          "type": {
+            "name": "Promise",
+            "elements": [
+              {
+                "name": "void"
+              }
+            ],
+            "raw": "Promise<void>"
+          }
+        },
+        "description": "Clears temporary map data from the data path defined in the given resource\noptions. Useful to reduce the disk usage or in case the disk cache contains\ninvalid data.\n\nv10 only",
+        "examples": []
+      },
+      {
         "name": "queryTerrainElevation",
         "docblock": "Queries the currently loaded data for elevation at a geographical location.\nThe elevation is returned in meters relative to mean sea-level.\nReturns null if terrain is disabled or if terrain data for the location hasn't been loaded yet.\n\n@param {Array<Number>} coordinate - the coordinates to query elevation at\n@return {Number}",
         "modifiers": [
@@ -6556,7 +6577,7 @@
           }
         ],
         "examples": [
-          "const progressListener = (offlineRegion, status) => console.log(offlineRegion, status);\nconst errorListener = (offlineRegion, err) => console.log(offlineRegion, err);\n\nawait MapboxGL.offlineManager.createPack({\n  name: 'offlinePack',\n  styleURL: 'mapbox://...',\n  minZoom: 14,\n  maxZoom: 20,\n  bounds: [[neLng, neLat], [swLng, swLat]]\n}, progressListener, errorListener)"
+          "const progressListener = (offlineRegion, status) => console.log(offlineRegion, status);\nconst errorListener = (offlineRegion, err) => console.log(offlineRegion, err);\n\nawait Mapbox.offlineManager.createPack({\n  name: 'offlinePack',\n  styleURL: 'mapbox://...',\n  minZoom: 14,\n  maxZoom: 20,\n  bounds: [[neLng, neLat], [swLng, swLat]]\n}, progressListener, errorListener)"
         ],
         "returns": {
           "description": "",
@@ -6579,7 +6600,7 @@
           }
         ],
         "examples": [
-          "await MapboxGL.offlineManager.invalidatePack('packName')"
+          "await Mapbox.offlineManager.invalidatePack('packName')"
         ],
         "returns": {
           "description": "",
@@ -6602,7 +6623,7 @@
           }
         ],
         "examples": [
-          "await MapboxGL.offlineManager.deletePack('packName')"
+          "await Mapbox.offlineManager.deletePack('packName')"
         ],
         "returns": {
           "description": "",
@@ -6616,7 +6637,7 @@
         "description": "Forces a revalidation of the tiles in the ambient cache and downloads a fresh version of the tiles from the tile server.\nThis is the recommend method for clearing the cache.\nThis is the most efficient method because tiles in the ambient cache are re-downloaded to remove outdated data from a device.\nIt does not erase resources from the ambient cache or delete the database, which can be computationally expensive operations that may carry unintended side effects.",
         "params": [],
         "examples": [
-          "await MapboxGL.offlineManager.invalidateAmbientCache();"
+          "await Mapbox.offlineManager.invalidateAmbientCache();"
         ],
         "returns": {
           "description": "",
@@ -6630,7 +6651,7 @@
         "description": "Erases resources from the ambient cache.\nThis method clears the cache and decreases the amount of space that map resources take up on the device.",
         "params": [],
         "examples": [
-          "await MapboxGL.offlineManager.clearAmbientCache();"
+          "await Mapbox.offlineManager.clearAmbientCache();"
         ],
         "returns": {
           "description": "",
@@ -6644,7 +6665,7 @@
         "description": "Migrates the offline cache from pre-v10 SDKs to the new v10 cache location",
         "params": [],
         "examples": [
-          "await MapboxGL.offlineManager.migrateOfflineCache()"
+          "await Mapbox.offlineManager.migrateOfflineCache()"
         ],
         "returns": {
           "description": "",
@@ -6667,7 +6688,7 @@
           }
         ],
         "examples": [
-          "await MapboxGL.offlineManager.setMaximumAmbientCacheSize(5000000);"
+          "await Mapbox.offlineManager.setMaximumAmbientCacheSize(5000000);"
         ],
         "returns": {
           "description": "",
@@ -6681,7 +6702,7 @@
         "description": "Deletes the existing database, which includes both the ambient cache and offline packs, then reinitializes it.",
         "params": [],
         "examples": [
-          "await MapboxGL.offlineManager.resetDatabase();"
+          "await Mapbox.offlineManager.resetDatabase();"
         ],
         "returns": {
           "description": "",
@@ -6695,7 +6716,7 @@
         "description": "Retrieves all the current offline packs that are stored in the database.",
         "params": [],
         "examples": [
-          "const offlinePacks = await MapboxGL.offlineManager.getPacks();"
+          "const offlinePacks = await Mapbox.offlineManager.getPacks();"
         ],
         "returns": {
           "description": "",
@@ -6718,7 +6739,7 @@
           }
         ],
         "examples": [
-          "const offlinePack = await MapboxGL.offlineManager.getPack();"
+          "const offlinePack = await Mapbox.offlineManager.getPack();"
         ],
         "returns": {
           "description": "",
@@ -6741,7 +6762,7 @@
           }
         ],
         "examples": [
-          "await MapboxGL.offlineManager.mergeOfflineRegions(path);"
+          "await Mapbox.offlineManager.mergeOfflineRegions(path);"
         ],
         "returns": {
           "description": "",
@@ -6764,7 +6785,7 @@
           }
         ],
         "examples": [
-          "MapboxGL.offlineManager.setTileCountLimit(1000);"
+          "Mapbox.offlineManager.setTileCountLimit(1000);"
         ],
         "returns": {
           "description": "",
@@ -6787,7 +6808,7 @@
           }
         ],
         "examples": [
-          "MapboxGL.offlineManager.setProgressEventThrottle(500);"
+          "Mapbox.offlineManager.setProgressEventThrottle(500);"
         ],
         "returns": {
           "description": "",
@@ -6826,7 +6847,7 @@
           }
         ],
         "examples": [
-          "const progressListener = (offlinePack, status) => console.log(offlinePack, status)\nconst errorListener = (offlinePack, err) => console.log(offlinePack, err)\nMapboxGL.offlineManager.subscribe('packName', progressListener, errorListener)"
+          "const progressListener = (offlinePack, status) => console.log(offlinePack, status)\nconst errorListener = (offlinePack, err) => console.log(offlinePack, err)\nMapbox.offlineManager.subscribe('packName', progressListener, errorListener)"
         ],
         "returns": {
           "description": "",
@@ -6849,7 +6870,7 @@
           }
         ],
         "examples": [
-          "MapboxGL.offlineManager.unsubscribe('packName')"
+          "Mapbox.offlineManager.unsubscribe('packName')"
         ],
         "returns": {
           "description": "",

--- a/ios/RCTMGL-v10/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL-v10/RCTMGLMapViewManager.m
@@ -90,4 +90,9 @@ RCT_EXTERN_METHOD(setHandledMapChangedEvents:(nonnull NSNumber*)reactTag
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(clearData: (nonnull NSNumber*)reactTag
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject
+                  )
+
 @end

--- a/ios/RCTMGL-v10/RCTMGLMapViewManager.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapViewManager.swift
@@ -237,4 +237,21 @@ extension RCTMGLMapViewManager {
         }
       }
    }
+  
+  @objc
+  func clearData(
+    _ reactTag: NSNumber,
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    withMapView(reactTag, name:"clearDataPath", rejecter: rejecter) { mapView in
+      mapView.mapboxMap.clearData { error in
+        if let error = error {
+          rejecter("clearData","failed to clearData: \(error.localizedDescription)", error)
+        } else {
+          resolver(nil)
+        }
+      }
+    }
+  }
 }

--- a/ios/RCTMGL-v10/RCTMGLOfflineModule.swift
+++ b/ios/RCTMGL-v10/RCTMGLOfflineModule.swift
@@ -200,7 +200,7 @@ class RCTMGLOfflineModule: RCTEventEmitter {
         self.tileStore.tileRegionMetadata(forId: name) { result in
           switch result {
           case .success(let metadata):
-            var pack = TileRegionPack(
+            let pack = TileRegionPack(
               name: name,
               progress: self.toProgress(region: region),
               metadata: logged("RCTMGLOfflineModule.getPackStatus") { metadata as? [String:Any] } ?? [:]
@@ -287,9 +287,9 @@ class RCTMGLOfflineModule: RCTEventEmitter {
       reject("migrateOfflineCache", error.localizedDescription, error)
     }
   }
-  
+
   @objc
-  func resetDatabase(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+  func resetDatabase(_ resolve: @escaping RCTPromiseResolveBlock, rejecter: @escaping RCTPromiseRejectBlock) {
     self.tileStore.allTileRegions { result in
       switch result {
       case .success(let regions):
@@ -308,12 +308,12 @@ class RCTMGLOfflineModule: RCTEventEmitter {
             resolve(nil)
           case .failure(let error):
             Logger.log(level:.error, message: "RCTMGLOfflineModule.resetDatabase/allStylePacks \(error.localizedDescription) \(error)")
-            reject("RCTMGLOfflineModule.resetDatabase/allStylePacks", error.localizedDescription, error)
+            rejecter("RCTMGLOfflineModule.resetDatabase/allStylePacks", error.localizedDescription, error)
           }
         }
       case .failure(let error):
         Logger.log(level:.error, message: "RCTMGLOfflineModule.resetDatabase/allTileRegions \(error.localizedDescription) \(error)")
-        reject("RCTMGLOfflineModule.resetDatabase/allTileRegions", error.localizedDescription, error)
+        rejecter("RCTMGLOfflineModule.resetDatabase/allTileRegions", error.localizedDescription, error)
       }
     }
   }

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -748,6 +748,24 @@ class MapView extends NativeBridgeComponent(
   }
 
   /**
+   *
+   * Clears temporary map data from the data path defined in the given resource
+   * options. Useful to reduce the disk usage or in case the disk cache contains
+   * invalid data.
+   *
+   * v10 only
+   */
+  async clearData(): Promise<void> {
+    if (!MGLModule.MapboxV10) {
+      console.warn(
+        'RNMapbox: clearData is only implemented in v10 implementation or later',
+      );
+      return;
+    }
+    await this._runNative<void>('clearData');
+  }
+
+  /**
    * Queries the currently loaded data for elevation at a geographical location.
    * The elevation is returned in meters relative to mean sea-level.
    * Returns null if terrain is disabled or if terrain data for the location hasn't been loaded yet.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -85,9 +85,10 @@ export function runNativeCommand<ReturnType = NativeArg>(
   }
 
   if (isAndroid()) {
+    const { Commands } = managerInstance;
     return NativeModules.UIManager.dispatchViewManagerCommand(
       handle,
-      managerInstance.Commands[name],
+      Commands._useCommandName ? name : Commands[name],
       args,
     );
   }


### PR DESCRIPTION
Fixes: #2797 

Unfortunately it's seems that CacheManger was removed from early iOS sdk. 

There is a new v10 only method `clearData` see https://docs.mapbox.com/ios/maps/api/10.12.2/Classes/MapboxMap.html#/s:10MapboxMaps0A3MapC9clearData10completionyys5Error_pSgc_tF

https://github.com/mapbox/mapbox-maps-ios/commit/5e79f92d061172998b583e00967a71d3c4c93d1d

https://docs.mapbox.com/ios/maps/api/10.0.0-beta.20/Extensions/CacheManager.html#/s:So15MBMCacheManagerC10MapboxMapsE17clearAmbientCacheyyys6ResultOyyts5Error_pGcF