### PR TITLE
fix(android): sometimes view tag is not resolved immediately

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/RNMBXPackage.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/RNMBXPackage.kt
@@ -16,6 +16,7 @@ import com.rnmapbox.rnmbx.components.images.RNMBXImagesManager
 import com.rnmapbox.rnmbx.components.location.RNMBXNativeUserLocationManager
 import com.rnmapbox.rnmbx.components.mapview.NativeMapViewModule
 import com.rnmapbox.rnmbx.components.mapview.RNMBXAndroidTextureMapViewManager
+import com.rnmapbox.rnmbx.components.mapview.RNMBXMapView
 import com.rnmapbox.rnmbx.components.mapview.RNMBXMapViewManager
 import com.rnmapbox.rnmbx.components.styles.RNMBXStyleImportManager
 import com.rnmapbox.rnmbx.components.styles.atmosphere.RNMBXAtmosphereManager
@@ -40,8 +41,21 @@ import com.rnmapbox.rnmbx.modules.RNMBXLogging
 import com.rnmapbox.rnmbx.modules.RNMBXModule
 import com.rnmapbox.rnmbx.modules.RNMBXOfflineModule
 import com.rnmapbox.rnmbx.modules.RNMBXSnapshotModule
+import com.rnmapbox.rnmbx.utils.ViewTagResolver
 
 class RNMBXPackage : TurboReactPackage() {
+
+    var mapViewTagResolver: ViewTagResolver<RNMBXMapView>? = null
+    fun getMapViewTagResolver(context: ReactApplicationContext) : ViewTagResolver<RNMBXMapView> {
+        val viewTagResolver = mapViewTagResolver
+        if (viewTagResolver == null) {
+            val viewTagResolver = ViewTagResolver<RNMBXMapView>(context)
+            mapViewTagResolver = viewTagResolver
+            return viewTagResolver
+        }
+        return viewTagResolver
+    }
+
     override fun getModule(
         s: String,
         reactApplicationContext: ReactApplicationContext
@@ -52,7 +66,7 @@ class RNMBXPackage : TurboReactPackage() {
             RNMBXOfflineModule.REACT_CLASS -> return RNMBXOfflineModule(reactApplicationContext)
             RNMBXSnapshotModule.REACT_CLASS -> return RNMBXSnapshotModule(reactApplicationContext)
             RNMBXLogging.REACT_CLASS -> return RNMBXLogging(reactApplicationContext)
-            NativeMapViewModule.NAME -> return NativeMapViewModule(reactApplicationContext)
+            NativeMapViewModule.NAME -> return NativeMapViewModule(reactApplicationContext, getMapViewTagResolver(reactApplicationContext))
         }
         return null
     }
@@ -67,8 +81,8 @@ class RNMBXPackage : TurboReactPackage() {
 
         // components
         managers.add(RNMBXCameraManager(reactApplicationContext))
-        managers.add(RNMBXAndroidTextureMapViewManager(reactApplicationContext))
-        managers.add(RNMBXMapViewManager(reactApplicationContext))
+        managers.add(RNMBXAndroidTextureMapViewManager(reactApplicationContext, getMapViewTagResolver(reactApplicationContext)))
+        managers.add(RNMBXMapViewManager(reactApplicationContext, getMapViewTagResolver(reactApplicationContext)))
         managers.add(RNMBXStyleImportManager(reactApplicationContext))
 
         // annotations

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXAndroidTextureMapViewManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXAndroidTextureMapViewManager.kt
@@ -7,9 +7,11 @@ import com.facebook.react.viewmanagers.RNMBXAndroidTextureMapViewManagerDelegate
 import com.facebook.react.viewmanagers.RNMBXAndroidTextureMapViewManagerInterface
 import com.facebook.react.viewmanagers.RNMBXMapViewManagerDelegate
 import com.mapbox.maps.MapInitOptions
+import com.rnmapbox.rnmbx.utils.ViewTagResolver
 
-class RNMBXAndroidTextureMapViewManager(context: ReactApplicationContext) : RNMBXMapViewManager(
-    context
+class RNMBXAndroidTextureMapViewManager(context: ReactApplicationContext, viewTagResolver: ViewTagResolver<RNMBXMapView>) : RNMBXMapViewManager(
+    context,
+    viewTagResolver
 ), RNMBXAndroidTextureMapViewManagerInterface<RNMBXMapView> {
     private val mDelegate: ViewManagerDelegate<RNMBXMapView>
 

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapView.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapView.kt
@@ -215,6 +215,11 @@ open class RNMBXMapView(private val mContext: Context, var mManager: RNMBXMapVie
         return mapView.getMapboxMap()
     }
 
+    override fun setId(id: Int) {
+        super.setId(id)
+        mManager.tagAssigned(id)
+    }
+
     val pointAnnotationManager: PointAnnotationManager?
         get() {
             if (mPointAnnotationManager == null) {

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapViewManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapViewManager.kt
@@ -22,6 +22,7 @@ import com.rnmapbox.rnmbx.events.AndroidCallbackEvent
 import com.rnmapbox.rnmbx.utils.ConvertUtils
 import com.rnmapbox.rnmbx.utils.ExpressionParser
 import com.rnmapbox.rnmbx.utils.Logger
+import com.rnmapbox.rnmbx.utils.ViewTagResolver
 import com.rnmapbox.rnmbx.utils.extensions.toCoordinate
 import com.rnmapbox.rnmbx.utils.extensions.toRectF
 import com.rnmapbox.rnmbx.utils.extensions.toScreenCoordinate
@@ -46,7 +47,7 @@ interface CommandResponse {
     fun error(message: String)
 }
 
-open class RNMBXMapViewManager(context: ReactApplicationContext) :
+open class RNMBXMapViewManager(context: ReactApplicationContext, val viewTagResolver: ViewTagResolver<RNMBXMapView>) :
     AbstractEventEmitter<RNMBXMapView>(context), RNMBXMapViewManagerInterface<RNMBXMapView> {
     private val mViews: MutableMap<Int, RNMBXMapView>
 
@@ -107,6 +108,9 @@ open class RNMBXMapViewManager(context: ReactApplicationContext) :
 
     override fun onDropViewInstance(mapView: RNMBXMapView) {
         val reactTag = mapView.id
+
+        viewTagResolver.viewRemoved(reactTag)
+
         if (mViews.containsKey(reactTag)) {
             mViews.remove(reactTag)
         }
@@ -116,6 +120,10 @@ open class RNMBXMapViewManager(context: ReactApplicationContext) :
 
     fun getByReactTag(reactTag: Int): RNMBXMapView? {
         return mViews[reactTag]
+    }
+
+    fun tagAssigned(reactTag: Int) {
+        return viewTagResolver.tagAssigned(reactTag)
     }
 
     // region React Props

--- a/android/src/main/java/com/rnmapbox/rnmbx/utils/ViewTagResolver.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/utils/ViewTagResolver.kt
@@ -1,0 +1,68 @@
+package com.rnmapbox.rnmbx.utils
+
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.UIManager
+import com.facebook.react.uimanager.IllegalViewOperationException
+import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.uimanager.common.UIManagerType
+import com.rnmapbox.rnmbx.BuildConfig
+
+data class ViewTagWaiter<V>(
+    val fn: (V) -> Unit,
+    val reject: Promise?
+)
+
+// see https://github.com/rnmapbox/maps/pull/3074
+open class ViewTagResolver<V>(val context: ReactApplicationContext) {
+    private val createdViews: HashSet<Int> = hashSetOf<Int>()
+    private val viewWaiters: HashMap<Int, MutableList<ViewTagWaiter<V>>> = hashMapOf()
+
+    // to be called from view.setId
+    fun tagAssigned(viewTag: Int) {
+        createdViews.add(viewTag)
+
+        val list = viewWaiters[viewTag]
+        if (list != null) {
+            context.runOnUiQueueThread {
+                try {
+                    val view = manager.resolveView(viewTag) as V
+
+                    list.forEach { it.fn(view) }
+                } catch (err: IllegalViewOperationException) {
+                    list.forEach { it.reject?.reject(err) }
+                }
+                viewWaiters.remove(viewTag)
+            }
+        }
+    }
+
+    fun viewRemoved(viewTag: Int) {
+        viewWaiters.remove(viewTag)
+        createdViews.remove(viewTag)
+    }
+
+    private val manager : UIManager
+        get() =
+            if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+                UIManagerHelper.getUIManager(context, UIManagerType.FABRIC)!!
+            } else {
+                UIManagerHelper.getUIManager(context, UIManagerType.DEFAULT)!!
+            }
+
+    // calls on UiQueueThread with resolved view
+    fun withViewResolved(viewTag: Int, reject: Promise? = null, fn: (V) -> Unit) {
+        context.runOnUiQueueThread() {
+            try {
+                val view = manager.resolveView(viewTag) as V
+                fn(view)
+            } catch (err: IllegalViewOperationException) {
+                if (!createdViews.contains(viewTag)) {
+                    viewWaiters.getOrPut(viewTag) { mutableListOf<ViewTagWaiter<V>>() }.add(ViewTagWaiter(fn, reject))
+                } else {
+                    reject?.reject(err)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes the folllowing warning on android:

Can be reproduce with this example:

```jsx
import React from 'react';
import { FlatList } from "react-native";
import { MapView, Camera, ShapeSource, LineLayer } from '@rnmapbox/maps';

const SHAPE = {
    "type": "FeatureCollection",
    "features": [
      {
        "type": "Feature",
        "geometry": {
          "type": "Polygon",
          "coordinates": [
            [
              [
                -105.02738295071447,
                -74.41429582091831
              ],
              [
                -108.67784207799926,
                -82.41571395310365
              ],
              [
                -117.5641615804278,
                -71.45151781686236
              ],
              [
                -105.02738295071447,
                -74.41429582091831
              ]
            ]
          ]
        },
      }
    ],
    "properties": {
        "bbox": [-117.5641615804278, -82.41571395310365, -105.02738295071447, -71.45151781686236],
    }
};

const SHAPES = Array.from({ length: 10 }).map(() => SHAPE);

const Example = () => <FlatList data={SHAPES} renderItem={renderItem} />;

const renderItem = ({ item }) => {
    const [minX, minY, maxX, maxY] = item.properties.bbox;

    return (
        <MapView zoomEnabled={false} scrollEnabled={false} scaleBarEnabled={false} style={{ height: 200 }}>
            <Camera
                bounds={{ ne: [maxX, maxY], sw: [minX, minY] }}
                animationDuration={0}
            />
            <ShapeSource id="shape" shape={item}>
                <LineLayer id="line" />
            </ShapeSource>
        </MapView>
    );
};

export default Example;
```

<img width="422" alt="image" src="https://github.com/rnmapbox/maps/assets/52435/51ad9f94-6246-41a1-a1d9-a7f505e82470">


See also: https://github.com/software-mansion/react-native-reanimated/pull/2982/files
