### PR TITLE
Add RNMapboxMapsDownloadToken required scopes to docs

### DIFF
--- a/plugin/install.md
+++ b/plugin/install.md
@@ -32,7 +32,7 @@ After installing this package, add the [config plugin](https://docs.expo.io/guid
 }
 ```
 
-For `mapbox` or `mapbox-gl` you'll need to provide `RNMapboxMapsDownloadToken` as well.
+For `mapbox` or `mapbox-gl` you'll need to provide `RNMapboxMapsDownloadToken` as well. This secret token requires the `DOWNLOADS:READ` scope. You can refer to the [iOS guide](https://docs.mapbox.com/ios/maps/guides/install/#configure-credentials), which explains how to configure this token under the section `Configure your secret token`.
 
 ```json
 {


### PR DESCRIPTION
## Description

I noticed when integrating via Expo that the docs don't mention the scopes required for the `RNMapboxMapsDownloadToken` secret token. The iOS integration guide does, so I've adapted the copy from those docs to the main install docs here.

Edit: `yarn generate` is failing for me locally. Might have time to debug later, but will pry leave it for the maintainers if that's cool ✌️ 

## Checklist

- [x] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [x] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video
Not applicable
