### PR TITLE
fix: implement interfaces in Android sources

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXImageSourceManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXImageSourceManager.kt
@@ -1,13 +1,15 @@
 package com.rnmapbox.rnmbx.components.styles.sources
 
 import android.view.View
-import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.Dynamic
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
+import com.facebook.react.viewmanagers.RNMBXImageSourceManagerInterface
 import com.rnmapbox.rnmbx.utils.GeoJSONUtils.toLatLngQuad
 
-class RNMBXImageSourceManager : ViewGroupManager<RNMBXImageSource>() {
+class RNMBXImageSourceManager : ViewGroupManager<RNMBXImageSource>(),
+    RNMBXImageSourceManagerInterface<RNMBXImageSource> {
     override fun getName(): String {
         return REACT_CLASS
     }
@@ -33,22 +35,28 @@ class RNMBXImageSourceManager : ViewGroupManager<RNMBXImageSource>() {
     }
 
     @ReactProp(name = "id")
-    fun setId(source: RNMBXImageSource, id: String?) {
-        source.iD = id
+    override fun setId(source: RNMBXImageSource, id: Dynamic) {
+        source.iD = id.asString()
     }
 
     @ReactProp(name = "url")
-    fun setUrl(source: RNMBXImageSource, url: String?) {
-        source.setURL(url)
+    override fun setUrl(source: RNMBXImageSource, url: Dynamic) {
+        source.setURL(url.asString())
     }
 
     @ReactProp(name = "coordinates")
-    fun setCoordinates(source: RNMBXImageSource, arr: ReadableArray?) {
-        val quad = toLatLngQuad(arr) ?: return
+    override fun setCoordinates(source: RNMBXImageSource, arr: Dynamic) {
+        val quad = toLatLngQuad(arr.asArray()) ?: return
         source.setCoordinates(quad)
+    }
+
+    @ReactProp(name = "existing")
+    override fun setExisting(source: RNMBXImageSource, value: Dynamic) {
+        source.mExisting = value.asBoolean()
     }
 
     companion object {
         const val REACT_CLASS = "RNMBXImageSource"
     }
+
 }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXRasterDemSourceManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXRasterDemSourceManager.kt
@@ -6,6 +6,7 @@ import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNMBXRasterDemSourceManagerInterface
+import com.rnmapbox.rnmbx.utils.Logger
 
 // import com.rnmapbox.rnmbx.components.annotation.RNMBXCallout;
 // import com.rnmapbox.rnmbx.utils.ResourceUtils;
@@ -38,6 +39,6 @@ class RNMBXRasterDemSourceManager(private val mContext: ReactApplicationContext)
 
     @ReactProp(name = "tileSize")
     override fun setTileSize(view: RNMBXRasterDemSource, value: Dynamic) {
-        // TODO: it does not exist on this class
+        Logger.e("RNMBXRasterDemSourceManager", "tileSize not implemented")
     }
 }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXRasterDemSourceManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXRasterDemSourceManager.kt
@@ -1,15 +1,18 @@
 package com.rnmapbox.rnmbx.components.styles.sources
 
+import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.annotations.ReactProp
+import com.facebook.react.viewmanagers.RNMBXRasterDemSourceManagerInterface
 
 // import com.rnmapbox.rnmbx.components.annotation.RNMBXCallout;
 // import com.rnmapbox.rnmbx.utils.ResourceUtils;
 class RNMBXRasterDemSourceManager(private val mContext: ReactApplicationContext) :
     RNMBXTileSourceManager<RNMBXRasterDemSource?>(
         mContext
-    ) {
+    ), RNMBXRasterDemSourceManagerInterface<RNMBXRasterDemSource> {
     override fun customEvents(): Map<String, String>? {
         return MapBuilder.builder<String, String>()
             .build()
@@ -26,5 +29,15 @@ class RNMBXRasterDemSourceManager(private val mContext: ReactApplicationContext)
     companion object {
         const val LOG_TAG = "RNMBXRasterDemSourceManager"
         const val REACT_CLASS = "RNMBXRasterDemSource"
+    }
+
+    @ReactProp(name = "existing")
+    override fun setExisting(view: RNMBXRasterDemSource, value: Dynamic) {
+        view.mExisting = value.asBoolean()
+    }
+
+    @ReactProp(name = "tileSize")
+    override fun setTileSize(view: RNMBXRasterDemSource, value: Dynamic) {
+        // TODO: it does not exist on this class
     }
 }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXRasterSourceManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXRasterSourceManager.kt
@@ -1,12 +1,15 @@
 package com.rnmapbox.rnmbx.components.styles.sources
 
+import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
+import com.facebook.react.viewmanagers.RNMBXRasterSourceManagerInterface
 import javax.annotation.Nonnull
 
 class RNMBXRasterSourceManager(reactApplicationContext: ReactApplicationContext) :
-    RNMBXTileSourceManager<RNMBXRasterSource?>(reactApplicationContext) {
+    RNMBXTileSourceManager<RNMBXRasterSource?>(reactApplicationContext),
+    RNMBXRasterSourceManagerInterface<RNMBXRasterSource> {
     @Nonnull
     override fun getName(): String {
         return REACT_CLASS
@@ -18,8 +21,8 @@ class RNMBXRasterSourceManager(reactApplicationContext: ReactApplicationContext)
     }
 
     @ReactProp(name = "tileSize")
-    fun setTileSize(source: RNMBXRasterSource, tileSize: Int) {
-        source.setTileSize(tileSize)
+    override fun setTileSize(source: RNMBXRasterSource, tileSize: Dynamic) {
+        source.setTileSize(tileSize.asInt())
     }
 
     override fun customEvents(): Map<String, String>? {
@@ -28,5 +31,10 @@ class RNMBXRasterSourceManager(reactApplicationContext: ReactApplicationContext)
 
     companion object {
         const val REACT_CLASS = "RNMBXRasterSource"
+    }
+
+    @ReactProp(name = "existing")
+    override fun setExisting(source: RNMBXRasterSource, value: Dynamic) {
+        source.mExisting = value.asBoolean()
     }
 }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXShapeSource.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXShapeSource.kt
@@ -35,8 +35,6 @@ class RNMBXShapeSource(context: Context, private val mManager: RNMBXShapeSourceM
     private var mBuffer: Long? = null
     private var mTolerance: Double? = null
     private var mLineMetrics: Boolean? = null
-    private val mImages: List<Map.Entry<String, ImageEntry>>? = null
-    private val mNativeImages: List<Map.Entry<String, BitmapDrawable>>? = null
 
     override fun hasNoDataSoRefersToExisting(): Boolean {
         return (mURL == null) && (mShape == null)

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXShapeSourceManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXShapeSourceManager.kt
@@ -1,13 +1,14 @@
 package com.rnmapbox.rnmbx.components.styles.sources
 
 import android.view.View
+import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReactApplicationContext
 import com.rnmapbox.rnmbx.components.AbstractEventEmitter
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
-import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
 import com.facebook.react.common.MapBuilder
+import com.facebook.react.viewmanagers.RNMBXShapeSourceManagerInterface
 import com.mapbox.bindgen.Value
 import com.mapbox.maps.extension.style.expressions.generated.Expression
 import com.rnmapbox.rnmbx.events.constants.EventKeys
@@ -22,7 +23,7 @@ import java.util.HashMap
 class RNMBXShapeSourceManager(private val mContext: ReactApplicationContext) :
     AbstractEventEmitter<RNMBXShapeSource>(
         mContext
-    ) {
+    ), RNMBXShapeSourceManagerInterface<RNMBXShapeSource> {
     override fun getName(): String {
         return REACT_CLASS
     }
@@ -48,51 +49,51 @@ class RNMBXShapeSourceManager(private val mContext: ReactApplicationContext) :
     }
 
     @ReactProp(name = "id")
-    fun setId(source: RNMBXShapeSource, id: String) {
-        source.iD = id
+    override fun setId(source: RNMBXShapeSource, id: Dynamic) {
+        source.iD = id.asString()
     }
 
     @ReactProp(name = "existing")
-    fun setExisting(source: RNMBXShapeSource, existing: Boolean) {
-        source.mExisting = existing;
+    override fun setExisting(source: RNMBXShapeSource, existing: Dynamic) {
+        source.mExisting = existing.asBoolean()
     }
 
     @ReactProp(name = "url")
-    fun setURL(source: RNMBXShapeSource, urlStr: String) {
+    override fun setUrl(source: RNMBXShapeSource, urlStr: Dynamic) {
         try {
-            source.setURL(URL(urlStr))
+            source.setURL(URL(urlStr.asString()))
         } catch (e: MalformedURLException) {
             Logger.w(LOG_TAG, e.localizedMessage ?: "Unknown URL error")
         }
     }
 
     @ReactProp(name = "shape")
-    fun setGeometry(source: RNMBXShapeSource, geoJSONStr: String) {
-        source.setShape(geoJSONStr)
+    override fun setShape(source: RNMBXShapeSource, geoJSONStr: Dynamic) {
+        source.setShape(geoJSONStr.asString())
     }
 
     @ReactProp(name = "cluster")
-    fun setCluster(source: RNMBXShapeSource, cluster: Int) {
-        source.setCluster(cluster == 1)
+    override fun setCluster(source: RNMBXShapeSource, cluster: Dynamic) {
+        source.setCluster(cluster.asInt() == 1)
     }
 
     @ReactProp(name = "clusterRadius")
-    fun setClusterRadius(source: RNMBXShapeSource, radius: Int) {
-        source.setClusterRadius(radius.toLong())
+    override fun setClusterRadius(source: RNMBXShapeSource, radius: Dynamic) {
+        source.setClusterRadius(radius.asInt().toLong())
     }
 
     @ReactProp(name = "clusterMaxZoomLevel")
-    fun setClusterMaxZoomLevel(source: RNMBXShapeSource, clusterMaxZoom: Int) {
-        source.setClusterMaxZoom(clusterMaxZoom.toLong())
+    override fun setClusterMaxZoomLevel(source: RNMBXShapeSource, clusterMaxZoom: Dynamic) {
+        source.setClusterMaxZoom(clusterMaxZoom.asInt().toLong())
     }
 
     @ReactProp(name = "clusterProperties")
-    fun setClusterProperties(source: RNMBXShapeSource, map: ReadableMap) {
+    override fun setClusterProperties(source: RNMBXShapeSource, map: Dynamic) {
         val properties = HashMap<String, Any>()
-        val iterator = map.keySetIterator()
+        val iterator = map.asMap().keySetIterator()
         while (iterator.hasNextKey()) {
             val name = iterator.nextKey()
-            val expressions = map.getArray(name)
+            val expressions = map.asMap().getArray(name)
             val builder: MutableList<Value> = ArrayList()
             for (iExp in 0 until expressions!!.size()) {
                 var argument: Expression
@@ -115,33 +116,33 @@ class RNMBXShapeSourceManager(private val mContext: ReactApplicationContext) :
     }
 
     @ReactProp(name = "maxZoomLevel")
-    fun setMaxZoomLevel(source: RNMBXShapeSource, maxZoom: Int) {
-        source.setMaxZoom(maxZoom.toLong())
+    override fun setMaxZoomLevel(source: RNMBXShapeSource, maxZoom: Dynamic) {
+        source.setMaxZoom(maxZoom.asInt().toLong())
     }
 
     @ReactProp(name = "buffer")
-    fun setBuffer(source: RNMBXShapeSource, buffer: Int) {
-        source.setBuffer(buffer.toLong())
+    override fun setBuffer(source: RNMBXShapeSource, buffer: Dynamic) {
+        source.setBuffer(buffer.asInt().toLong())
     }
 
     @ReactProp(name = "tolerance")
-    fun setTolerance(source: RNMBXShapeSource, tolerance: Double) {
-        source.setTolerance(tolerance)
+    override fun setTolerance(source: RNMBXShapeSource, tolerance: Dynamic) {
+        source.setTolerance(tolerance.asDouble())
     }
 
     @ReactProp(name = "lineMetrics")
-    fun setLineMetrics(source: RNMBXShapeSource, lineMetrics: Boolean) {
-        source.setLineMetrics(lineMetrics)
+    override fun setLineMetrics(source: RNMBXShapeSource, lineMetrics: Dynamic) {
+        source.setLineMetrics(lineMetrics.asBoolean())
     }
 
     @ReactProp(name = "hasPressListener")
-    fun setHasPressListener(source: RNMBXShapeSource, hasPressListener: Boolean) {
-        source.setHasPressListener(hasPressListener)
+    override fun setHasPressListener(source: RNMBXShapeSource, hasPressListener: Dynamic) {
+        source.setHasPressListener(hasPressListener.asBoolean())
     }
 
     @ReactProp(name = "hitbox")
-    fun setHitbox(source: RNMBXShapeSource, map: ReadableMap) {
-        source.setHitbox(map)
+    override fun setHitbox(source: RNMBXShapeSource, map: Dynamic) {
+        source.setHitbox(map.asMap())
     }
 
     override fun customEvents(): Map<String, String>? {

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXSource.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXSource.kt
@@ -61,7 +61,7 @@ abstract class RNMBXSource<T : Source?>(context: Context?) : AbstractMapFeature(
                 if (hasNoDataSoRefersToExisting()) {
                     Logger.w(
                         LOG_TAG,
-                        "RNMBXSource: soure with id: $id seems to refer to existing value but existing flag is not set. This is deprecated."
+                        "RNMBXSource: source with id: $id seems to refer to existing value but existing flag is not set. This is deprecated."
                     )
                     result = true
                 } else {

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXTileSourceManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXTileSourceManager.kt
@@ -1,8 +1,8 @@
 package com.rnmapbox.rnmbx.components.styles.sources
 
 import android.view.View
+import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableType
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.rnmapbox.rnmbx.components.AbstractEventEmitter
@@ -27,43 +27,43 @@ abstract class RNMBXTileSourceManager<T : RNMBXTileSource<*>?> internal construc
     }
 
     @ReactProp(name = "id")
-    fun setID(source: T, id: String?) {
-        source!!.iD = id
+    fun setId(source: T, id: Dynamic) {
+        source!!.iD = id.asString()
     }
 
     @ReactProp(name = "url")
-    fun setURL(source: T, url: String?) {
-        source!!.uRL = url
+    fun setUrl(source: T, url: Dynamic) {
+        source!!.uRL = url.asString()
     }
 
     @ReactProp(name = "tileUrlTemplates")
-    fun setTileUrlTemplates(source: T, tileUrlTemplates: ReadableArray) {
+    fun setTileUrlTemplates(source: T, tileUrlTemplates: Dynamic) {
         val urls: MutableList<String> = ArrayList()
-        for (i in 0 until tileUrlTemplates.size()) {
-            if (tileUrlTemplates.getType(0) == ReadableType.String) {
-                urls.add(tileUrlTemplates.getString(i))
+        for (i in 0 until tileUrlTemplates.asArray().size()) {
+            if (tileUrlTemplates.asArray().getType(0) == ReadableType.String) {
+                urls.add(tileUrlTemplates.asArray().getString(i))
             }
         }
         source!!.tileUrlTemplates = urls
     }
 
     @ReactProp(name = "attribution")
-    fun setAttribution(source: T, attribution: String?) {
-        source!!.attribution = attribution
+    fun setAttribution(source: T, attribution: Dynamic) {
+        source!!.attribution = attribution.asString()
     }
 
     @ReactProp(name = "minZoomLevel")
-    fun setMinZoomLevel(source: T, minZoomLevel: Int) {
-        source!!.minZoomLevel = minZoomLevel
+    fun setMinZoomLevel(source: T, minZoomLevel: Dynamic) {
+        source!!.minZoomLevel = minZoomLevel.asInt()
     }
 
     @ReactProp(name = "maxZoomLevel")
-    fun setMaxZoomLevel(source: T, maxZoomLevel: Int) {
-        source!!.maxZoomLevel = maxZoomLevel
+    fun setMaxZoomLevel(source: T, maxZoomLevel: Dynamic) {
+        source!!.maxZoomLevel = maxZoomLevel.asInt()
     }
 
     @ReactProp(name = "tms")
-    fun setTMS(source: T, tms: Boolean) {
-        source!!.tMS = tms
+    fun setTms(source: T, tms: Dynamic) {
+        source!!.tMS = tms.asBoolean()
     }
 }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXVectorSourceManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXVectorSourceManager.kt
@@ -1,18 +1,17 @@
 package com.rnmapbox.rnmbx.components.styles.sources
 
+import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.ReadableArray
-import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
+import com.facebook.react.viewmanagers.RNMBXVectorSourceManagerInterface
 import com.rnmapbox.rnmbx.events.constants.EventKeys
-import com.rnmapbox.rnmbx.utils.ConvertUtils
-import com.rnmapbox.rnmbx.utils.ExpressionParser
 import javax.annotation.Nonnull
 
 class RNMBXVectorSourceManager(reactApplicationContext: ReactApplicationContext) :
-    RNMBXTileSourceManager<RNMBXVectorSource?>(reactApplicationContext) {
+    RNMBXTileSourceManager<RNMBXVectorSource?>(reactApplicationContext),
+    RNMBXVectorSourceManagerInterface<RNMBXVectorSource> {
     @Nonnull
     override fun getName(): String {
         return REACT_CLASS
@@ -24,13 +23,18 @@ class RNMBXVectorSourceManager(reactApplicationContext: ReactApplicationContext)
     }
 
     @ReactProp(name = "hasPressListener")
-    fun setHasPressListener(source: RNMBXVectorSource, hasPressListener: Boolean) {
-        source.setHasPressListener(hasPressListener)
+    override fun setHasPressListener(source: RNMBXVectorSource, hasPressListener: Dynamic) {
+        source.setHasPressListener(hasPressListener.asBoolean())
     }
 
     @ReactProp(name = "hitbox")
-    fun setHitbox(source: RNMBXVectorSource, map: ReadableMap?) {
-        source.setHitbox(map!!)
+    override fun setHitbox(source: RNMBXVectorSource, map: Dynamic) {
+        source.setHitbox(map.asMap())
+    }
+
+    @ReactProp(name = "existing")
+    override fun setExisting(view: RNMBXVectorSource, value: Dynamic) {
+        view.mExisting = value.asBoolean()
     }
 
     override fun customEvents(): Map<String, String>? {
@@ -40,30 +44,7 @@ class RNMBXVectorSourceManager(reactApplicationContext: ReactApplicationContext)
             .build()
     }
 
-    override fun getCommandsMap(): Map<String, Int>? {
-        return MapBuilder.builder<String, Int>()
-            .put("features", METHOD_FEATURES)
-            .build()
-    }
-
-    override fun receiveCommand(
-        vectorSource: RNMBXVectorSource,
-        commandID: Int,
-        args: ReadableArray?
-    ) {
-        when (commandID) {
-            METHOD_FEATURES -> vectorSource.querySourceFeatures(
-                args!!.getString(0),
-                ConvertUtils.toStringList(args.getArray(1)),
-                ExpressionParser.from(args.getArray(2))
-            )
-        }
-    }
-
     companion object {
         const val REACT_CLASS = "RNMBXVectorSource"
-
-        //region React Methods
-        const val METHOD_FEATURES = 102
     }
 }

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXShapeSourceManagerDelegate.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXShapeSourceManagerDelegate.java
@@ -58,12 +58,6 @@ public class RNMBXShapeSourceManagerDelegate<T extends View, U extends BaseViewM
       case "lineMetrics":
         mViewManager.setLineMetrics(view, new DynamicFromObject(value));
         break;
-      case "images":
-        mViewManager.setImages(view, new DynamicFromObject(value));
-        break;
-      case "nativeImages":
-        mViewManager.setNativeImages(view, new DynamicFromObject(value));
-        break;
       case "hasPressListener":
         mViewManager.setHasPressListener(view, new DynamicFromObject(value));
         break;

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXShapeSourceManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXShapeSourceManagerInterface.java
@@ -25,8 +25,6 @@ public interface RNMBXShapeSourceManagerInterface<T extends View> {
   void setBuffer(T view, Dynamic value);
   void setTolerance(T view, Dynamic value);
   void setLineMetrics(T view, Dynamic value);
-  void setImages(T view, Dynamic value);
-  void setNativeImages(T view, Dynamic value);
   void setHasPressListener(T view, Dynamic value);
   void setHitbox(T view, Dynamic value);
 }

--- a/fabricexample/ios/Podfile.lock
+++ b/fabricexample/ios/Podfile.lock
@@ -8,12 +8,12 @@ PODS:
     - hermes-engine/Pre-built (= 0.72.4)
   - hermes-engine/Pre-built (0.72.4)
   - libevent (2.1.12)
-  - MapboxCommon (23.8.0)
-  - MapboxCoreMaps (10.16.0):
+  - MapboxCommon (23.8.3)
+  - MapboxCoreMaps (10.16.1):
     - MapboxCommon (~> 23.8)
-  - MapboxMaps (10.16.0):
-    - MapboxCommon (= 23.8.0)
-    - MapboxCoreMaps (= 10.16.0)
+  - MapboxMaps (10.16.1):
+    - MapboxCommon (= 23.8.3)
+    - MapboxCoreMaps (= 10.16.1)
     - MapboxMobileEvents (= 1.0.10)
     - Turf (~> 2.0)
   - MapboxMobileEvents (1.0.10)
@@ -1074,23 +1074,27 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - rnmapbox-maps (10.1.0-beta.9):
-    - MapboxMaps (~> 10.16.0)
+  - rnmapbox-maps (10.1.0-beta.14):
+    - MapboxMaps (~> 10.16.1)
     - React
     - React-Core
-    - rnmapbox-maps/DynamicLibrary (= 10.1.0-beta.9)
+    - rnmapbox-maps/DynamicLibrary (= 10.1.0-beta.14)
     - Turf
-  - rnmapbox-maps/DynamicLibrary (10.1.0-beta.9):
-    - MapboxMaps (~> 10.16.0)
+  - rnmapbox-maps/DynamicLibrary (10.1.0-beta.14):
+    - hermes-engine
+    - MapboxMaps (~> 10.16.1)
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
     - React
     - React-Codegen
     - React-Core
+    - React-NativeModulesApple
     - React-RCTFabric
+    - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Turf
+    - Yoga
   - RNScreens (3.25.0):
     - RCT-Folly
     - RCTRequired
@@ -1158,7 +1162,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - Yoga
   - SocketRocket (0.6.1)
-  - Turf (2.6.1)
+  - Turf (2.7.0)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -1332,9 +1336,9 @@ SPEC CHECKSUMS:
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 81191603c4eaa01f5e4ae5737a9efcf64756c7b2
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
-  MapboxCommon: 8592a003eae487508461d452d62cfc5906a9682a
-  MapboxCoreMaps: faa14a797417dc32088c98019a3ce72e46cda5cd
-  MapboxMaps: f10aecadbfb7cf96368852ca313101eb4171da53
+  MapboxCommon: b2c348867dfed7d7a23545e6c2024d712bfda10f
+  MapboxCoreMaps: c66f482b5ea983cf873122853c4ee94c159bec43
+  MapboxMaps: fdbe05e3899abd24f31a7f91789586e44e57f7fc
   MapboxMobileEvents: de50b3a4de180dd129c326e09cd12c8adaaa46d6
   RCT-Folly: 424b8c9a7a0b9ab2886ffe9c3b041ef628fd4fb1
   RCTRequired: c0569ecc035894e4a68baecb30fe6a7ea6e399f9
@@ -1374,12 +1378,12 @@ SPEC CHECKSUMS:
   React-utils: b79f2411931f9d3ea5781404dcbb2fa8a837e13a
   ReactCommon: 4b2bdcb50a3543e1c2b2849ad44533686610826d
   RNCAsyncStorage: 2b77010cff31de7199eb7f65c59ae35abf9970b1
-  rnmapbox-maps: efdc7b17ad07f7e077f56b1ad06e474ea6293db2
+  rnmapbox-maps: 04deea8b9ece57dc06b7f31acf9085c47f65d06a
   RNScreens: cba72a26a6c967765a8388fe85f78e7771012ca1
   RNSVG: df9aaada196f6a61c8e30dc55d41e6c108a954e7
   RNVectorIcons: 61c44830bebe662f0bcb40aad2e6a31a34c8d8ba
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  Turf: 469ce2c3d22e5e8e4818d5a3b254699a5c89efa4
+  Turf: 13d1a92d969ca0311bbc26e8356cca178ce95da2
   Yoga: 3efc43e0d48686ce2e8c60f99d4e6bd349aff981
 
 PODFILE CHECKSUM: ddac4d16bae15c3a589d18f707074a66b448710a

--- a/src/specs/RNMBXShapeSourceNativeComponent.ts
+++ b/src/specs/RNMBXShapeSourceNativeComponent.ts
@@ -23,8 +23,6 @@ export interface NativeProps extends ViewProps {
   buffer: UnsafeMixed<Double>;
   tolerance: UnsafeMixed<Double>;
   lineMetrics: UnsafeMixed<boolean>;
-  images: UnsafeMixed<any>; // unused ??
-  nativeImages: UnsafeMixed<Array<any>>; // unused ??
   hasPressListener: UnsafeMixed<boolean>;
   hitbox: UnsafeMixed<any>;
   onMapboxShapeSourcePress: DirectEventHandler<OnMapboxShapeSourcePressEventType>;


### PR DESCRIPTION
PR fixing not implemented interfaces in `Source` components, adding not implemented setters for `existing` and removing unused `images` and `nativeImages` props