### PR TITLE
fix: example Podfile for arm64

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -103,6 +103,11 @@ target 'RNMapboxGLExample' do
 
   if !ENV['CI']
     post_install do |installer|
+      installer.pods_project.targets.each do |target|
+        target.build_configurations.each do |config|
+          config.build_settings["ONLY_ACTIVE_ARCH"] = "NO"
+        end
+      end
       react_native_post_install(
         installer,
         # Set `mac_catalyst_enabled` to `true` in order to apply patches

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -103,6 +103,7 @@ target 'RNMapboxGLExample' do
 
   if !ENV['CI']
     post_install do |installer|
+      # See https://github.com/rnmapbox/maps/pull/2878
       installer.pods_project.targets.each do |target|
         target.build_configurations.each do |config|
           config.build_settings["ONLY_ACTIVE_ARCH"] = "NO"


### PR DESCRIPTION
## Description

These [changes to fix running the example iOS on an M1 Mac](https://github.com/rnmapbox/maps/commit/7338e793#diff-4fb44f272217447e6b4b3580916d09d23b9055f6a217ad8b26269cfa6031203a) were reverted during the [latest example upgrade](https://github.com/rnmapbox/maps/commit/27d28066d2f506ce1977ce7ef5e435607bf611a5#diff-4fb44f272217447e6b4b3580916d09d23b9055f6a217ad8b26269cfa6031203aL89-L93). Without these lines `yarn ios` fails with: 

```
❌  fatal error: module map file '<some-path>/Build/Products/Debug-iphonesimulator/YogaKit/YogaKit.modulemap' not found
```

Therefore I added those lines again to make it work. To reproduce on a M1 Mac run the following in the `example` dir:
```
yarn purge:ios && yarn pod:install && yarn ios
```

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
