### PR TITLE
Add pod install to example/README.md

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -56,7 +56,13 @@ cd example
 
 * Android: Set up your Mapbox developer keys as described in https://github.com/rnmapbox/maps/blob/main/android/install.md#adding-mapbox-maven-repo (no need to change build.gradle, just set up gradle.properties)
 
-* iOS: Set up your Mapbox developer keys as described in [https://github.com/rnmapbox/maps/blob/main/ios/install.md#adding-mapbox-maven-repo](https://github.com/rnmapbox/maps/blob/main/ios/install.md#mapbox-maps-sdk-v10) (add your cerdentials to .netrc as described)
+* iOS: 
+  1. Set up your Mapbox developer keys as described in [https://github.com/rnmapbox/maps/blob/main/ios/install.md#adding-mapbox-maven-repo](https://github.com/rnmapbox/maps/blob/main/ios/install.md#mapbox-maps-sdk-v10) (add your cerdentials to .netrc as described)
+  2. Install pod dependencies
+    ```
+    cd ios
+    pod install
+    ```
 
 
 <br>


### PR DESCRIPTION
## Description

While installing the example project, it was required to go in the iOS folder and run `pod install` to install the dependencies.
This PR adds this step to the README.

## Checklist

<!-- Check completed item: [X] -->

- [-] I have tested this on a device/simulator for each compatible OS
- [X] I updated the documentation with running `yarn generate` in the root folder
- [-] I added/updated a sample - if a new feature was implemented (`/example`)
`[-]` = not applicable