### PR TITLE
chore: remove pre commit hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
+#. "$(dirname -- "$0")/_/husky.sh"
 
-npm run generate
-npx lint-staged
+#npm run generate
+#npx lint-staged

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "build:examples.json": "cd example; jest __tests__/dumpExamplesJson.ts",
     "lint:plugin": "yarn eslint plugin/src/*",
     "build": "yarn bob build",
-    "prepare": "yarn bob build && yarn husky install"
+    "prepare": "yarn bob build"
   },
   "peerDependencies": {
     "expo": ">=47.0.0",


### PR DESCRIPTION
I usually commit with `--no-verify` to avoid running hooks. 

See also: 
https://www.youtube.com/watch?v=RAelLqnnOp0