### PR TITLE
chore: publish preelease version with tag next to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Install dependencies and build 🔧
         run: npm install --force
       - name: Publish package on NPM 📦
-        run: npm publish
+        run: npm publish ${{ github.event.release.prelease && '--tag next' || ''}}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN_RNMAPBOX }}


### PR DESCRIPTION
Fixes: #2971 

Add ```--tag next``` to npm publish in case it's a prerelease version