### PR TITLE
Fix examples dependency and AnimatedLine issues

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -18,6 +18,7 @@
     "@mapbox/geo-viewport": "^0.5.0",
     "@mapbox/mapbox-sdk": "^0.13.0",
     "@react-native-async-storage/async-storage": "^1.17.11",
+    "@react-native-masked-view/masked-view": "^0.2.9",
     "@react-navigation/compat": "^5.3.20",
     "@react-navigation/native": "^6.0.11",
     "@react-navigation/native-stack": "^6.7.0",

--- a/example/src/examples/Animations/AnimatedLine.js
+++ b/example/src/examples/Animations/AnimatedLine.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Easing, Button } from 'react-native';
-import { Animated, MapView, Camera } from '@rnmapbox/maps';
+import MapboxGL, { Animated, MapView, Camera } from '@rnmapbox/maps';
 import along from '@turf/along';
 import length from '@turf/length';
 import { point, lineString } from '@turf/helpers';
@@ -47,7 +47,7 @@ class AnimatedLine extends React.Component {
   constructor(props) {
     super(props);
 
-    const route = new Animated.RouteCoordinatesArray([
+    const route = new MapboxGL.AnimatedRouteCoordinatesArray([
       [blon, blat],
       [blon, blat + 2 * bdelta],
       [blon + bdelta, blat + 2 * bdelta + bdelta],
@@ -58,7 +58,7 @@ class AnimatedLine extends React.Component {
       backgroundColor: 'blue',
       coordinates: [[-73.99155, 40.73581]],
 
-      shape: new Animated.CoordinatesArray(
+      shape: new MapboxGL.AnimatedCoordinatesArray(
         [...Array(steps).keys()].map((v, i) => [
           lon + delta * (i / steps) * (i / steps),
           lat + (delta * i) / steps,
@@ -69,7 +69,7 @@ class AnimatedLine extends React.Component {
         features: [],
       },
       route,
-      actPoint: new Animated.ExtractCoordinateFromArray(route, -1),
+      actPoint: new MapboxGL.AnimatedExtractCoordinateFromArray(route, -1),
     };
   }
 
@@ -219,7 +219,7 @@ class AnimatedLine extends React.Component {
           <Animated.ShapeSource
             id={'route'}
             shape={
-              new Animated.Shape({
+              new MapboxGL.AnimatedShape({
                 type: 'LineString',
                 coordinates: this.state.route,
               })
@@ -231,7 +231,7 @@ class AnimatedLine extends React.Component {
           <Animated.ShapeSource
             id="currentLocationSource"
             shape={
-              new Animated.Shape({
+              new MapboxGL.AnimatedShape({
                 type: 'Point',
                 coordinates: this.state.actPoint,
               })
@@ -246,7 +246,7 @@ class AnimatedLine extends React.Component {
           <Animated.ShapeSource
             id={'shape'}
             shape={
-              new Animated.Shape({
+              new MapboxGL.AnimatedShape({
                 type: 'LineString',
                 coordinates: this.state.shape,
               })


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

This PR targets example and is intended to fix react-navigation issue importing SafeAreaProviderCompat by adding dependency in example/package.json. And also fixes AnimetedLine example with correct Animated reference.

## Checklist

<!-- Check completed item: [X] -->

- [X] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

Screenshots before fix:

![Screenshot_1685554583](https://github.com/rnmapbox/maps/assets/55847858/056bcb69-0cca-4152-9c70-596770d45d72)
![Screenshot_1685555068](https://github.com/rnmapbox/maps/assets/55847858/5d36c61a-e210-411a-b11a-a9e98d4d771d)

