### PR TITLE
ci-for-fored-repos renamed and removed extra environment key

### DIFF
--- a/.github/workflows/ci-for-forked-repos.yml
+++ b/.github/workflows/ci-for-forked-repos.yml
@@ -11,8 +11,6 @@ jobs:
 
   call_ci_requiring_tokens:
     name: "CI requiring tokens"
-    enivoronment:
-      name: CI with Mapbox Tokens
     needs: [approve]
     uses: ./.github/workflows/ci-requiring-tokens.yml
     with:


### PR DESCRIPTION
After pushing to a fork of @rnmapbox/maps, the Github Action fails with:
```
[Invalid workflow file: .github/workflows/ci-for-fored-repos.yml#L14](https://github.com/rnmapbox/maps/actions/runs/7039820452/workflow)
The workflow is not valid. .github/workflows/ci-for-fored-repos.yml (Line: 14, Col: 5): Unexpected value 'enivoronment'
```
Wasn't sure if the misspelled key in the yaml was supposed to be there or not (even if correctly spelled) so removed it - sorry if it was meant to be there for some other functionality and will close this pr if so!

Also renamed file assuming it's supposed to be `ci-for-forked-repos`