### PR TITLE
Renamed OnDestory to OnDestroy in RCTMGLCamera's RemovalReason

### DIFF
--- a/ios/RCTMGL-v10/RCTMGLCamera.swift
+++ b/ios/RCTMGL-v10/RCTMGLCamera.swift
@@ -3,7 +3,7 @@ import MapboxMaps
 import Turf
 
 enum RemovalReason {
-    case ViewRemoval, StyleChange, OnDestory, ComponentChange, Reorder
+    case ViewRemoval, StyleChange, OnDestroy, ComponentChange, Reorder
 }
 
 protocol RCTMGLMapComponent: AnyObject {

--- a/ios/RCTMGL-v10/RCTMGLMapView.swift
+++ b/ios/RCTMGL-v10/RCTMGLMapView.swift
@@ -129,7 +129,7 @@ open class RCTMGLMapView : MapView {
       if let entryIndex = entryIndex {
         var entry = features[entryIndex]
         if (entry.addedToMap) {
-            mapComponent.removeFromMap(self, reason: .OnDestory)
+            mapComponent.removeFromMap(self, reason: .OnDestroy)
             entry.addedToMap = false
         }
         features.remove(at: entryIndex)


### PR DESCRIPTION
## Description
Destroy was misspelled in the RemovalReason swift enum, so I renamed OnDestory to OnDestroy.

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
- [x] I added/updated a sample - if a new feature was implemented (`/example`)

