### PR TITLE
Update VectorSource.md

### DIFF
--- a/docs/VectorSource.md
+++ b/docs/VectorSource.md
@@ -65,11 +65,11 @@ maxZoomLevel, if specified. The default value for this option is 0.
 ```tsx
 number
 ```
-An unsigned integer that specifies the maximum zoom level at which to display tiles from the source.
+
+An unsigned integer that specifies the maximum zoom level for which tiles are available, as in the TileJSON spec. Data from tiles at the maxzoom are used when displaying the map at higher zoom levels.
+
 The value should be between 0 and 22, inclusive, and less than
 minZoomLevel, if specified. The default value for this option is 22.
-
-
   
 ### tms
 


### PR DESCRIPTION

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Made clear that maxZoomLevel doesn't actually hide the data. Setting this can actually help reveal data! This was quite surprising to find, with the doc written as they were.

Used the language here:
https://docs.mapbox.com/style-spec/reference/sources/#vector-maxzoom

So adding 13 to the VectorSource's maxZoomLevel here, actually allowed the LineLayer to keep showing data. I guess because the url the titleUrlTemplate was pointing at did not provide data beyond 13, so it's essentially caching it. 

```
    <ErrorBoundary>
      <MapboxGL.VectorSource
        id={sourceId}
        tileUrlTemplates={[url,]}
        maxZoomLevel={13}
      >
        <MapboxGL.LineLayer
          id={lineLayerId}
          sourceLayerID={sourceId}
          style={{
            visibility:  visibility,
            lineColor:   lineColor,
            lineWidth:   ['interpolate', ['linear',], ['zoom',], 16, 0.8, 18, 5,],
            lineOpacity: ['interpolate', ['linear',], ['zoom',], 16, 0.8, 18, 1,],
          }}
          minZoomLevel={11}
        />
```

## Checklist

- [x] I have tested this on a device/simulator for each compatible OS
- [na] I updated the documentation with running `yarn generate` in the root folder
- [ na] I added/updated a sample - if a new feature was implemented (`/example`)
