### PR TITLE
Avoid crash (scale = 0.0) when using remote png on Android

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/utils/DownloadMapImageTask.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/utils/DownloadMapImageTask.kt
@@ -126,7 +126,7 @@ class DownloadMapImageTask(context: Context, map: MapboxMap, callback: OnAllImag
                     bitmapImages[image.name] = image.bitmap
                     val info = image.info
                     style.addBitmapImage(image.name, image.bitmap,sdf = info.sdf, stretchX = info.stretchX, stretchY = info.stretchY,
-                        content = info.content,scale = info.scale
+                        content = info.content,scale = if (info.scale == 0.0) 1.0 else info.scale
                     )
                 }
             }


### PR DESCRIPTION
## Description

The app crashes when rendering remote images on the map. Because the scale is by default equal to 0.
This merge request fixes a default value to 1 on Android if scale is zero.

## Checklist

- [X] I have tested this on a device/simulator for each compatible OS
- [X] I updated the documentation with running `yarn generate` in the root folder => Not needed
- [X] I added/updated a sample - if a new feature was implemented (`/example`) => Not needed