### PR TITLE
Enable pulsing on iOS native user location

### DIFF
--- a/ios/RNMBX/RNMBXNativeUserLocation.swift
+++ b/ios/RNMBX/RNMBXNativeUserLocation.swift
@@ -17,7 +17,9 @@ public class RNMBXNativeUserLocation : UIView, RNMBXMapComponent {
   
   func _applySettings(_ map: RNMBXMapView) {
     let location = map.mapView.location!
-    location.options.puckType = .puck2D(.makeDefault(showBearing: iosShowsUserHeadingIndicator))
+    var configuration: Puck2DConfiguration = .makeDefault(showBearing: iosShowsUserHeadingIndicator)
+    configuration.pulsing = .default
+    location.options.puckType = .puck2D(configuration)
     if (iosShowsUserHeadingIndicator) {
        #if RNMBX_11
       location.options.puckBearing = .heading


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Enables pulsing on iOS native user location, as it is already done on Android.

## Checklist

<!-- Check completed item: [X] -->

- [x] I have tested this on a device/simulator for each compatible OS
- [ ] I updated the documentation with running `yarn generate` in the root folder
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->
