### PR TITLE
fix(android): change minSdkVersion to 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ _See [iOS](ios/install.md) & [Android](android/install.md) setup guide for more 
 
 ## Prerequisite
 
-1. On Android we support from version 6 (API 23) upwards
-2. Please [Sign Up to Mapbox](https://account.mapbox.com/auth/signup/) to get the Mapbox Access Token.
+1. Please [Sign Up to Mapbox](https://account.mapbox.com/auth/signup/) to get the Mapbox Access Token.
 
 
 ## Dependencies

--- a/android/rctmgl/build.gradle
+++ b/android/rctmgl/build.gradle
@@ -72,7 +72,7 @@ android {
     buildToolsVersion safeExtGet("buildToolsVersion", '28.0.3')
 
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 16)
+        minSdkVersion safeExtGet('minSdkVersion', 21)
         targetSdkVersion safeExtGet('targetSdkVersion', 26)
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
## Description

Change `minSdkVersion` for android.

Since Mapbox v10, we need to use the minimum version sdk 21 as describe here : https://docs.mapbox.com/android/maps/guides/migrate-to-v10/#requirements.

Since React Native 0.64, the min sdk version is 21 : https://reactnative.dev/blog/2021/03/12/version-0.64. It's already in the doc that we must use react native 0.64+.

Please let me know if there is any reasons why the following line : "On Android we support from version 6 (API 23) upwards" was written

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
