### PR TITLE
fix: invalid return and property errors

### DIFF
--- a/ios/RNMBX/RNMBXMarkerViewComponentView.mm
+++ b/ios/RNMBX/RNMBXMarkerViewComponentView.mm
@@ -113,7 +113,6 @@ using namespace facebook::react;
         layoutMetrics.borderWidth,
         layoutMetrics.displayType,
         layoutMetrics.layoutDirection,
-        layoutMetrics.wasLeftAndRightSwapped,
         layoutMetrics.pointScaleFactor,
         layoutMetrics.overflowInset
     };

--- a/ios/RNMBX/RNMBXMarkerViewComponentView.mm
+++ b/ios/RNMBX/RNMBXMarkerViewComponentView.mm
@@ -113,6 +113,7 @@ using namespace facebook::react;
         layoutMetrics.borderWidth,
         layoutMetrics.displayType,
         layoutMetrics.layoutDirection,
+        layoutMetrics.wasLeftAndRightSwapped,
         layoutMetrics.pointScaleFactor,
         layoutMetrics.overflowInset
     };

--- a/ios/RNMBX/RNMBXViewportComponentView.mm
+++ b/ios/RNMBX/RNMBXViewportComponentView.mm
@@ -49,6 +49,7 @@ NSNumber* convertDynamicToOptional_boolean(const folly::dynamic &dyn, NSString* 
                           propertyName,
                           ss.str().c_str()
                          ]];
+      return NULL;
   }
 }
 


### PR DESCRIPTION
## Description

This fixes an invalid return in a utility function, and a nonexistent property being used in `LayoutMetrics` init. Both were causing build errors.