### PR TITLE
feat: Add expo plugin property for v11 on iOS

### DIFF
--- a/ios/install.md
+++ b/ios/install.md
@@ -93,6 +93,7 @@ $RNMapboxMapsUseV11 = true # use 11 version
 $RNMapboxMapsVersion = '= 11.0.0-beta.3'
 ```
 
+If using expo managed workflow, set the "RNMapboxMapsVersion" variable and the "RNMapboxMapsUseV11" variable to `true`. See the [expo guide](/plugin/install.md)
 
 ## Troubleshooting
 

--- a/plugin/build/withMapbox.d.ts
+++ b/plugin/build/withMapbox.d.ts
@@ -7,10 +7,14 @@ export declare type MapboxPlugProps = {
      */
     RNMapboxMapsVersion?: string;
     RNMapboxMapsDownloadToken?: string;
+    /**
+     * @platform ios
+     */
+    RNMapboxMapsUseV11?: boolean;
 };
 export declare const addInstallerBlock: (src: string, blockName: InstallerBlockName) => string;
-export declare const addConstantBlock: (src: string, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, }: MapboxPlugProps) => string;
-export declare const applyCocoaPodsModifications: (contents: string, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, }: MapboxPlugProps) => string;
+export declare const addConstantBlock: (src: string, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, }: MapboxPlugProps) => string;
+export declare const applyCocoaPodsModifications: (contents: string, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, }: MapboxPlugProps) => string;
 export declare const addMapboxInstallerBlock: (src: string, blockName: InstallerBlockName) => string;
 export declare const addMapboxMavenRepo: (src: string) => string;
 declare const _default: ConfigPlugin<MapboxPlugProps>;

--- a/plugin/build/withMapbox.d.ts
+++ b/plugin/build/withMapbox.d.ts
@@ -11,10 +11,15 @@ export declare type MapboxPlugProps = {
      * @platform ios
      */
     RNMapboxMapsUseV11?: boolean;
+    /**
+     * Enable if using static frameworks
+     * @platform ios
+     */
+    RNMapboxMapsUseFrameworks?: boolean;
 };
 export declare const addInstallerBlock: (src: string, blockName: InstallerBlockName) => string;
-export declare const addConstantBlock: (src: string, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, }: MapboxPlugProps) => string;
-export declare const applyCocoaPodsModifications: (contents: string, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, }: MapboxPlugProps) => string;
+export declare const addConstantBlock: (src: string, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, RNMapboxMapsUseFrameworks, }: MapboxPlugProps) => string;
+export declare const applyCocoaPodsModifications: (contents: string, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, RNMapboxMapsUseFrameworks, }: MapboxPlugProps) => string;
 export declare const addMapboxInstallerBlock: (src: string, blockName: InstallerBlockName) => string;
 export declare const addMapboxMavenRepo: (src: string) => string;
 declare const _default: ConfigPlugin<MapboxPlugProps>;

--- a/plugin/build/withMapbox.js
+++ b/plugin/build/withMapbox.js
@@ -46,7 +46,7 @@ const addInstallerBlock = (src, blockName) => {
     }).contents;
 };
 exports.addInstallerBlock = addInstallerBlock;
-const addConstantBlock = (src, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, }) => {
+const addConstantBlock = (src, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, RNMapboxMapsUseFrameworks, }) => {
     const tag = `@rnmapbox/maps-rnmapboxmapsimpl`;
     if (RNMapboxMapsImpl == null) {
         const modified = (0, generateCode_1.removeGeneratedContents)(src, tag);
@@ -67,6 +67,9 @@ const addConstantBlock = (src, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapbox
     if (RNMapboxMapsUseV11) {
         newSrc.push(`$RNMapboxMapsUseV11 = true`);
     }
+    if (RNMapboxMapsUseFrameworks) {
+        newSrc.push(`$RNMapboxMapsUseFrameworks = true`);
+    }
     return (0, generateCode_1.mergeContents)({
         tag,
         src,
@@ -80,13 +83,14 @@ const addConstantBlock = (src, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapbox
 exports.addConstantBlock = addConstantBlock;
 // Only the preinstaller block is required, the post installer block is
 // used for spm (swift package manager) which Expo doesn't currently support.
-const applyCocoaPodsModifications = (contents, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, }) => {
+const applyCocoaPodsModifications = (contents, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, RNMapboxMapsUseFrameworks, }) => {
     // Ensure installer blocks exist
     let src = (0, exports.addConstantBlock)(contents, {
         RNMapboxMapsImpl,
         RNMapboxMapsVersion,
         RNMapboxMapsDownloadToken,
         RNMapboxMapsUseV11,
+        RNMapboxMapsUseFrameworks,
     });
     src = (0, exports.addInstallerBlock)(src, 'pre');
     src = (0, exports.addInstallerBlock)(src, 'post');
@@ -110,7 +114,7 @@ exports.addMapboxInstallerBlock = addMapboxInstallerBlock;
  *
  * https://github.com/rnmapbox/maps/blob/main/ios/install.md#react-native--0600
  */
-const withCocoaPodsInstallerBlocks = (config, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, }) => (0, config_plugins_1.withDangerousMod)(config, [
+const withCocoaPodsInstallerBlocks = (config, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, RNMapboxMapsUseFrameworks, }) => (0, config_plugins_1.withDangerousMod)(config, [
     'ios',
     async (exportedConfig) => {
         const file = path_1.default.join(exportedConfig.modRequest.platformProjectRoot, 'Podfile');
@@ -120,6 +124,7 @@ const withCocoaPodsInstallerBlocks = (config, { RNMapboxMapsImpl, RNMapboxMapsVe
             RNMapboxMapsVersion,
             RNMapboxMapsDownloadToken,
             RNMapboxMapsUseV11,
+            RNMapboxMapsUseFrameworks,
         }), 'utf-8');
         return exportedConfig;
     },
@@ -253,7 +258,7 @@ const withMapboxAndroid = (config, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken
     config = withAndroidAppGradle(config, { RNMapboxMapsImpl });
     return config;
 };
-const withMapbox = (config, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, }) => {
+const withMapbox = (config, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, RNMapboxMapsUseFrameworks, }) => {
     config = withMapboxAndroid(config, {
         RNMapboxMapsImpl,
         RNMapboxMapsVersion,
@@ -264,6 +269,7 @@ const withMapbox = (config, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMap
         RNMapboxMapsVersion,
         RNMapboxMapsDownloadToken,
         RNMapboxMapsUseV11,
+        RNMapboxMapsUseFrameworks,
     });
     return config;
 };

--- a/plugin/build/withMapbox.js
+++ b/plugin/build/withMapbox.js
@@ -46,7 +46,7 @@ const addInstallerBlock = (src, blockName) => {
     }).contents;
 };
 exports.addInstallerBlock = addInstallerBlock;
-const addConstantBlock = (src, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, }) => {
+const addConstantBlock = (src, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, }) => {
     const tag = `@rnmapbox/maps-rnmapboxmapsimpl`;
     if (RNMapboxMapsImpl == null) {
         const modified = (0, generateCode_1.removeGeneratedContents)(src, tag);
@@ -64,6 +64,9 @@ const addConstantBlock = (src, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapbox
     if (RNMapboxMapsVersion) {
         newSrc.push(`$RNMapboxMapsVersion = '${RNMapboxMapsVersion}'`);
     }
+    if (RNMapboxMapsUseV11) {
+        newSrc.push(`$RNMapboxMapsUseV11 = true`);
+    }
     return (0, generateCode_1.mergeContents)({
         tag,
         src,
@@ -77,12 +80,13 @@ const addConstantBlock = (src, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapbox
 exports.addConstantBlock = addConstantBlock;
 // Only the preinstaller block is required, the post installer block is
 // used for spm (swift package manager) which Expo doesn't currently support.
-const applyCocoaPodsModifications = (contents, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, }) => {
+const applyCocoaPodsModifications = (contents, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, }) => {
     // Ensure installer blocks exist
     let src = (0, exports.addConstantBlock)(contents, {
         RNMapboxMapsImpl,
         RNMapboxMapsVersion,
         RNMapboxMapsDownloadToken,
+        RNMapboxMapsUseV11,
     });
     src = (0, exports.addInstallerBlock)(src, 'pre');
     src = (0, exports.addInstallerBlock)(src, 'post');
@@ -106,7 +110,7 @@ exports.addMapboxInstallerBlock = addMapboxInstallerBlock;
  *
  * https://github.com/rnmapbox/maps/blob/main/ios/install.md#react-native--0600
  */
-const withCocoaPodsInstallerBlocks = (config, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken }) => (0, config_plugins_1.withDangerousMod)(config, [
+const withCocoaPodsInstallerBlocks = (config, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, }) => (0, config_plugins_1.withDangerousMod)(config, [
     'ios',
     async (exportedConfig) => {
         const file = path_1.default.join(exportedConfig.modRequest.platformProjectRoot, 'Podfile');
@@ -115,6 +119,7 @@ const withCocoaPodsInstallerBlocks = (config, { RNMapboxMapsImpl, RNMapboxMapsVe
             RNMapboxMapsImpl,
             RNMapboxMapsVersion,
             RNMapboxMapsDownloadToken,
+            RNMapboxMapsUseV11,
         }), 'utf-8');
         return exportedConfig;
     },
@@ -248,7 +253,7 @@ const withMapboxAndroid = (config, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken
     config = withAndroidAppGradle(config, { RNMapboxMapsImpl });
     return config;
 };
-const withMapbox = (config, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken }) => {
+const withMapbox = (config, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, }) => {
     config = withMapboxAndroid(config, {
         RNMapboxMapsImpl,
         RNMapboxMapsVersion,
@@ -258,6 +263,7 @@ const withMapbox = (config, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMap
         RNMapboxMapsImpl,
         RNMapboxMapsVersion,
         RNMapboxMapsDownloadToken,
+        RNMapboxMapsUseV11,
     });
     return config;
 };

--- a/plugin/install.md
+++ b/plugin/install.md
@@ -90,6 +90,26 @@ For `mapbox` or `mapbox-gl` on iOS it's possible to overwrite the native SDK ver
 }
 ```
 
+If using V11, on iOS, you can use property `RNMapboxMapsUseV11`, see [the ios guide](/ios/install.md):
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "@rnmapbox/maps",
+        {
+          "RNMapboxMapsImpl": "mapbox",
+          "RNMapboxMapsVersion": "11.XX.XX",
+          "RNMapboxMapsDownloadToken": "sk.ey...qg",
+          "RNMapboxMapsUseV11": true
+        }
+      ]
+    ]
+  }
+}
+```
+
 ## Manual Setup
 
 For bare workflow projects, you can follow the manual setup guides:

--- a/plugin/src/withMapbox.ts
+++ b/plugin/src/withMapbox.ts
@@ -43,6 +43,12 @@ export type MapboxPlugProps = {
    * @platform ios
    */
   RNMapboxMapsUseV11?: boolean;
+
+  /**
+   * Enable if using static frameworks
+   * @platform ios
+   */
+  RNMapboxMapsUseFrameworks?: boolean;
 };
 
 export const addInstallerBlock = (
@@ -86,6 +92,7 @@ export const addConstantBlock = (
     RNMapboxMapsVersion,
     RNMapboxMapsDownloadToken,
     RNMapboxMapsUseV11,
+    RNMapboxMapsUseFrameworks,
   }: MapboxPlugProps,
 ): string => {
   const tag = `@rnmapbox/maps-rnmapboxmapsimpl`;
@@ -112,6 +119,10 @@ export const addConstantBlock = (
     newSrc.push(`$RNMapboxMapsUseV11 = true`);
   }
 
+  if (RNMapboxMapsUseFrameworks) {
+    newSrc.push(`$RNMapboxMapsUseFrameworks = true`);
+  }
+
   return mergeContents({
     tag,
     src,
@@ -132,6 +143,7 @@ export const applyCocoaPodsModifications = (
     RNMapboxMapsVersion,
     RNMapboxMapsDownloadToken,
     RNMapboxMapsUseV11,
+    RNMapboxMapsUseFrameworks,
   }: MapboxPlugProps,
 ): string => {
   // Ensure installer blocks exist
@@ -140,6 +152,7 @@ export const applyCocoaPodsModifications = (
     RNMapboxMapsVersion,
     RNMapboxMapsDownloadToken,
     RNMapboxMapsUseV11,
+    RNMapboxMapsUseFrameworks,
   });
   src = addInstallerBlock(src, 'pre');
   src = addInstallerBlock(src, 'post');
@@ -175,6 +188,7 @@ const withCocoaPodsInstallerBlocks: ConfigPlugin<MapboxPlugProps> = (
     RNMapboxMapsVersion,
     RNMapboxMapsDownloadToken,
     RNMapboxMapsUseV11,
+    RNMapboxMapsUseFrameworks,
   },
 ) =>
   withDangerousMod(config, [
@@ -193,6 +207,7 @@ const withCocoaPodsInstallerBlocks: ConfigPlugin<MapboxPlugProps> = (
           RNMapboxMapsVersion,
           RNMapboxMapsDownloadToken,
           RNMapboxMapsUseV11,
+          RNMapboxMapsUseFrameworks,
         }),
         'utf-8',
       );
@@ -398,6 +413,7 @@ const withMapbox: ConfigPlugin<MapboxPlugProps> = (
     RNMapboxMapsVersion,
     RNMapboxMapsDownloadToken,
     RNMapboxMapsUseV11,
+    RNMapboxMapsUseFrameworks,
   },
 ) => {
   config = withMapboxAndroid(config, {
@@ -410,6 +426,7 @@ const withMapbox: ConfigPlugin<MapboxPlugProps> = (
     RNMapboxMapsVersion,
     RNMapboxMapsDownloadToken,
     RNMapboxMapsUseV11,
+    RNMapboxMapsUseFrameworks,
   });
 
   return config;

--- a/plugin/src/withMapbox.ts
+++ b/plugin/src/withMapbox.ts
@@ -38,6 +38,11 @@ export type MapboxPlugProps = {
   RNMapboxMapsVersion?: string;
 
   RNMapboxMapsDownloadToken?: string;
+
+  /**
+   * @platform ios
+   */
+  RNMapboxMapsUseV11?: boolean;
 };
 
 export const addInstallerBlock = (
@@ -80,6 +85,7 @@ export const addConstantBlock = (
     RNMapboxMapsImpl,
     RNMapboxMapsVersion,
     RNMapboxMapsDownloadToken,
+    RNMapboxMapsUseV11,
   }: MapboxPlugProps,
 ): string => {
   const tag = `@rnmapbox/maps-rnmapboxmapsimpl`;
@@ -102,6 +108,10 @@ export const addConstantBlock = (
     newSrc.push(`$RNMapboxMapsVersion = '${RNMapboxMapsVersion}'`);
   }
 
+  if (RNMapboxMapsUseV11) {
+    newSrc.push(`$RNMapboxMapsUseV11 = true`);
+  }
+
   return mergeContents({
     tag,
     src,
@@ -121,6 +131,7 @@ export const applyCocoaPodsModifications = (
     RNMapboxMapsImpl,
     RNMapboxMapsVersion,
     RNMapboxMapsDownloadToken,
+    RNMapboxMapsUseV11,
   }: MapboxPlugProps,
 ): string => {
   // Ensure installer blocks exist
@@ -128,6 +139,7 @@ export const applyCocoaPodsModifications = (
     RNMapboxMapsImpl,
     RNMapboxMapsVersion,
     RNMapboxMapsDownloadToken,
+    RNMapboxMapsUseV11,
   });
   src = addInstallerBlock(src, 'pre');
   src = addInstallerBlock(src, 'post');
@@ -158,7 +170,12 @@ export const addMapboxInstallerBlock = (
  */
 const withCocoaPodsInstallerBlocks: ConfigPlugin<MapboxPlugProps> = (
   config,
-  { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken },
+  {
+    RNMapboxMapsImpl,
+    RNMapboxMapsVersion,
+    RNMapboxMapsDownloadToken,
+    RNMapboxMapsUseV11,
+  },
 ) =>
   withDangerousMod(config, [
     'ios',
@@ -175,6 +192,7 @@ const withCocoaPodsInstallerBlocks: ConfigPlugin<MapboxPlugProps> = (
           RNMapboxMapsImpl,
           RNMapboxMapsVersion,
           RNMapboxMapsDownloadToken,
+          RNMapboxMapsUseV11,
         }),
         'utf-8',
       );
@@ -375,7 +393,12 @@ const withMapboxAndroid: ConfigPlugin<MapboxPlugProps> = (
 
 const withMapbox: ConfigPlugin<MapboxPlugProps> = (
   config,
-  { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken },
+  {
+    RNMapboxMapsImpl,
+    RNMapboxMapsVersion,
+    RNMapboxMapsDownloadToken,
+    RNMapboxMapsUseV11,
+  },
 ) => {
   config = withMapboxAndroid(config, {
     RNMapboxMapsImpl,
@@ -386,6 +409,7 @@ const withMapbox: ConfigPlugin<MapboxPlugProps> = (
     RNMapboxMapsImpl,
     RNMapboxMapsVersion,
     RNMapboxMapsDownloadToken,
+    RNMapboxMapsUseV11,
   });
 
   return config;


### PR DESCRIPTION
Added the ability to set "use_frameworks" and v11 with a config plugin to allow continued use of the managed workflow with expo. I also added some documentation with it as well

## Checklist

- [x] I have tested this on a device/simulator for each compatible OS
- [x] I updated the documentation with running `yarn generate` in the root folder
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

