### PR TITLE
fix locale

### DIFF
--- a/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.kt
+++ b/android/rctmgl/src/main/java-v10/com/mapbox/rctmgl/components/mapview/RCTMGLMapView.kt
@@ -567,7 +567,8 @@ open class RCTMGLMapView(private val mContext: Context, var mManager: RCTMGLMapV
     fun applyLocalizeLabels() {
         val localeStr = mLocaleString
         if (localeStr != null) {
-            val locale = if (localeStr == "current") Locale.getDefault() else Locale(localeStr)
+            val locale = if (localeStr == "current") Locale.getDefault() else Locale.Builder()
+                .setLanguageTag(localeStr).build()
             savedStyle?.localizeLabels(locale, mLocaleLayerIds)
         }
     }


### PR DESCRIPTION
## Description

The previous implementation has problems with locale strings with variants. e.g:
Settings locale to zh-Hant-HK will give errors like:
`[maps-android\LocalizationPluginImpl]: Locale: zh-hant-hk is not supported.`
Fixed by the following code.

## Checklist

<!-- Check completed item: [X] -->

- [X] I have tested this on a device/simulator for each compatible OS
- [X] I updated the documentation with running `yarn generate` in the root folder
- [X] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
