### PR TITLE
Update install.md for more accurate ios 

### DIFF
--- a/ios/install.md
+++ b/ios/install.md
@@ -29,7 +29,7 @@ Add the following to your `ios/Podfile`:
 
 Set the `$RNMapboxMapsImpl` to `mapbox` aka v10 implementation [see bellow for detailed instructions](#mapbox-maps-sdk-v10)
 
-Run `pod install` to download the proper mapbox dependency. You may need to run `pod repo update` if you get an error of ` CocoaPods could not find compatible versions for pod "MapboxMaps"`
+Run `pod install` to download the proper mapbox dependency.
 
 ```sh
 # Go to the ios folder

--- a/ios/install.md
+++ b/ios/install.md
@@ -27,7 +27,7 @@ Add the following to your `ios/Podfile`:
   end
 ```
 
-You must set the the `$RNMapboxMapsImpl`. For use with mapbox, set this to `mapbox` aka v10 implementation [see bellow for detailed instructions](#mapbox-maps-sdk-v10)
+Set the `$RNMapboxMapsImpl` to `mapbox` aka v10 implementation [see bellow for detailed instructions](#mapbox-maps-sdk-v10)
 
 Run `pod install` to download the proper mapbox dependency. You may need to run `pod repo update` if you get an error of ` CocoaPods could not find compatible versions for pod "MapboxMaps"`
 

--- a/ios/install.md
+++ b/ios/install.md
@@ -29,7 +29,7 @@ Add the following to your `ios/Podfile`:
 
 You must set the the `$RNMapboxMapsImpl`. For use with mapbox, set this to `mapbox` aka v10 implementation [see bellow for detailed instructions](#mapbox-maps-sdk-v10)
 
-Run `pod install` to download the proper mapbox dependency
+Run `pod install` to download the proper mapbox dependency. You may need to run `pod repo update` if you get an error of ` CocoaPods could not find compatible versions for pod "MapboxMaps"`
 
 ```sh
 # Go to the ios folder

--- a/ios/install.md
+++ b/ios/install.md
@@ -27,9 +27,9 @@ Add the following to your `ios/Podfile`:
   end
 ```
 
-We also recommend setting the `$RNMapboxMapsImpl` to `mapbox` aka v10 implementation [see bellow for detailed instructions](#mapbox-maps-sdk-v10)
+You must set the the `$RNMapboxMapsImpl`. For use with mapbox, set this to `mapbox` aka v10 implementation [see bellow for detailed instructions](#mapbox-maps-sdk-v10)
 
-Running `pod install` download the proper mapbox dependency
+Run `pod install` to download the proper mapbox dependency
 
 ```sh
 # Go to the ios folder


### PR DESCRIPTION
## Description

setting is no longer optional and will throw the following error if left out
```
[!] Invalid `Podfile` file: 
[!] Invalid `rnmapbox-maps.podspec` file: Setting $RNMapboxMapsImpl is now required - https://github.com/rnmapbox/maps/wiki/Deprecated-RNMapboxImpl-Unset#ios.
```

also add a note for anyone encountering 
https://github.com/rnmapbox/maps/discussions/2830#discussioncomment-5762648


## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
- [x] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
