### PR TITLE
fix(iOS, fabric): support build without modual_headers!

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -53,7 +53,6 @@ end
 
 flags = get_default_flags()
 if flags[:fabric_enabled]
-  use_modular_headers!
   pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec', :modular_headers => false
 end
 

--- a/rnmapbox-maps.podspec
+++ b/rnmapbox-maps.podspec
@@ -230,7 +230,10 @@ Pod::Spec.new do |s|
       sp.source_files = "ios/RNMBX/**/*.{h,m,mm,swift}"
       sp.private_header_files = 'ios/RNMBX/RNMBXFabricHelpers.h', 'ios/RNMBX/rnmapbox_maps-Swift.pre.h'
       if new_arch_enabled
+        sp.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
         install_modules_dependencies(sp)
+        dependencies_only_requiring_modular_headers = ["React-Fabric", "React-graphics", "React-utils", "React-debug"]
+        sp.dependencies = sp.dependencies.select { |d| !dependencies_only_requiring_modular_headers.include?(d.name) }.map {|d| [d.name, []]}.to_h
       end
       if ENV['USE_FRAMEWORKS'] || $RNMapboxMapsUseFrameworks
         $RNMapboxMaps._add_compiler_flags(sp, "-DRNMBX_USE_FRAMEWORKS=1")


### PR DESCRIPTION
Add `DEFINES_MODULE=YES` to rnmapbox-maps target if new arch is enabled

```sh
RCT_NEW_ARCH_ENABLED=1 pod update MapboxMaps
```



![image](https://github.com/rnmapbox/maps/assets/52435/b5112f32-1510-4ee2-b3ae-e1446065163b)
