### PR TITLE
chore: Android bump heap

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 
         if (project.hasProperty('RNMBX11') && project.getProperty('RNMBX11').toBoolean()) {
             RNMapboxMapsUseV11 = true
-            RNMapboxMapsVersion = '11.0.0-rc.1'
+            RNMapboxMapsVersion = '11.0.0-rc.2'
         }
 
         useCustomMapbox = false
@@ -16,7 +16,7 @@ buildscript {
             kotlinVersion = '1.6.21'
         } else if (System.getenv('CI_MAP_IMPL').equals('mapbox11')) {
             RNMapboxMapsUseV11 = true
-            RNMapboxMapsVersion = '11.0.0-rc.1'
+            RNMapboxMapsVersion = '11.0.0-rc.2'
             RNMapboxMapsImpl = "mapbox"
         }
 

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -10,7 +10,7 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx512m -XX:MaxMetaspaceSize=256m
-org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -11,7 +11,7 @@ prepare_react_native_project!
 $RNMapboxMapsImpl = 'mapbox'
 if ENV['RNMBX11']
   $RNMapboxMapsUseV11 = true # use 11 version
-  $RNMapboxMapsVersion = '= 11.0.0-rc.1'
+  $RNMapboxMapsVersion = '= 11.0.0-rc.2'
 end
 
 if ENV['CI_MAP_IMPL']
@@ -22,7 +22,7 @@ if ENV['CI_MAP_IMPL']
   when 'mapbox11'
     $RNMapboxMapsImpl = 'mapbox'
     $RNMapboxMapsUseV11 = true # use 11 version
-    $RNMapboxMapsVersion = '= 11.0.0-rc.1'
+    $RNMapboxMapsVersion = '= 11.0.0-rc.2'
   else
     fail "Invalid CI_MAP_IMPL value: #{ENV['CI_MAP_IMPL']}"
   end


### PR DESCRIPTION
Fixes: 

https://github.com/rnmapbox/maps/actions/runs/6941926774/job/18883872023

See: 
```
* What went wrong:
Execution failed for task ':app:checkDebugAarMetadata'.
> Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
   > Failed to transform hermes-android-0.73.0-rc.4-debug.aar (com.facebook.react:hermes-android:0.73.0-rc.4) to match attributes {artifactType=android-aar-metadata, com.android.build.api.attributes.BuildTypeAttr=debug, org.gradle.category=library, org.gradle.dependency.bundling=external, org.gradle.libraryelements=aar, org.gradle.status=release, org.gradle.usage=java-runtime}.
      > Execution failed for JetifyTransform: /home/runner/.gradle/caches/modules-2/files-2.1/com.facebook.react/hermes-android/0.73.0-rc.4/c39b36896cb2df598cfa60a8cc0855e0a0b7e6de/hermes-android-0.73.0-rc.4-debug.aar.
         > Java heap space

```