### PR TITLE
Fix "already initialized constant" MapboxImplVersion

### DIFF
--- a/rnmapbox-maps.podspec
+++ b/rnmapbox-maps.podspec
@@ -92,11 +92,11 @@ end
 case $RNMapboxMapsImpl
 when 'mapbox'
   rnMapboxMapsTargetsToChangeToDynamic = ['MapboxMobileEvents', 'Turf', 'MapboxMaps', 'MapboxCoreMaps', 'MapboxCommon']
-  MapboxImplVersion = $RNMapboxMapsVersion || rnMapboxMapsDefaultMapboxVersion
+  $MapboxImplVersion = $RNMapboxMapsVersion || rnMapboxMapsDefaultMapboxVersion
 when 'mapbox-gl'
   puts 'WARNING: mapbox-gl in @rnmapbox/maps is deprecated. Set $RNMapboxMapsImpl=mapbox in your Podfile. See https://github.com/rnmapbox/maps/wiki/Deprecated-RNMapboxImpl-Maplibre#ios'
   rnMapboxMapsTargetsToChangeToDynamic = ['MapboxMobileEvents']
-  MapboxImplVersion = $RNMapboxMapsVersion || rnMapboxMapsDefaultMapboxGLVersion
+  $MapboxImplVersion = $RNMapboxMapsVersion || rnMapboxMapsDefaultMapboxGLVersion
 when 'maplibre'
   puts 'WARNING: maplibre in @rnmapbox/maps is deprecated. Set $RNMapboxMapsImpl=mapbox in your Podfile. See https://github.com/rnmapbox/maps/wiki/Deprecated-RNMapboxImpl-MapboxGL#ios'
   rnMapboxMapsTargetsToChangeToDynamic = ['MapboxMobileEvents']
@@ -239,11 +239,11 @@ Pod::Spec.new do |s|
   unless $RNMapboxMapsSwiftPackageManager
     case $RNMapboxMapsImpl
     when 'mapbox'
-      s.dependency 'MapboxMaps', MapboxImplVersion
+      s.dependency 'MapboxMaps', $MapboxImplVersion
       s.dependency 'Turf'
       s.swift_version = '5.0'
     when 'mapbox-gl'
-      s.dependency 'Mapbox-iOS-SDK', MapboxImplVersion
+      s.dependency 'Mapbox-iOS-SDK', $MapboxImplVersion
     when 'maplibre'
       fail "internal error: maplibre requires $RNMapboxMapsSwiftPackageManager"
     else


### PR DESCRIPTION
## Description

Fixes warning (see below) that causes builds to fail, when using a build system sensitive to `pod install` warnings (e.g. Nx).

```
[**]:95: warning: already initialized constant Pod::MapboxImplVersion
[**]:95: warning: previous definition of MapboxImplVersion was here
```

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
