### PR TITLE
feat: initial v11 on iOS

### DIFF
--- a/android/src/main/java-v10/com/mapbox/rctmgl/mapbox/Light.kt
+++ b/android/src/main/java-v10/com/mapbox/rctmgl/mapbox/Light.kt
@@ -1,0 +1,6 @@
+package com.mapbox.rctmgl.mapbox
+
+
+public class Light {
+
+}

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -2,6 +2,10 @@ require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
 $RNMapboxMapsImpl = 'mapbox' # mapbox-gl, maplibre
+if ENV['MBX11']
+  $RNMapboxMapsUseV11 = true # use 11 version
+  $RNMapboxMapsVersion = '= 11.0.0-beta.3'
+end
 
 if ENV['CI_MAP_IMPL']
   fail "Invalid CI_MAP_IMPL value" unless ["maplibre", "mapbox-gl", "mapbox"].include?(ENV['CI_MAP_IMPL'])
@@ -9,11 +13,12 @@ if ENV['CI_MAP_IMPL']
   $RNMapboxMapsImpl = ENV['CI_MAP_IMPL']
 end
 
-if $RNMapboxMapsImpl == 'mapbox'
-  platform :ios, '13.0'
-else
-  platform :ios, '12.4'
-end
+#if $RNMapboxMapsImpl == 'mapbox'
+#  platform :ios, '13.0'
+#else
+#  platform :ios, '12.4'
+#end
+platform :ios, '13.0'
 
 # If you are using a `react-native-flipper` your iOS build will fail when `NO_FLIPPER=1` is set.
 # because `react-native-flipper` depends on (FlipperKit,...) that will be excluded

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -338,8 +338,12 @@ PODS:
   - React-jsinspector (0.71.7)
   - React-logger (0.71.7):
     - glog
-  - react-native-safe-area-context (4.7.1):
+  - react-native-safe-area-context (4.6.4):
+    - RCT-Folly
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - ReactCommon/turbomodule/core
   - React-perflogger (0.71.7)
   - React-RCTActionSheet (0.71.7):
     - React-Core/RCTActionSheetHeaders (= 0.71.7)
@@ -424,21 +428,20 @@ PODS:
     - React-jsi (= 0.71.7)
     - React-logger (= 0.71.7)
     - React-perflogger (= 0.71.7)
-  - RNCAsyncStorage (1.19.2):
+  - RNCAsyncStorage (1.19.0):
     - React-Core
-
-  - rnmapbox-maps (10.0.14):
+  - rnmapbox-maps (10.1.0-beta.1):
     - MapboxMaps (~> 10.16.0)
     - React
     - React-Core
-    - rnmapbox-maps/DynamicLibrary (= 10.0.14)
+    - rnmapbox-maps/DynamicLibrary (= 10.1.0-beta.1)
     - Turf
-  - rnmapbox-maps/DynamicLibrary (10.0.14):
+  - rnmapbox-maps/DynamicLibrary (10.1.0-beta.1):
     - MapboxMaps (~> 10.16.0)
     - React
     - React-Core
     - Turf
-  - RNScreens (3.24.0):
+  - RNScreens (3.22.0):
     - React-Core
     - React-RCTImage
   - RNSVG (12.5.1):
@@ -446,7 +449,7 @@ PODS:
   - RNVectorIcons (9.2.0):
     - React-Core
   - SocketRocket (0.6.0)
-  - Turf (2.4.0)
+  - Turf (2.7.0)
   - Yoga (1.14.0)
   - YogaKit (1.18.1):
     - Yoga (~> 1.14)
@@ -661,7 +664,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: eaa5f71eb8f6861cf0e57f1a0f52aeb020d9e18e
   React-jsinspector: 9885f6f94d231b95a739ef7bb50536fb87ce7539
   React-logger: 3f8ebad1be1bf3299d1ab6d7f971802d7395c7ef
-  react-native-safe-area-context: 9697629f7b2cda43cf52169bb7e0767d330648c2
+  react-native-safe-area-context: 68b07eabfb0d14547d36f6929c0e98d818064f02
   React-perflogger: 2d505bbe298e3b7bacdd9e542b15535be07220f6
   React-RCTActionSheet: 0e96e4560bd733c9b37efbf68f5b1a47615892fb
   React-RCTAnimation: fd138e26f120371c87e406745a27535e2c8a04ef
@@ -675,16 +678,16 @@ SPEC CHECKSUMS:
   React-RCTVibration: 08f132cad9896458776f37c112e71d60aef1c6ae
   React-runtimeexecutor: c5c89f8f543842dd864b63ded1b0bbb9c9445328
   ReactCommon: dbfbe2f7f3c5ce4ce44f43f2fd0d5950d1eb67c5
-  RNCAsyncStorage: f57e929cd7757f2cb3dd8186d123c09e8281a1ad
-  rnmapbox-maps: c778f0cb59634946d44dfaa354de4e63552d10ff
-  RNScreens: b21dc57dfa2b710c30ec600786a3fc223b1b92e7
+  RNCAsyncStorage: 4b98ac3c64efa4e35c1197cb0c5ca5e9f5d4c666
+  rnmapbox-maps: a912599e99f1d670b650056ec2d52bc528932c6f
+  RNScreens: 68fd1060f57dd1023880bf4c05d74784b5392789
   RNSVG: d7d7bc8229af3842c9cfc3a723c815a52cdd1105
   RNVectorIcons: fcc2f6cb32f5735b586e66d14103a74ce6ad61f8
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
-  Turf: 60b93cfdc62758526bc7bf1ef191a829aeb9694d
+  Turf: 13d1a92d969ca0311bbc26e8356cca178ce95da2
   Yoga: d56980c8914db0b51692f55533409e844b66133c
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: bfab0669ee1685ddf9f7583652d73bd51f1c9919
+PODFILE CHECKSUM: 8d1544f6b7b7a6eb430e9f982a1166fec762cad9
 
 COCOAPODS: 1.12.1

--- a/ios/RCTMGL-v10/CustomHttpHeaders.swift
+++ b/ios/RCTMGL-v10/CustomHttpHeaders.swift
@@ -10,11 +10,20 @@ class CustomHttpHeaders : HttpServiceInterceptorInterface {
   var customHeaders : [String:String] = [:]
 
   func install() {
+    #if RNMBX_11
+    HttpServiceFactory.setHttpServiceInterceptorForInterceptor(self)
+    #else
     HttpServiceFactory.getInstance().setInterceptorForInterceptor(self)
+    #endif
   }
 
   func reset() {
+    #if RNMBX_11
+    HttpServiceFactory.setHttpServiceInterceptorForInterceptor(nil)
+    #else
     HttpServiceFactory.getInstance().setInterceptorForInterceptor(nil)
+
+    #endif
   }
 
   // MARK: - HttpServiceInterceptorInterface
@@ -36,4 +45,13 @@ class CustomHttpHeaders : HttpServiceInterceptorInterface {
   func onResponse(for response: HttpResponse) -> HttpResponse {
     return response
   }
+  
+  #if RNMBX_11
+  func onUpload(forUpload upload: UploadOptions) -> UploadOptions {
+    customHeaders.forEach {(key,value) in
+      upload.headers[key] = value
+    }
+    return upload
+  }
+  #endif
 }

--- a/ios/RCTMGL-v10/MBXMapViewManager.swift
+++ b/ios/RCTMGL-v10/MBXMapViewManager.swift
@@ -1,5 +1,11 @@
 import MapboxMaps
 
+#if RNMBX_11
+extension QueriedSourceFeature {
+  var feature: Feature { return self.queriedFeature.feature }
+}
+#endif
+
 @objc(MBXMapViewManager)
 public class MBXMapViewManager: RCTViewManager {
     @objc
@@ -218,13 +224,21 @@ extension MBXMapViewManager {
         }
       }
     }
+
+    static func clearData(_ view: RCTMGLMapView, completion: @escaping (Error?) -> Void) {
+      #if RNMBX_11
+      MapboxMap.clearData(completion: completion)
+      #else
+      view.mapboxMap.clearData(completion: completion)
+      #endif
+    }
   
     @objc public static func clearData(
-        _ view: RCTMGLMapView,
+        _ mapView: RCTMGLMapView,
         resolver:@escaping RCTPromiseResolveBlock,
         rejecter:@escaping RCTPromiseRejectBlock
     ) {
-        view.mapboxMap.clearData { error in
+        self.clearData(mapView) { error in
           if let error = error {
             rejecter("clearData","failed to clearData: \(error.localizedDescription)", error)
           } else {

--- a/ios/RCTMGL-v10/MBXMapViewModule.mm
+++ b/ios/RCTMGL-v10/MBXMapViewModule.mm
@@ -114,21 +114,21 @@ RCT_EXPORT_METHOD(getZoom:(NSNumber*)viewRef resolve:(RCTPromiseResolveBlock)res
 }
 
 
-RCT_EXPORT_METHOD(queryRenderedFeaturesAtPoint:(NSNumber*)viewRef atPoint:(NSArray *)atPoint withFilter:(NSArray *)withFilter withLayerIDs:(NSArray *)withLayerIDs resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+RCT_EXPORT_METHOD(queryRenderedFeaturesAtPoint:(nonnull NSNumber*)viewRef atPoint:(nonnull NSArray *)atPoint withFilter:(NSArray *)withFilter withLayerIDs:(NSArray *)withLayerIDs resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     [self withMapView:viewRef block:^(MBXMapView *view) {
         [MBXMapViewManager queryRenderedFeaturesAtPoint:view atPoint:atPoint withFilter:withFilter withLayerIDs:withLayerIDs resolver:resolve rejecter:reject];
     } reject:reject methodName:@"queryRenderedFeaturesAtPoint"];
 }
 
 
-RCT_EXPORT_METHOD(queryRenderedFeaturesInRect:(NSNumber*)viewRef withBBox:(NSArray *)withBBox withFilter:(NSArray *)withFilter withLayerIDs:(NSArray *)withLayerIDs resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+RCT_EXPORT_METHOD(queryRenderedFeaturesInRect:(nonnull NSNumber*)viewRef withBBox:(NSArray *)withBBox withFilter:(NSArray *)withFilter withLayerIDs:(NSArray *)withLayerIDs resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     [self withMapView:viewRef block:^(MBXMapView *view) {
         [MBXMapViewManager queryRenderedFeaturesInRect:view withBBox:withBBox withFilter:withFilter withLayerIDs:withLayerIDs resolver:resolve rejecter:reject];
     } reject:reject methodName:@"queryRenderedFeaturesInRect"];
 }
 
 
-RCT_EXPORT_METHOD(queryTerrainElevation:(NSNumber*)viewRef coordinates:(NSArray *)coordinates resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+RCT_EXPORT_METHOD(queryTerrainElevation:(nonnull NSNumber*)viewRef coordinates:(NSArray *)coordinates resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     [self withMapView:viewRef block:^(MBXMapView *view) {
         [MBXMapViewManager queryTerrainElevation:view coordinates:coordinates resolver:resolve rejecter:reject];
     } reject:reject methodName:@"queryTerrainElevation"];
@@ -142,13 +142,13 @@ RCT_EXPORT_METHOD(setHandledMapChangedEvents:(nonnull NSNumber*)viewRef events:(
 }
 
 
-RCT_EXPORT_METHOD(setSourceVisibility:(NSNumber*)viewRef visible:(BOOL)visible sourceId:(NSString *)sourceId sourceLayerId:(NSString *)sourceLayerId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+RCT_EXPORT_METHOD(setSourceVisibility:(nonnull NSNumber*)viewRef visible:(BOOL)visible sourceId:(NSString *)sourceId sourceLayerId:(NSString *)sourceLayerId resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     [self withMapView:viewRef block:^(MBXMapView *view) {
         [MBXMapViewManager setSourceVisibility:view visible:visible sourceId:sourceId sourceLayerId:sourceLayerId resolver:resolve rejecter:reject];
     } reject:reject methodName:@"setSourceVisibility"];
 }
 
-RCT_EXPORT_METHOD(querySourceFeatures:(NSNumber*)viewRef sourceId:(NSString*)sourceId withFilter:(NSArray<id>*)withFilter withSourceLayerIDs:(NSArray<NSString*>*)withSourceLayerIDs resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+RCT_EXPORT_METHOD(querySourceFeatures:(nonnull NSNumber*)viewRef sourceId:(NSString*)sourceId withFilter:(NSArray<id>*)withFilter withSourceLayerIDs:(NSArray<NSString*>*)withSourceLayerIDs resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     [self withMapView:viewRef block:^(MBXMapView *view) {
         [MBXMapViewManager querySourceFeatures:view withSourceId:sourceId withFilter:withFilter withSourceLayerIds:withSourceLayerIDs resolver:resolve rejecter:reject];
     } reject:reject methodName:@"querySourceFeatures"];

--- a/ios/RCTMGL-v10/MGLModule.swift
+++ b/ios/RCTMGL-v10/MGLModule.swift
@@ -1,13 +1,25 @@
 import Foundation
 import MapboxMaps
+#if canImport(MapboxMobileEvents)
 import MapboxMobileEvents
+#endif
 
 
 let DEFAULT_SOURCE_ID = "composite";
 
 @objc(MGLModule)
 class MGLModule : NSObject {
-  static var accessToken : String?
+  #if RNMBX_11
+  static var accessToken : String? {
+    didSet {
+      if let token = accessToken {
+        MapboxOptions.accessToken = token
+      }
+    }
+  }
+  #else
+    static var accessToken : String?
+  #endif
     
   @objc
   func constantsToExport() -> [AnyHashable: Any]! {
@@ -91,7 +103,9 @@ class MGLModule : NSObject {
   }
   
   @objc func setTelemetryEnabled(_ telemetryEnabled: Bool) {
+    #if !RNMBX_11 // RNMBX_11_TODO
     UserDefaults.mme_configuration().mme_isCollectionEnabled = telemetryEnabled
+    #endif
   }
 
   @objc func setWellKnownTileServer(_ tileServer: String) {

--- a/ios/RCTMGL-v10/MGLSnapshotModule.swift
+++ b/ios/RCTMGL-v10/MGLSnapshotModule.swift
@@ -93,13 +93,19 @@ class MGLSnapshotModule : NSObject {
           let height = jsOptions["height"] as? NSNumber else {
       throw RCTMGLError.paramError("width, height: is not a number")
     }
-    
+    #if RNMBX_11
+    let mapSnapshotOptions = MapSnapshotOptions(
+      size: CGSize(width: width.doubleValue, height: height.doubleValue),
+      pixelRatio: 1.0
+    )
+    #else
     let resourceOptions = ResourceOptions(accessToken: MGLModule.accessToken!)
     let mapSnapshotOptions = MapSnapshotOptions(
       size: CGSize(width: width.doubleValue, height: height.doubleValue),
       pixelRatio: 1.0,
       resourceOptions: resourceOptions
     )
+    #endif
     
     return mapSnapshotOptions
   }

--- a/ios/RCTMGL-v10/RCTMGLAtmosphere.swift
+++ b/ios/RCTMGL-v10/RCTMGLAtmosphere.swift
@@ -1,5 +1,9 @@
 import MapboxMaps
 
+#if RNMBX_11
+typealias Style = StyleManager
+#endif
+
 @objc(RCTMGLAtmosphere)
 class RCTMGLAtmosphere : RCTMGLSingletonLayer, RCTMGLMapComponent, RCTMGLSourceConsumer {
   var atmosphere : Atmosphere? = nil

--- a/ios/RCTMGL-v10/RCTMGLBackgroundLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLBackgroundLayer.swift
@@ -5,10 +5,11 @@ class RCTMGLBackgroundLayer: RCTMGLLayer {
   typealias LayerType = BackgroundLayer
 
   override func makeLayer(style: Style) throws -> Layer {
-    let vectorSource : VectorSource = try self.layerWithSourceID(in: style)
     var layer = LayerType(id: self.id!)
+    #if !RNMBX_11
     layer.sourceLayer = self.sourceLayerID
     layer.source = sourceID
+    #endif
     return layer
   }
 

--- a/ios/RCTMGL-v10/RCTMGLCircleLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLCircleLayer.swift
@@ -7,7 +7,11 @@ class RCTMGLCircleLayer: RCTMGLVectorLayer {
 
   override func makeLayer(style: Style) throws -> Layer {
     let _ : VectorSource = try self.layerWithSourceID(in: style)
+    #if RNMBX_11
+    var layer = LayerType(id: self.id!, source: self.sourceID!)
+    #else
     var layer = LayerType(id: self.id!)
+    #endif
     layer.sourceLayer = self.sourceLayerID
     layer.source = sourceID
     return layer

--- a/ios/RCTMGL-v10/RCTMGLFillExtrustionLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLFillExtrustionLayer.swift
@@ -6,7 +6,11 @@ class RCTMGLFillExtrusionLayer: RCTMGLVectorLayer {
 
   override func makeLayer(style: Style) throws -> Layer {
     let _ : VectorSource = try self.layerWithSourceID(in: style)
+    #if RNMBX_11
+    var layer = LayerType(id: self.id!, source:sourceID!)
+    #else
     var layer = LayerType(id: self.id!)
+    #endif
     layer.sourceLayer = self.sourceLayerID
     layer.source = sourceID
     return layer

--- a/ios/RCTMGL-v10/RCTMGLFillLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLFillLayer.swift
@@ -6,7 +6,11 @@ class RCTMGLFillLayer: RCTMGLVectorLayer {
 
   override func makeLayer(style: Style) throws -> Layer {
     let _ : VectorSource = try self.layerWithSourceID(in: style)
+    #if RNMBX_11
+    var layer: Layer = FillLayer(id: self.id!, source: sourceID!)
+    #else
     var layer: Layer = FillLayer(id: self.id!)
+    #endif
     
     setOptions(&layer)
     

--- a/ios/RCTMGL-v10/RCTMGLHeatmapLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLHeatmapLayer.swift
@@ -6,8 +6,11 @@ class RCTMGLHeatmapLayer: RCTMGLVectorLayer {
 
   override func makeLayer(style: Style) throws -> Layer {
     let _ : VectorSource = try self.layerWithSourceID(in: style)
+    #if RNMBX_11
+    var layer: Layer = LayerType(id: self.id!, source: self.sourceID!)
+    #else
     var layer: Layer = LayerType(id: self.id!)
-    
+    #endif
     setOptions(&layer)
     
     return layer

--- a/ios/RCTMGL-v10/RCTMGLImageSource.swift
+++ b/ios/RCTMGL-v10/RCTMGLImageSource.swift
@@ -35,7 +35,11 @@ class RCTMGLImageSource : RCTMGLSource {
 
   override func makeSource() -> Source
   {
+    #if RNMBX_11
+    var result = ImageSource(id: self.id)
+    #else
     var result = ImageSource()
+    #endif
     if let url = url {
       result.url = url
     }

--- a/ios/RCTMGL-v10/RCTMGLImages.swift
+++ b/ios/RCTMGL-v10/RCTMGLImages.swift
@@ -4,6 +4,18 @@ protocol RCTMGLImageSetter : AnyObject {
   func addImage(name: String, image: UIImage, sdf: Bool?, stretchX: [[NSNumber]], stretchY: [[NSNumber]], content: [NSNumber]?, log: String) -> Bool
 }
 
+func hasImage(style: Style, name: String) -> Bool {
+  #if RNMBX_11
+  return style.imageExists(withId: name)
+  #else
+  return (style.styleManager.getStyleImage(forImageId: name) != nil)
+  #endif
+}
+
+#if RNMBX_11
+typealias StyleImageMissingPayload = StyleImageMissing
+#endif
+
 class RCTMGLImages : UIView, RCTMGLMapComponent {
   
   weak var bridge : RCTBridge! = nil
@@ -104,7 +116,7 @@ class RCTMGLImages : UIView, RCTMGLMapComponent {
         if !sameImage(oldValue: oldImages[name], newValue: images[name]) {
           missingImages[name] = images[name]
         } else {
-          if style.styleManager.getStyleImage(forImageId: name) == nil {
+          if !hasImage(style: style, name: name) {
             logged("RCTMGLImages.addImagePlaceholder") {
               try? style.addImage(placeholderImage, id: name, stretchX: [], stretchY: [])
               missingImages[name] = images[name]
@@ -231,7 +243,7 @@ class RCTMGLImages : UIView, RCTMGLMapComponent {
   func addNativeImages(style: Style, nativeImages: [NativeImageInfo]) {
     for imageInfo in nativeImages {
       let imageName = imageInfo.name
-      if style.styleManager.getStyleImage(forImageId: imageInfo.name) == nil {
+      if !hasImage(style: style, name: imageInfo.name) {
         if let image = UIImage(named: imageName) {
           logged("RCTMGLImage.addNativeImage: \(imageName)") {
             try style.addImage(image, id: imageName, sdf: imageInfo.sdf,

--- a/ios/RCTMGL-v10/RCTMGLLight.swift
+++ b/ios/RCTMGL-v10/RCTMGLLight.swift
@@ -1,4 +1,8 @@
-import MapboxMaps
+@_spi(Experimental) import MapboxMaps
+
+#if RNMBX_11
+typealias Light = FlatLight
+#endif
 
 @objc(RCTMGLLight)
 class RCTMGLLight: UIView, RCTMGLMapComponent {
@@ -17,9 +21,15 @@ class RCTMGLLight: UIView, RCTMGLMapComponent {
   }
   
   func apply(light: Light) {
-    let lightData = try! JSONEncoder().encode(light)
-    let lightDictionary = try! JSONSerialization.jsonObject(with: lightData)
-    try! self.map.style.setLight(properties: lightDictionary as! [String:Any])
+    logged("RCTMGLLight.apply") {
+#if RNMBX_11
+      try self.map.setLights(light)
+#else
+      let lightData = try JSONEncoder().encode(light)
+      let lightDictionary = try JSONSerialization.jsonObject(with: lightData)
+      try self.map.style.setLight(properties: lightDictionary as! [String:Any])
+#endif
+    }
   }
 
   func addStyles() {

--- a/ios/RCTMGL-v10/RCTMGLLineLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLLineLayer.swift
@@ -6,7 +6,11 @@ class RCTMGLLineLayer: RCTMGLVectorLayer {
 
   override func makeLayer(style: Style) throws -> Layer {
     let vectorSource : VectorSource = try self.layerWithSourceID(in: style)
+    #if RNMBX_11
+    var layer = LayerType(id: self.id!, source: sourceID!)
+    #else
     var layer = LayerType(id: self.id!)
+    #endif
     layer.sourceLayer = self.sourceLayerID
     layer.source = sourceID
     return layer

--- a/ios/RCTMGL-v10/RCTMGLLocationModule.swift
+++ b/ios/RCTMGL-v10/RCTMGLLocationModule.swift
@@ -1,6 +1,8 @@
 import Foundation
 import MapboxMaps
 
+#if !RNMBX_11
+
 @objc(RCTMGLLocation)
 class RCTMGLLocation: NSObject {
   var location : CLLocation = CLLocation(latitude: 0.0, longitude: 0.0)
@@ -32,6 +34,10 @@ let RCT_MAPBOX_USER_LOCATION_UPDATE = "MapboxUserLocationUpdate";
 /// This implementation of LocationProviderDelegate is used by `LocationManager` to work around
 /// the fact that the `LocationProvider` API does not allow the delegate to be set to `nil`.
 internal class EmptyLocationProviderDelegate: LocationProviderDelegate {
+    #if RNMBX_11
+    func onLocationUpdateReceived(for locations: [Location]) {}
+    #endif
+  
     func locationProvider(_ provider: LocationProvider, didFailWithError error: Error) {}
     func locationProvider(_ provider: LocationProvider, didUpdateHeading newHeading: CLHeading) {}
     func locationProvider(_ provider: LocationProvider, didUpdateLocations locations: [CLLocation]) {}
@@ -44,6 +50,18 @@ protocol LocationProviderRCTMGLDelegate : AnyObject {
 
 class RCTMGLAppleLocationProvider: NSObject {
     private var locationProvider: CLLocationManager
+  
+  #if RNMBX_11
+    private var observers : [LocationObserver] = []
+    private var privateAppleLocationProviderOptions: AppleLocationProvider.Options {
+        didSet {
+            locationProvider.distanceFilter = privateAppleLocationProviderOptions.distanceFilter
+            locationProvider.desiredAccuracy = privateAppleLocationProviderOptions.desiredAccuracy
+            locationProvider.activityType = privateAppleLocationProviderOptions.activityType
+        }
+    }
+    private var privateLocationProviderOptions: LocationOptions
+  #else
     private var privateLocationProviderOptions: LocationOptions {
         didSet {
             locationProvider.distanceFilter = privateLocationProviderOptions.distanceFilter
@@ -52,6 +70,7 @@ class RCTMGLAppleLocationProvider: NSObject {
         }
     }
     private weak var delegate: LocationProviderDelegate?
+  #endif
 
     public var headingOrientation: CLDeviceOrientation {
         didSet { locationProvider.headingOrientation = headingOrientation }
@@ -59,6 +78,9 @@ class RCTMGLAppleLocationProvider: NSObject {
 
     public override init() {
         locationProvider = CLLocationManager()
+      #if RNMBX_11
+        privateAppleLocationProviderOptions = AppleLocationProvider.Options()
+      #endif
         privateLocationProviderOptions = LocationOptions()
         headingOrientation = locationProvider.headingOrientation
         super.init()
@@ -67,6 +89,20 @@ class RCTMGLAppleLocationProvider: NSObject {
 }
 
 extension RCTMGLAppleLocationProvider: LocationProvider {
+  #if RNMBX_11
+    func addLocationObserver(for observer: LocationObserver) {
+      observers.append(observer)
+    }
+    
+    func removeLocationObserver(for observer: LocationObserver) {
+      observers.removeAll { $0 === observer }
+    }
+    
+    func getLastObservedLocation() -> Location? {
+      locationProvider.location
+    }
+  #endif
+  
 
     public var locationProviderOptions: LocationOptions {
         get { privateLocationProviderOptions }
@@ -132,22 +168,38 @@ extension RCTMGLAppleLocationProvider: LocationProvider {
 }
 
 extension RCTMGLAppleLocationProvider: CLLocationManagerDelegate {
-    public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        delegate?.locationProvider(self, didUpdateLocations: locations)
-    }
+  public func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+  #if RNMBX_11
+    observers.forEach { $0.onLocationUpdateReceived(for: locations) }
+  #else
+    delegate?.locationProvider(self, didUpdateLocations: locations)
+  #endif
+  }
 
-    public func locationManager(_ manager: CLLocationManager, didUpdateHeading heading: CLHeading) {
-        delegate?.locationProvider(self, didUpdateHeading: heading)
-    }
+    public func locationManager(_ manager: CLLocationManager, didUpdateHeading heading: CLHeading)
+  {
+    #if RNMBX_11
+      
+    #else
+      delegate?.locationProvider(self, didUpdateHeading: heading)
+    #endif
+  }
 
-    public func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        delegate?.locationProvider(self, didFailWithError: error)
-    }
+  public func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+    #if RNMBX_11
+      
+    #else
+      delegate?.locationProvider(self, didFailWithError: error)
+    #endif
+  }
 
     @available(iOS 14.0, *)
-    public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
-        delegate?.locationProviderDidChangeAuthorization(self)
-    }
+  public func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+    #if RNMBX_11
+    #else
+      delegate?.locationProviderDidChangeAuthorization(self)
+    #endif
+  }
 
     public func locationManagerShouldDisplayHeadingCalibration(_ manager: CLLocationManager) -> Bool {
         guard let calibratingDelegate = delegate as? CalibratingLocationProviderDelegate else {
@@ -573,4 +625,5 @@ class RCTMGLLocationModule: RCTEventEmitter, LocationProviderRCTMGLDelegate {
   }
 }
 
+#endif
 

--- a/ios/RCTMGL-v10/RCTMGLLocationModuleV11.swift
+++ b/ios/RCTMGL-v10/RCTMGLLocationModuleV11.swift
@@ -1,0 +1,32 @@
+#if RNMBX_11
+import MapboxMaps
+
+let RCT_MAPBOX_USER_LOCATION_UPDATE = "MapboxUserLocationUpdate";
+
+@objc(RCTMGLLocationModule)
+class RCTMGLLocationModule: RCTEventEmitter {
+  
+  static weak var shared : RCTMGLLocationModule? = nil
+  
+  override init() {
+    super.init()
+    RCTMGLLocationModule.shared = self
+  }
+  
+  @objc
+  override static func requiresMainQueueSetup() -> Bool {
+    return true
+  }
+  
+  @objc override func supportedEvents() -> [String]
+  {
+    return [RCT_MAPBOX_USER_LOCATION_UPDATE];
+  }
+
+  var locationProvider : LocationProvider & HeadingProvider {
+    get {
+      fatalError("RCTMGLLocationModule.locationProvider not implemented")
+    }
+  }
+}
+#endif

--- a/ios/RCTMGL-v10/RCTMGLNativeUserLocation.swift
+++ b/ios/RCTMGL-v10/RCTMGLNativeUserLocation.swift
@@ -18,7 +18,11 @@ class RCTMGLNativeUserLocation : UIView, RCTMGLMapComponent {
   func _applySettings(_ map: RCTMGLMapView) {
     map.location.options.puckType = .puck2D(.makeDefault(showBearing: iosShowsUserHeadingIndicator))
     if (iosShowsUserHeadingIndicator) {
+      #if RNMBX_11
+      map.location.options.puckBearing = .heading
+      #else
       map.location.options.puckBearingSource = .heading
+      #endif
       map.location.options.puckBearingEnabled = true
     } else {
       map.location.options.puckBearingEnabled = false

--- a/ios/RCTMGL-v10/RCTMGLOfflineModule.swift
+++ b/ios/RCTMGL-v10/RCTMGLOfflineModule.swift
@@ -33,11 +33,19 @@ class RCTMGLOfflineModule: RCTEventEmitter {
   }
   
   lazy var offlineManager : OfflineManager = {
+    #if RNMBX_11
+    return OfflineManager()
+    #else
     return OfflineManager(resourceOptions: .init(accessToken: MGLModule.accessToken!))
+    #endif
   }()
   
   lazy var offlineRegionManager: OfflineRegionManager = {
+    #if RNMBX_11
+    return OfflineRegionManager()
+    #else
     return OfflineRegionManager(resourceOptions: .init(accessToken: MGLModule.accessToken!))
+    #endif
   }()
 
   lazy var tileStore : TileStore = {
@@ -350,11 +358,20 @@ class RCTMGLOfflineModule: RCTEventEmitter {
     
     let stylePackLoadOptions = StylePackLoadOptions(glyphsRasterizationMode: .ideographsRasterizedLocally, metadata: pack.metadata)
     
+    #if RNMBX_11
+    let descriptorOptions = TilesetDescriptorOptions(
+      styleURI: styleURI,
+      zoomRange: zoomRange,
+      tilesets: [], // RNMBX_11_TODO
+      stylePackOptions: stylePackLoadOptions
+    )
+    #else
     let descriptorOptions = TilesetDescriptorOptions(
       styleURI: styleURI,
       zoomRange: zoomRange,
       stylePackOptions: stylePackLoadOptions
     )
+    #endif
     let tilesetDescriptor = self.offlineManager.createTilesetDescriptor(for: descriptorOptions)
     
     let loadOptions = TileRegionLoadOptions(

--- a/ios/RCTMGL-v10/RCTMGLRasterDemSource.swift
+++ b/ios/RCTMGL-v10/RCTMGLRasterDemSource.swift
@@ -30,7 +30,11 @@ class RCTMGLRasterDemSource : RCTMGLSource {
 
   override func makeSource() -> Source
   {
+    #if RNMBX_11 // RNMBX_11_TODO
+    var result = SourceType(id: "raster-dem-source-id-todo")
+    #else
     var result = SourceType()
+    #endif
     if let url = url {
       result.url = url
     } else if let tileUrlTemplates = tileUrlTemplates {

--- a/ios/RCTMGL-v10/RCTMGLRasterLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLRasterLayer.swift
@@ -6,7 +6,11 @@ class RCTMGLRasterLayer: RCTMGLLayer {
 
   override func makeLayer(style: Style) throws -> Layer {
     // let source : ImageSource = try self.sourceWithSourceID(in: style)
+    #if RNMBX_11
+    var layer = LayerType(id: self.id!, source: sourceID!)
+    #else
     var layer = LayerType(id: self.id!)
+    #endif
     layer.source = sourceID
     return layer
   }

--- a/ios/RCTMGL-v10/RCTMGLRasterSource.swift
+++ b/ios/RCTMGL-v10/RCTMGLRasterSource.swift
@@ -18,7 +18,11 @@ class RCTMGLRasterSource : RCTMGLSource {
 
   override func makeSource() -> Source
   {
+    #if RNMBX_11
+    var result = RasterSource(id: self.id)
+    #else
     var result = RasterSource()
+    #endif
     if let url = url {
       result.url = url
     } else {

--- a/ios/RCTMGL-v10/RCTMGLSource.swift
+++ b/ios/RCTMGL-v10/RCTMGLSource.swift
@@ -83,7 +83,11 @@ class RCTMGLSource : RCTMGLInteractiveElement {
       self.ownsSource = true
       self.source = source
       logged("SyleSource.addToMap", info: {"id: \(optional: self.id)"}) {
+        #if RNMBX_11
+        try style.addSource(source)
+        #else
         try style.addSource(source, id: self.id)
+        #endif
       }
     }
 

--- a/ios/RCTMGL-v10/RCTMGLStyleValue.swift
+++ b/ios/RCTMGL-v10/RCTMGLStyleValue.swift
@@ -203,6 +203,28 @@ class RCTMGLStyleValue {
     }
   }
 
+  #if RNMBX_11
+  func mglStyleValueNumberRaw() -> Value<Double> {
+    guard let value = value as? Dictionary<String,Any> else {
+      Logger.log(level: .error, message: "Invalid value for number: \(value) retuning 0.0")
+      return .constant(0.0)
+    }
+    
+    let valueObj = RCTMGLStyleValue.convert(value["stylevalue"] as! [String:Any])
+    
+    if let num = valueObj as? NSNumber {
+      return .constant(num.doubleValue)
+    } else if let num = valueObj as? Double {
+      return .constant(num)
+    } else if let num = valueObj as? Int {
+      return .constant(Double(num))
+    } else {
+      Logger.log(level: .error, message: "Invalid value for number: \(value) retuning 0.0")
+      return .constant(0.0)
+    }
+    return .constant(1.0)
+  }
+  #else
   func mglStyleValueNumberRaw() -> Double {
     guard let value = value as? Dictionary<String,Any> else {
       Logger.log(level: .error, message: "Invalid value for number: \(value) retuning 0.0")
@@ -223,6 +245,7 @@ class RCTMGLStyleValue {
     }
     return 1.0
   }
+  #endif
 
   func uicolor(_ rgbValue: Int) -> UIColor {
       return UIColor(
@@ -257,6 +280,23 @@ class RCTMGLStyleValue {
     return decodedExpression
   }
 
+  #if RNMBX_11
+  func mglStyleValueColorRaw() -> Value<StyleColor> {
+    guard let value = value as? Dictionary<String,Any> else {
+      Logger.log(level: .error, message: "Invalid value for color: \(value) retuning red")
+      return .constant(StyleColor(UIColor.red))
+    }
+    let valueObj = RCTMGLStyleValue.convert(value["stylevalue"] as! [String:Any])
+
+    if let num = value as? Int {
+      let uicolor = uicolor(num)
+      return .constant(StyleColor(uicolor))
+    } else {
+      Logger.log(level: .error, message: "Unexpeted value for color: \(valueObj), retuning red")
+      return .constant(StyleColor(UIColor.red))
+    }
+  }
+  #else
   func mglStyleValueColorRaw() -> StyleColor {
     guard let value = value as? Dictionary<String,Any> else {
       Logger.log(level: .error, message: "Invalid value for color: \(value) retuning red")
@@ -272,6 +312,7 @@ class RCTMGLStyleValue {
       return StyleColor(UIColor.red)
     }
   }
+  #endif
   
   func mglStyleValueBoolean() -> Value<Bool> {
     guard let value = value as? Dictionary<String,Any> else {
@@ -406,9 +447,16 @@ class RCTMGLStyleValue {
     return Value.constant([])
   }
   
+  #if RNMBX_11
+  func mglStyleValueAnchorRaw() -> Value<Anchor> {
+    // RNMBX_11 TODO Support expressions
+    return .constant(mglStyleEnum())
+  }
+  #else
   func mglStyleValueAnchorRaw() -> Anchor {
     return mglStyleEnum()
   }
+  #endif
 
   func shouldAddImage() -> Bool {
     if let uri = getImageURI() {
@@ -480,16 +528,27 @@ class RCTMGLStyleValue {
     return Value.constant([.left])
   }
   
+  #if RNMBX_11
+  func getSphericalPosition() -> Value<[Double]> {
+    if let array = styleObject as? [NSNumber] {
+      var result = array.map { $0.doubleValue }
+      result[0] = deg2rad(result[0])
+      return .constant(result)
+    }
+    Logger.log(level: .error, message: "Expected array of numbers as position received: \(optional: styleObject)")
+    return .constant([])
+  }
+  #else
   func getSphericalPosition() -> [Double] {
     if let array = styleObject as? [NSNumber] {
       var result = array.map { $0.doubleValue }
       result[0] = deg2rad(result[0])
-      print("REturning: \(result)")
       return result
     }
     Logger.log(level: .error, message: "Expected array of numbers as position received: \(optional: styleObject)")
     return []
   }
+  #endif
   
   func mglStyleValueFormatted() -> Value<String> {
     if let value = value as? Dictionary<String,Any> {

--- a/ios/RCTMGL-v10/RCTMGLSymbolLayer.swift
+++ b/ios/RCTMGL-v10/RCTMGLSymbolLayer.swift
@@ -7,7 +7,11 @@ class RCTMGLSymbolLayer: RCTMGLVectorLayer {
 
   override func makeLayer(style: Style) throws -> Layer {
     let _ : VectorSource = try self.layerWithSourceID(in: style)
+    #if RNMBX_11
+    var layer = LayerType(id: self.id!, source: sourceID!)
+    #else
     var layer = LayerType(id: self.id!)
+    #endif
     layer.sourceLayer = self.sourceLayerID
     layer.source = sourceID
     return layer

--- a/ios/RCTMGL-v10/RCTMGLVectorSource.swift
+++ b/ios/RCTMGL-v10/RCTMGLVectorSource.swift
@@ -15,7 +15,11 @@ class RCTMGLVectorSource : RCTMGLTileSource {
 
   override func makeSource() -> Source
   {
+    #if RNMBX_11
+    var result = VectorSource(id: self.id)
+    #else
     var result = VectorSource()
+    #endif
     if let url = url {
       result.url = url
     } else {

--- a/rnmapbox-maps.podspec
+++ b/rnmapbox-maps.podspec
@@ -156,6 +156,13 @@ def $RNMapboxMaps._add_spm_to_target(project, target, url, requirement, product_
 end
 
 def $RNMapboxMaps.post_install(installer)
+
+  if $RNMapboxMapsUseV11
+    installer.pods_project.build_configurations.each do |config|
+      config.build_settings['OTHER_SWIFT_FLAGS'] ||= ['$(inherited)', '-D RNMBX_11']
+    end
+  end
+
   if $RNMapboxMapsSwiftPackageManager
     return if $RNMapboxMapsSwiftPackageManager == "manual"
 
@@ -236,7 +243,11 @@ Pod::Spec.new do |s|
   s.homepage    	= "https://github.com/rnmapbox/maps#readme"
   s.source      	= { :git => "https://github.com/rnmapbox/maps.git" }
   s.license     	= "MIT"
-  s.platform    	= :ios, "11.0"
+  if $RNMapboxMapsUseV11
+    s.platform    	= :ios, "13.0"
+  else
+    s.platform    	= :ios, "11.0"
+  end
   s.header_dir = "rnmapbox_maps"
 
   unless $RNMapboxMapsSwiftPackageManager


### PR DESCRIPTION
V11 support branch. Currently it's experimental. 

One challenge is that since we have fabric development going on the main branch, I'd prefer adding v11 as a conditional compilation rather than creating a branch for that. On iOS that's straightforward with swift conditional compilation (#if).

Kotlin doesn't have such feature, so we'll see how is it possible on android.


For apps to try the v11 version use this in your Podfile:

```ruby
$RNMapboxMapsUseV11 = true
$RNMapboxMapsVersion = '= 11.0.0-beta.3'
```

TODO
- [ ] iOS
   - [x] get BugReportExample working
   - [ ] fix LocationManager on iOS
   - [ ] fix all other RNMBX_11_TODO on iOS
- [ ] Android
  - [ ] get something simple working
  - [ ] finish
