### PR TITLE
fix(android): withLayerIDs: is optional

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/NativeMapViewModule.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/NativeMapViewModule.kt
@@ -125,7 +125,7 @@ class NativeMapViewModule(context: ReactApplicationContext, val viewTagResolver:
         viewRef: Double?,
         withBBox: ReadableArray,
         withFilter: ReadableArray,
-        withLayerIDs: ReadableArray,
+        withLayerIDs: ReadableArray?,
         promise: Promise
     ) {
         withMapViewOnUIThread(viewRef, promise) {


### PR DESCRIPTION
Fixes: #3177


Component to reproduce:

```tsx
import React from 'react';
import {
  MapView,
  ShapeSource,
  LineLayer,
  Camera,
  UserLocation,
} from '@rnmapbox/maps';

const getBBox = (
  screenPointX: number,
  screenPointY: number,
  tapMargin: number,
) => [
  screenPointY + tapMargin,
  screenPointX + tapMargin,
  screenPointY - tapMargin,
  screenPointX - tapMargin,
];

export default function BugReportExample() {
  const mapRef = React.useRef<MapView>(null);

  return (
    <>
      <MapView
        style={{ flex: 1 }}
        ref={mapRef}
        onPress={async (event: any) => {
          console.log('Map.onPress', event);
          const { screenPointX, screenPointY } = event.properties as any;
          const bbox = getBBox(screenPointX, screenPointY, 1);

          const filter = ['==', 'type', 'Point'];
          const featureCollection =
            await mapRef.current?.queryRenderedFeaturesInRect(
              bbox as [],
              filter,
            );
          console.log('Features found: ', featureCollection?.features.length);
        }}
      >
        <UserLocation visible showsUserHeadingIndicator />
      </MapView>
    </>
  );
}

export default BugReportExample;
```