### PR TITLE
Null-check OutputStream

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/utils/BitmapUtils.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/utils/BitmapUtils.kt
@@ -87,6 +87,9 @@ object BitmapUtils {
         if (tempFile == null) {
             return null
         }
+        if (outputStream == null) {
+            return null
+        }
         bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
         closeSnapshotOutputStream(outputStream)
         return Uri.fromFile(tempFile).toString()


### PR DESCRIPTION
This fixes a build failure - `bitmap.compress()` cannot accept an optional as the third argument.