### PR TITLE
fix(ios,v10): location manager race condition with initial location update

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLLocationModule.swift
+++ b/ios/RCTMGL-v10/RCTMGLLocationModule.swift
@@ -42,6 +42,126 @@ protocol LocationProviderRCTMGLDelegate : AnyObject {
   func locationManager(_ locationManager: LocationProviderRCTMGL, didUpdateLocation: RCTMGLLocation)
 }
 
+class RCTMGLAppleLocationProvider: NSObject {
+    private var locationProvider: CLLocationManager
+    private var privateLocationProviderOptions: LocationOptions {
+        didSet {
+            locationProvider.distanceFilter = privateLocationProviderOptions.distanceFilter
+            locationProvider.desiredAccuracy = privateLocationProviderOptions.desiredAccuracy
+            locationProvider.activityType = privateLocationProviderOptions.activityType
+        }
+    }
+    private weak var delegate: LocationProviderDelegate?
+
+    public var headingOrientation: CLDeviceOrientation {
+        didSet { locationProvider.headingOrientation = headingOrientation }
+    }
+
+    public override init() {
+        locationProvider = CLLocationManager()
+        privateLocationProviderOptions = LocationOptions()
+        headingOrientation = locationProvider.headingOrientation
+        super.init()
+        locationProvider.delegate = self
+    }
+}
+
+extension RCTMGLAppleLocationProvider: LocationProvider {
+
+    public var locationProviderOptions: LocationOptions {
+        get { privateLocationProviderOptions }
+        set { privateLocationProviderOptions = newValue }
+    }
+
+    public var authorizationStatus: CLAuthorizationStatus {
+        if #available(iOS 14.0, *) {
+            return locationProvider.authorizationStatus
+        } else {
+            return CLLocationManager.authorizationStatus()
+        }
+    }
+
+    public var accuracyAuthorization: CLAccuracyAuthorization {
+        if #available(iOS 14.0, *) {
+            return locationProvider.accuracyAuthorization
+        } else {
+            return .fullAccuracy
+        }
+    }
+
+    public var heading: CLHeading? {
+        return locationProvider.heading
+    }
+
+    public func setDelegate(_ delegate: LocationProviderDelegate) {
+        self.delegate = delegate
+    }
+
+    public func requestAlwaysAuthorization() {
+        locationProvider.requestAlwaysAuthorization()
+    }
+
+    public func requestWhenInUseAuthorization() {
+        locationProvider.requestWhenInUseAuthorization()
+    }
+
+    @available(iOS 14.0, *)
+    public func requestTemporaryFullAccuracyAuthorization(withPurposeKey purposeKey: String) {
+        locationProvider.requestTemporaryFullAccuracyAuthorization(withPurposeKey: purposeKey)
+    }
+
+    public func startUpdatingLocation() {
+        locationProvider.startUpdatingLocation()
+    }
+
+    public func stopUpdatingLocation() {
+        locationProvider.stopUpdatingLocation()
+    }
+
+    public func startUpdatingHeading() {
+        locationProvider.startUpdatingHeading()
+    }
+
+    public func stopUpdatingHeading() {
+        locationProvider.stopUpdatingHeading()
+    }
+
+    public func dismissHeadingCalibrationDisplay() {
+        locationProvider.dismissHeadingCalibrationDisplay()
+    }
+}
+
+extension RCTMGLAppleLocationProvider: CLLocationManagerDelegate {
+    public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        delegate?.locationProvider(self, didUpdateLocations: locations)
+    }
+
+    public func locationManager(_ manager: CLLocationManager, didUpdateHeading heading: CLHeading) {
+        delegate?.locationProvider(self, didUpdateHeading: heading)
+    }
+
+    public func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        delegate?.locationProvider(self, didFailWithError: error)
+    }
+
+    @available(iOS 14.0, *)
+    public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        delegate?.locationProviderDidChangeAuthorization(self)
+    }
+
+    public func locationManagerShouldDisplayHeadingCalibration(_ manager: CLLocationManager) -> Bool {
+        guard let calibratingDelegate = delegate as? CalibratingLocationProviderDelegate else {
+            return false
+        }
+
+        return calibratingDelegate.locationProviderShouldDisplayHeadingCalibration(self)
+    }
+}
+
+internal protocol CalibratingLocationProviderDelegate: LocationProviderDelegate {
+    func locationProviderShouldDisplayHeadingCalibration(_ locationProvider: LocationProvider) -> Bool
+}
+
 /// LocationProviderRCTMGL listens to updates from a locationProvider and implements the LocationProvider interface itself
 /// So it can be source of Mapbox locationProduces (which updates location pluck and viewport if configured) as well as source to updates
 /// to RCTMGLLocationModules.
@@ -84,7 +204,7 @@ class LocationProviderRCTMGL : LocationProviderDelegate {
   }
 
   init() {
-    provider = AppleLocationProvider()
+    provider = RCTMGLAppleLocationProvider()
     provider.setDelegate(self)
   }
   
@@ -222,6 +342,17 @@ extension LocationProviderRCTMGL: LocationProvider {
   func setDelegate(_ delegate: LocationProviderDelegate) {
     provider.setDelegate(self)
     locationProviderDelage = delegate
+
+    if let lastLocation = lastKnownLocation {
+      DispatchQueue.main.async {
+        self.locationProviderDelage?.locationProvider(self, didUpdateLocations: [lastLocation])
+      }
+    }
+    if let lastHeading = lastKnownHeading {
+      DispatchQueue.main.async { [self] in
+        self.locationProviderDelage?.locationProvider(self, didUpdateHeading: lastHeading)
+      }
+    }
   }
   
   func requestAlwaysAuthorization() {


### PR DESCRIPTION
Fixes: #2919 



The issue is on initial update. These are the operations, normally
1.) subscribe to location updates from CoreLocation
2.) Mapbox maps viewport subscribes to locationProvider
3.) first update is received

Now when we use our own UserLocation component the order is (1) (3) (2), as we listen to updates a bit earlier,  so the first update might be received before Mapbox maps viewport subscribes to updates. Therefore the first update might be lost.

To fix this I've modified the code so when the delegate is attached to LocationProvider, and we have a location, we send this location to the delegate. 



To reproduce on iOS simulator set location to a static location like (Features/Location/Apple). Then run the following component:


```tsx

import React, { useState, useRef } from 'react';
import Mapbox, {
  MarkerView,
  PointAnnotation,
  UserLocationRenderMode,
  UserTrackingMode,
  ShapeSource,
  Images,
  LineLayer,
  ImageSource,
  UserLocation,
  MapView,
  MapState,
  Camera,
} from '@rnmapbox/maps';
import { StyleSheet } from 'react-native';

const Bug = () => {
  const camera = useRef<Camera>(null);
  const map = useRef<MapView>(null);
  const [followingUser, setFollowingUser] = useState(true);
  const [customStyle, setCustomStyle] = useState(
    `mapbox://styles/mapbox/streets-v12?fresh=true&t=${new Date().getTime()}`,
  ); // THIS STYLE IS THE STANDARD STREET STYLE
  const [zoom, setZoom] = useState(17);

  const onCameraChanged = async () => {
    const currentZoom = await map.current?.getZoom();
    if (currentZoom != zoom) {
      setZoom(currentZoom);
    }
  };

  return (
    <Mapbox.MapView
      ref={map}
      styleURL={customStyle}
      style={styles.mapContainer}
      scaleBarEnabled={false}
      logoEnabled={false}
      compassEnabled={true}
      compassFadeWhenNorth={false}
      onDidFinishLoadingStyle={() => console.log('loaded style')}
      onMapIdle={() => console.log('IDDDDLEE')}
      onDidFinishLoadingMap={() => console.log('finish')}
      attributionEnabled={false}
      onCameraChanged={onCameraChanged}
    >
      <Camera
        ref={camera}
        followUserLocation={followingUser}
        followUserMode={UserTrackingMode.Follow}
        animationMode={'flyTo'}
        followZoomLevel={17}
      />
      {false && <UserLocation renderMode={UserLocationRenderMode.Native} />}
      {true && (
        <UserLocation
          androidRenderMode={'gps'}
          renderMode={UserLocationRenderMode.Normal}
          showsUserHeadingIndicator={true}
          visible={true}
          onUpdate={() => console.log('on update')}
          requestsAlwaysUse={true}
          minDisplacement={3}
          animated={true}
        />
      )}
    </Mapbox.MapView>
  );
};

const styles = StyleSheet.create({
  mapContainer: {
    flex: 1,
    width: '100%',
    height: '100%',
  },
});

export default Bug;
```