### PR TITLE
fix: add deselectAnnotationOnTap to deselect and hide pointannotation callout on press, refactor point annotation manager or android

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXPointAnnotation.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXPointAnnotation.kt
@@ -6,12 +6,9 @@ import com.rnmapbox.rnmbx.components.AbstractMapFeature
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotation
 import com.mapbox.maps.MapboxMap
 import com.rnmapbox.rnmbx.components.mapview.RNMBXMapView
-import com.rnmapbox.rnmbx.components.annotation.RNMBXCallout
 import com.rnmapbox.rnmbx.utils.GeoJSONUtils
 import com.rnmapbox.rnmbx.events.constants.EventTypes
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
-import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager
-import com.rnmapbox.rnmbx.components.annotation.RNMBXPointAnnotation
 import com.mapbox.maps.extension.style.layers.properties.generated.IconAnchor
 import com.rnmapbox.rnmbx.events.PointAnnotationClickEvent
 import android.graphics.PointF
@@ -28,7 +25,7 @@ import java.util.*
 import com.rnmapbox.rnmbx.v11compat.annotation.*;
 
 class RNMBXPointAnnotation(private val mContext: Context, private val mManager: RNMBXPointAnnotationManager) : AbstractMapFeature(mContext), View.OnLayoutChangeListener {
-    var marker: PointAnnotation? = null
+    var annotation: PointAnnotation? = null
         private set
     private var mMap: MapboxMap? = null
     private val mHasChildren = false
@@ -100,8 +97,8 @@ class RNMBXPointAnnotation(private val mContext: Context, private val mManager: 
 
     override fun removeFromMap(mapView: RNMBXMapView, reason: RemovalReason): Boolean {
         val map = (if (mMapView != null) mMapView else mapView) ?: return true
-        if (marker != null) {
-            map.pointAnnotationManager?.delete(marker!!)
+        if (annotation != null) {
+            map.pointAnnotationManager?.delete(annotation!!)
         }
         if (mChildView != null) {
             map.offscreenAnnotationViewContainer?.removeView(mChildView)
@@ -141,33 +138,33 @@ class RNMBXPointAnnotation(private val mContext: Context, private val mManager: 
     val latLng: LatLng?
         get() = mCoordinate?.let { GeoJSONUtils.toLatLng(it) }
     val mapboxID: AnnotationID
-        get() = if (marker == null) INVALID_ANNOTATION_ID else marker!!.id
+        get() = if (annotation == null) INVALID_ANNOTATION_ID else annotation!!.id
 
     fun setCoordinate(point: Point) {
         mCoordinate = point
-        if (marker != null) {
-            marker!!.point = point
-            mMapView?.pointAnnotationManager?.update(marker!!)
+        annotation?.let {
+            it.point = point
+            mMapView?.pointAnnotationManager?.update(it)
         }
-        if (mCalloutSymbol != null) {
-            mCalloutSymbol!!.point = point
-            mMapView?.pointAnnotationManager?.update(mCalloutSymbol!!)
+        mCalloutSymbol?.let {
+            it.point = point
+            mMapView?.pointAnnotationManager?.update(it)
         }
     }
 
     fun setAnchor(x: Float, y: Float) {
         mAnchor = arrayOf(x, y)
-        if (marker != null) {
+        if (annotation != null) {
             updateAnchor()
-            mMapView?.pointAnnotationManager?.update(marker!!)
+            mMapView?.pointAnnotationManager?.update(annotation!!)
         }
     }
 
     fun setDraggable(draggable: Boolean) {
         mDraggable = draggable
-        if (marker != null) {
-            marker!!.isDraggable = draggable
-            mMapView?.pointAnnotationManager?.update(marker!!)
+        annotation?.let {
+            it.isDraggable = draggable
+            mMapView?.pointAnnotationManager?.update(it)
         }
     }
 
@@ -188,17 +185,17 @@ class RNMBXPointAnnotation(private val mContext: Context, private val mManager: 
     }
 
     fun onDragStart() {
-        mCoordinate = marker!!.point
+        mCoordinate = annotation!!.point
         mManager.handleEvent(makeDragEvent(EventTypes.ANNOTATION_DRAG_START))
     }
 
     fun onDrag() {
-        mCoordinate = marker!!.point
+        mCoordinate = annotation!!.point
         mManager.handleEvent(makeDragEvent(EventTypes.ANNOTATION_DRAG))
     }
 
     fun onDragEnd() {
-        mCoordinate = marker!!.point
+        mCoordinate = annotation!!.point
         mManager.handleEvent(makeDragEvent(EventTypes.ANNOTATION_DRAG_END))
     }
 
@@ -210,41 +207,42 @@ class RNMBXPointAnnotation(private val mContext: Context, private val mManager: 
                 .withIconSize(1.0)
                 .withSymbolSortKey(10.0)
         }
-        val symbolManager = mMapView?.pointAnnotationManager
-        if (symbolManager != null && options != null) {
-            marker = symbolManager.create(options)
-            updateOptions()
+        mMapView?.pointAnnotationManager?.let { annotationManager ->
+            options?.let {
+                annotation = annotationManager.create(options)
+                updateOptions()
+            }
         }
     }
 
     private fun updateOptions() {
-        if (marker != null) {
+        if (annotation != null) {
             updateIconImage()
             updateAnchor()
-            mMapView?.pointAnnotationManager?.update(marker!!)
+            mMapView?.pointAnnotationManager?.update(annotation!!)
         }
     }
 
     private fun updateIconImage() {
         if (mChildView != null) {
             if (mChildBitmapId != null) {
-                marker?.iconImage = mChildBitmapId
+                annotation?.iconImage = mChildBitmapId
             }
         } else {
-            marker?.iconImage = MARKER_IMAGE_ID
-            marker?.iconAnchor = IconAnchor.BOTTOM
+            annotation?.iconImage = MARKER_IMAGE_ID
+            annotation?.iconAnchor = IconAnchor.BOTTOM
         }
     }
 
     private fun updateAnchor() {
-        if (mAnchor != null && mChildView != null && mChildBitmap != null && marker != null) {
+        if (mAnchor != null && mChildView != null && mChildBitmap != null && annotation != null) {
             var w = mChildBitmap!!.width
             var h = mChildBitmap!!.height
             val scale = resources.displayMetrics.density
             w = (w / scale).toInt()
             h = (h / scale).toInt()
-            marker?.iconAnchor = IconAnchor.TOP_LEFT
-            marker?.iconOffset = Arrays.asList(w.toDouble() * mAnchor!![0] * -1.0, h.toDouble() * mAnchor!![1] * -1.0)
+            annotation?.iconAnchor = IconAnchor.TOP_LEFT
+            annotation?.iconOffset = Arrays.asList(w.toDouble() * mAnchor!![0] * -1.0, h.toDouble() * mAnchor!![1] * -1.0)
         }
     }
 

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapViewManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapViewManager.kt
@@ -330,6 +330,13 @@ open class RNMBXMapViewManager(context: ReactApplicationContext, val viewTagReso
         mapView.requestDisallowInterceptTouchEvent = requestDisallowInterceptTouchEvent.asBoolean()
     }
 
+    @ReactProp(name = "deselectAnnotationOnTap")
+    override fun setDeselectAnnotationOnTap(mapView: RNMBXMapView, value: Dynamic?) {
+        value?.let {
+            mapView.deselectAnnotationOnTap = it.asBoolean()
+        }
+    }
+
     override fun setCompassImage(view: RNMBXMapView, value: Dynamic?) {
         // TODO: No-op on Android?
     }

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXMapViewManagerDelegate.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXMapViewManagerDelegate.java
@@ -67,6 +67,9 @@ public class RNMBXMapViewManagerDelegate<T extends View, U extends BaseViewManag
       case "pitchEnabled":
         mViewManager.setPitchEnabled(view, new DynamicFromObject(value));
         break;
+      case "deselectAnnotationOnTap":
+        mViewManager.setDeselectAnnotationOnTap(view, new DynamicFromObject(value));
+        break;
       case "requestDisallowInterceptTouchEvent":
         mViewManager.setRequestDisallowInterceptTouchEvent(view, new DynamicFromObject(value));
         break;

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXMapViewManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXMapViewManagerInterface.java
@@ -28,6 +28,7 @@ public interface RNMBXMapViewManagerInterface<T extends View> {
   void setScrollEnabled(T view, Dynamic value);
   void setRotateEnabled(T view, Dynamic value);
   void setPitchEnabled(T view, Dynamic value);
+  void setDeselectAnnotationOnTap(T view, Dynamic value);
   void setRequestDisallowInterceptTouchEvent(T view, Dynamic value);
   void setProjection(T view, Dynamic value);
   void setLocalizeLabels(T view, Dynamic value);

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -522,6 +522,16 @@ The emitted frequency of regiondidchange events
   _defaults to:_ `500`
 
   
+### deselectAnnotationOnTap
+
+```tsx
+boolean
+```
+Set to true to deselect any selected annotation when the map is tapped. If set to true you will not receive
+the onPress event for the taps that deselect the annotation. Default is false.
+
+[Show Point Annotations](../examples/Annotations/ShowPointAnnotation)
+  
 
 
 

--- a/docs/PointAnnotation.md
+++ b/docs/PointAnnotation.md
@@ -179,4 +179,4 @@ On v10 and pre v10 android point annotation is rendered offscreen with a canvas 
 
 
 
-
+[Show Point Annotations](../examples/Annotations/ShowPointAnnotation)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -4227,6 +4227,13 @@
         "type": "number",
         "default": "500",
         "description": "The emitted frequency of regiondidchange events"
+      },
+      {
+        "name": "deselectAnnotationOnTap",
+        "required": false,
+        "type": "boolean",
+        "default": "none",
+        "description": "Set to true to deselect any selected annotation when the map is tapped. If set to true you will not receive\nthe onPress event for the taps that deselect the annotation. Default is false."
       }
     ],
     "fileNameWithExt": "MapView.tsx",

--- a/docs/examples.json
+++ b/docs/examples.json
@@ -566,7 +566,10 @@
         "metadata": {
           "title": "Show Point Annotations",
           "tags": [
-            "PointAnnotation"
+            "PointAnnotation",
+            "MapView#deselectAnnotationOnTap",
+            "PointAnnotation#refresh",
+            "getAnnotationsLayerID"
           ],
           "docs": "\nShows Point annotation with images\n"
         },

--- a/example/src/examples/Annotations/ShowPointAnnotation.tsx
+++ b/example/src/examples/Annotations/ShowPointAnnotation.tsx
@@ -138,6 +138,7 @@ const ShowPointAnnotation = () => {
           ]);
         }}
         style={styles.matchParent}
+        deselectAnnotationOnTap={true}
       >
         <Camera
           defaultSettings={{ centerCoordinate: coordinates[0], zoomLevel: 16 }}
@@ -199,7 +200,12 @@ export default ShowPointAnnotation;
 
 const metadata: ExampleWithMetadata['metadata'] = {
   title: 'Show Point Annotations',
-  tags: ['PointAnnotation'],
+  tags: [
+    'PointAnnotation',
+    'MapView#deselectAnnotationOnTap',
+    'PointAnnotation#refresh',
+    'getAnnotationsLayerID',
+  ],
   docs: `
 Shows Point annotation with images
 `,

--- a/ios/RNMBX/RNMBXMapViewComponentView.mm
+++ b/ios/RNMBX/RNMBXMapViewComponentView.mm
@@ -11,6 +11,8 @@
 #import <react/renderer/components/rnmapbox_maps_specs/Props.h>
 #import <react/renderer/components/rnmapbox_maps_specs/RCTComponentViewHelpers.h>
 
+#import "RNMBXFabricPropConvert.h"
+
 using namespace facebook::react;
 
 @interface RNMBXMapViewComponentView () <RCTRNMBXMapViewViewProtocol>
@@ -125,99 +127,103 @@ using namespace facebook::react;
 
 - (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
-  const auto &newProps = static_cast<const RNMBXMapViewProps &>(*props);
-    id attributionEnabled = RNMBXConvertFollyDynamicToId(newProps.attributionEnabled);
+    const auto &oldViewProps = static_cast<const RNMBXMapViewProps &>(*oldProps);
+    const auto &newViewProps = static_cast<const RNMBXMapViewProps &>(*props);
+  
+    id attributionEnabled = RNMBXConvertFollyDynamicToId(newViewProps.attributionEnabled);
     if (attributionEnabled != nil) {
         _view.reactAttributionEnabled = attributionEnabled;
     }
 
-    id attributionPosition = RNMBXConvertFollyDynamicToId(newProps.attributionPosition);
+    id attributionPosition = RNMBXConvertFollyDynamicToId(newViewProps.attributionPosition);
     if (attributionPosition != nil) {
         _view.reactAttributionPosition = attributionPosition;
     }
 
-    id logoEnabled = RNMBXConvertFollyDynamicToId(newProps.logoEnabled);
+    id logoEnabled = RNMBXConvertFollyDynamicToId(newViewProps.logoEnabled);
     if (logoEnabled != nil) {
         _view.reactLogoEnabled = logoEnabled;
     }
 
-    id logoPosition = RNMBXConvertFollyDynamicToId(newProps.logoPosition);
+    id logoPosition = RNMBXConvertFollyDynamicToId(newViewProps.logoPosition);
     if (logoPosition != nil) {
         _view.reactLogoPosition = logoPosition;
     }
 
-    id compassEnabled = RNMBXConvertFollyDynamicToId(newProps.compassEnabled);
+    id compassEnabled = RNMBXConvertFollyDynamicToId(newViewProps.compassEnabled);
     if (compassEnabled != nil) {
         _view.reactCompassEnabled = compassEnabled;
     }
 
-    id compassFadeWhenNorth = RNMBXConvertFollyDynamicToId(newProps.compassFadeWhenNorth);
+    id compassFadeWhenNorth = RNMBXConvertFollyDynamicToId(newViewProps.compassFadeWhenNorth);
     if (compassFadeWhenNorth != nil) {
         _view.reactCompassFadeWhenNorth = compassFadeWhenNorth;
     }
 
-    id compassPosition = RNMBXConvertFollyDynamicToId(newProps.compassPosition);
+    id compassPosition = RNMBXConvertFollyDynamicToId(newViewProps.compassPosition);
     if (compassPosition != nil) {
         _view.reactCompassPosition = compassPosition;
     }
 
-    id compassViewPosition = RNMBXConvertFollyDynamicToId(newProps.compassViewPosition);
+    id compassViewPosition = RNMBXConvertFollyDynamicToId(newViewProps.compassViewPosition);
     if (compassViewPosition != nil) {
         _view.reactCompassViewPosition = [(NSNumber *)compassViewPosition doubleValue];
     }
 
-    NSDictionary<NSString *, NSNumber *> *compassViewMargins = RNMBXConvertFollyDynamicToId(newProps.compassViewMargins);
+    NSDictionary<NSString *, NSNumber *> *compassViewMargins = RNMBXConvertFollyDynamicToId(newViewProps.compassViewMargins);
     if (compassViewMargins != nil) {
         CGPoint margins = CGPointMake([compassViewMargins[@"x"] doubleValue], [compassViewMargins[@"y"] doubleValue]);
         _view.reactCompassViewMargins = margins;
     }
 
-    id compassImage = RNMBXConvertFollyDynamicToId(newProps.compassImage);
+    id compassImage = RNMBXConvertFollyDynamicToId(newViewProps.compassImage);
     if (compassImage != nil) {
         _view.reactCompassImage = compassImage;
     }
 
-    id scaleBarEnabled = RNMBXConvertFollyDynamicToId(newProps.scaleBarEnabled);
+    id scaleBarEnabled = RNMBXConvertFollyDynamicToId(newViewProps.scaleBarEnabled);
     if (scaleBarEnabled != nil) {
         _view.reactScaleBarEnabled = scaleBarEnabled;
     }
 
-    id scaleBarPosition = RNMBXConvertFollyDynamicToId(newProps.scaleBarPosition);
+    id scaleBarPosition = RNMBXConvertFollyDynamicToId(newViewProps.scaleBarPosition);
     if (scaleBarPosition != nil) {
         _view.reactScaleBarPosition = scaleBarPosition;
     }
 
-    id zoomEnabled = RNMBXConvertFollyDynamicToId(newProps.zoomEnabled);
+    id zoomEnabled = RNMBXConvertFollyDynamicToId(newViewProps.zoomEnabled);
     if (zoomEnabled != nil) {
         _view.reactZoomEnabled = zoomEnabled;
     }
 
-    id scrollEnabled = RNMBXConvertFollyDynamicToId(newProps.scrollEnabled);
+    id scrollEnabled = RNMBXConvertFollyDynamicToId(newViewProps.scrollEnabled);
     if (scrollEnabled != nil) {
         _view.reactScrollEnabled = scrollEnabled;
     }
 
-    id rotateEnabled = RNMBXConvertFollyDynamicToId(newProps.rotateEnabled);
+    id rotateEnabled = RNMBXConvertFollyDynamicToId(newViewProps.rotateEnabled);
     if (rotateEnabled != nil) {
         _view.reactRotateEnabled = rotateEnabled;
     }
 
-    id pitchEnabled = RNMBXConvertFollyDynamicToId(newProps.pitchEnabled);
+    id pitchEnabled = RNMBXConvertFollyDynamicToId(newViewProps.pitchEnabled);
     if (pitchEnabled != nil) {
         _view.reactPitchEnabled = pitchEnabled;
     }
 
-    id projection = RNMBXConvertFollyDynamicToId(newProps.projection);
+    id projection = RNMBXConvertFollyDynamicToId(newViewProps.projection);
     if (projection != nil) {
         _view.reactProjection = projection;
     }
 
-    id localizeLabels = RNMBXConvertFollyDynamicToId(newProps.localizeLabels);
+    id localizeLabels = RNMBXConvertFollyDynamicToId(newViewProps.localizeLabels);
     if (localizeLabels != nil) {
         _view.reactLocalizeLabels = localizeLabels;
     }
+  
+    RNMBX_OPTIONAL_PROP_BOOL(deselectAnnotationOnTap);
 
-    id styleURL = RNMBXConvertFollyDynamicToId(newProps.styleURL);
+    id styleURL = RNMBXConvertFollyDynamicToId(newViewProps.styleURL);
     if (styleURL != nil) {
         _view.reactStyleURL = styleURL;
     }

--- a/ios/RNMBX/RNMBXMapViewManager.m
+++ b/ios/RNMBX/RNMBXMapViewManager.m
@@ -25,6 +25,7 @@ RCT_REMAP_VIEW_PROPERTY(zoomEnabled, reactZoomEnabled, BOOL)
 RCT_REMAP_VIEW_PROPERTY(scrollEnabled, reactScrollEnabled, BOOL)
 RCT_REMAP_VIEW_PROPERTY(rotateEnabled, reactRotateEnabled, BOOL)
 RCT_REMAP_VIEW_PROPERTY(pitchEnabled, reactPitchEnabled, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(deselectAnnotationOnTap, BOOL)
 
 RCT_REMAP_VIEW_PROPERTY(projection, reactProjection, NSString)
 RCT_REMAP_VIEW_PROPERTY(localizeLabels, reactLocalizeLabels, NSDictionary)

--- a/ios/RNMBX/RNMBXMarkerViewContentComponentView.mm
+++ b/ios/RNMBX/RNMBXMarkerViewContentComponentView.mm
@@ -17,11 +17,25 @@ using namespace facebook::react;
 @end
 
 @implementation RNMBXMarkerViewContentComponentView {
+  RNMBXMarkerView *_view;
+  CGRect _frame;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
-  return [super initWithFrame:frame];
+  if (self = [super initWithFrame:frame]) {
+    static const auto defaultProps = std::make_shared<const RNMBXMarkerViewProps>();
+    _props = defaultProps;
+    _frame = frame;
+    [self prepareView];
+  }
+  return self;
+}
+
+- (void)prepareView
+{
+  _view =  [[RNMBXMarkerView alloc] initWithFrame:_frame];
+  self.contentView = _view;
 }
 
 #pragma mark - RCTComponentViewProtocol

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -427,6 +427,12 @@ type Props = ViewProps & {
    * The emitted frequency of regiondidchange events
    */
   regionDidChangeDebounceTime?: number;
+
+  /**
+   * Set to true to deselect any selected annotation when the map is tapped. If set to true you will not receive
+   * the onPress event for the taps that deselect the annotation. Default is false.
+   */
+  deselectAnnotationOnTap?: boolean;
 };
 
 type CallbablePropKeys =

--- a/src/specs/RNMBXMapViewNativeComponent.ts
+++ b/src/specs/RNMBXMapViewNativeComponent.ts
@@ -52,6 +52,8 @@ export interface NativeProps extends ViewProps {
   rotateEnabled?: OptionalProp<boolean>;
   pitchEnabled?: OptionalProp<boolean>;
 
+  deselectAnnotationOnTap?: OptionalProp<boolean>;
+
   requestDisallowInterceptTouchEvent?: OptionalProp<boolean>;
 
   projection?: OptionalProp<'mercator' | 'globe'>;


### PR DESCRIPTION
Fixes: #1723, #3111

Added new option `deselectAnnotationOnTap`. Deselect will hide the callout.