### PR TITLE
fix: fix image scaling on android in production

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/images/RNMBXImages.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/images/RNMBXImages.kt
@@ -228,8 +228,8 @@ class RNMBXImages(context: Context, private val mManager: RNMBXImagesManager) : 
             var maxY = info.stretchY.maxOfOrNull { max(it.first, it.second) } ?: 0.0f
             var maxX = info.stretchX.maxOfOrNull { max(it.first, it.second) } ?: 0.0f
             if (info.content != null) {
-                maxX = max(max(info.content.left,info.content.right), maxX)
-                maxY = max(max(info.content.top,info.content.bottom), maxY)
+                maxX = max(max(info.content.left, info.content.right), maxX)
+                maxY = max(max(info.content.top, info.content.bottom), maxY)
             }
             return emptyImage(ceil(maxX).toInt()+1, ceil(maxY).toInt()+1)
         } else {

--- a/android/src/main/java/com/rnmapbox/rnmbx/utils/BitmapUtils.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/utils/BitmapUtils.kt
@@ -33,10 +33,6 @@ object BitmapUtils {
             }
         }
 
-    fun getBitmapFromURL(url: String?): Bitmap? {
-        return getBitmapFromURL(url, null)
-    }
-
     fun toImage(bitmap: Bitmap): Image {
         if (bitmap.config != Bitmap.Config.ARGB_8888) {
             throw RuntimeException("Only ARGB_8888 bitmap config is supported!")
@@ -71,33 +67,6 @@ object BitmapUtils {
         }
     }
 
-    fun getBitmapFromURL(url: String?, options: BitmapFactory.Options?): Bitmap? {
-        var bitmap = getImage(url)
-        if (bitmap != null) {
-            return bitmap
-        }
-        try {
-            val bitmapStream = URL(url).openStream()
-            bitmap = BitmapFactory.decodeStream(bitmapStream, null, options)
-            bitmapStream.close()
-            addImage(url, bitmap)
-        } catch (e: Exception) {
-            Log.w(LOG_TAG, e.localizedMessage)
-            bitmap =
-                Bitmap.createBitmap(1, 1, Bitmap.Config.ALPHA_8) // Returns a transparent bitmap
-        }
-        return bitmap
-    }
-
-    fun getBitmapFromResource(
-        context: Context,
-        resourceName: String?,
-        options: BitmapFactory.Options?
-    ): Bitmap {
-        val resources = context.resources
-        val resID = resources.getIdentifier(resourceName, "drawable", context.packageName)
-        return BitmapFactory.decodeResource(resources, resID, options)
-    }
 
     @Throws(IOException::class)
     fun createImgTempFile(context: Context, image: Image): String? {


### PR DESCRIPTION
Fixes: #3009 

So in production our assets looks like this:

```js
{icon1: {"scale":2,"height":64,"uri":"src_assets_scaletesticon","width":64,"__packager_asset":true}}
```

The issue was solved by using fresco to load images from resource in case of release mode. Previously we've loaded manually and we were using wrong combination of scale, [inDensity](https://developer.android.com/reference/android/graphics/BitmapFactory.Options?hl=en#inDensity), [inScreenDensity](https://developer.android.com/reference/android/graphics/BitmapFactory.Options#inScreenDensity), [inTargetDensity](https://developer.android.com/reference/android/graphics/BitmapFactory.Options#inTargetDensity). (tested with `yarn android --mode release `)

![image](https://github.com/rnmapbox/maps/assets/52435/8fd3ac5d-46b4-4753-a96c-ba6a1424e118)
