### PR TITLE
fix(v10): depreate contentInset; fix(ios): don't clear defaultSetting…

### DIFF
--- a/__tests__/components/Camera.test.js
+++ b/__tests__/components/Camera.test.js
@@ -38,9 +38,7 @@ describe('Camera', () => {
   test('defaults are set', () => {
     const result = render(<Camera />);
     const { props } = result.queryByTestId('Camera');
-    expect(props.stop).toStrictEqual({
-      ...paddingZero,
-    });
+    expect(props.stop).toStrictEqual({});
   });
   test('set location by center', () => {
     const result = render(
@@ -51,7 +49,6 @@ describe('Camera', () => {
     expect(props.stop).toStrictEqual({
       centerCoordinate: toFeature(coordinate1),
       zoom: 14,
-      ...paddingZero,
     });
   });
   test('set location by bounds', () => {
@@ -60,7 +57,6 @@ describe('Camera', () => {
     props.stop.bounds = JSON.parse(props.stop.bounds);
     expect(props.stop).toStrictEqual({
       bounds: toFeatureCollection(bounds1),
-      ...paddingZero,
     });
   });
   test('animation mode', () => {

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -16,6 +16,7 @@ MapView backed by Mapbox Native GL
 number | number[]
 ```
 The distance from the edges of the map view’s frame to the edges of the map view’s logical viewport.
+@deprecated use Camera `padding` instead
 
 
   

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3113,7 +3113,7 @@
         "required": false,
         "type": "number \\| number[]",
         "default": "none",
-        "description": "The distance from the edges of the map view’s frame to the edges of the map view’s logical viewport."
+        "description": "The distance from the edges of the map view’s frame to the edges of the map view’s logical viewport.\n@deprecated use Camera `padding` instead"
       },
       {
         "name": "projection",

--- a/ios/RCTMGL-v10/RCTMGLCamera.swift
+++ b/ios/RCTMGL-v10/RCTMGLCamera.swift
@@ -359,6 +359,9 @@ class RCTMGLCamera : RCTMGLMapComponentBase {
   }
   
   private func toUpdateItem(stop: [String: Any]) -> CameraUpdateItem? {
+    if (stop.isEmpty) {
+      return nil
+    }
     var zoom: CGFloat?
     if let z = stop["zoom"] as? Double {
       zoom = CGFloat(z)

--- a/src/components/Camera.tsx
+++ b/src/components/Camera.tsx
@@ -281,14 +281,29 @@ export const Camera = memo(
             _nativeStop.bounds = JSON.stringify(makeLatLngBounds(ne, sw));
           }
 
-          _nativeStop.paddingTop =
-            stop.padding?.paddingTop ?? stop.bounds?.paddingTop ?? 0;
-          _nativeStop.paddingRight =
-            stop.padding?.paddingRight ?? stop.bounds?.paddingRight ?? 0;
-          _nativeStop.paddingBottom =
-            stop.padding?.paddingBottom ?? stop.bounds?.paddingBottom ?? 0;
-          _nativeStop.paddingLeft =
-            stop.padding?.paddingLeft ?? stop.bounds?.paddingLeft ?? 0;
+          const paddingTop =
+            stop.padding?.paddingTop ?? stop.bounds?.paddingTop;
+          if (paddingTop !== undefined) {
+            _nativeStop.paddingTop = paddingTop;
+          }
+
+          const paddingRight =
+            stop.padding?.paddingRight ?? stop.bounds?.paddingRight;
+          if (paddingRight !== undefined) {
+            _nativeStop.paddingRight = paddingRight;
+          }
+
+          const paddingBottom =
+            stop.padding?.paddingBottom ?? stop.bounds?.paddingBottom;
+          if (paddingBottom != undefined) {
+            _nativeStop.paddingBottom = paddingBottom;
+          }
+
+          const paddingLeft =
+            stop.padding?.paddingLeft ?? stop.bounds?.paddingLeft;
+          if (paddingLeft !== undefined) {
+            _nativeStop.paddingLeft = paddingLeft;
+          }
 
           return _nativeStop;
         },

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -100,6 +100,7 @@ type LocalizeLabels =
 type Props = ViewProps & {
   /**
    * The distance from the edges of the map view’s frame to the edges of the map view’s logical viewport.
+   * @deprecated use Camera `padding` instead
    */
   contentInset?: number | number[];
 
@@ -410,7 +411,12 @@ class MapView extends NativeBridgeComponent(
     regionDidChangeDebounceTime: 500,
   };
 
-  deprecationLogged: { regionDidChange: boolean; regionIsChanging: boolean } = {
+  deprecationLogged: {
+    contentInset: boolean;
+    regionDidChange: boolean;
+    regionIsChanging: boolean;
+  } = {
+    contentInset: false,
     regionDidChange: false,
     regionIsChanging: false,
   };
@@ -952,6 +958,15 @@ class MapView extends NativeBridgeComponent(
   _getContentInset() {
     if (!this.props.contentInset) {
       return;
+    }
+
+    if (MGLModule.MapboxV10) {
+      if (!this.deprecationLogged.contentInset) {
+        console.warn(
+          '@rnmapbox/maps: contentInset is deprecated, use Camera padding instead.',
+        );
+        this.deprecationLogged.contentInset = true;
+      }
     }
 
     if (!Array.isArray(this.props.contentInset)) {


### PR DESCRIPTION
…s.padding if no padding was specified

Fixes: #2843 