### PR TITLE
Fix crash setting zoomEnabled on MapView creation

### DIFF
--- a/ios/RNMBX/RNMBXMapView.swift
+++ b/ios/RNMBX/RNMBXMapView.swift
@@ -273,6 +273,7 @@ open class RNMBXMapView: UIView {
     case scaleBar
     case onLongPress
     case onPress
+    case zoomEnabled
     case scrollEnabled
     case rotateEnabled
     case pitchEnabled
@@ -298,6 +299,8 @@ open class RNMBXMapView: UIView {
         map.applyOnLongPress()
       case .onPress:
         map.applyOnPress()
+      case .zoomEnabled:
+        map.applyZoomEnabled()
       case .scrollEnabled:
         map.applyScrollEnabled()
       case .rotateEnabled:
@@ -661,10 +664,18 @@ open class RNMBXMapView: UIView {
     changes.apply(self)
   }
 
+  var zoomEnabled: Bool? = nil
   @objc public func setReactZoomEnabled(_ value: Bool) {
-    self.mapView.gestures.options.quickZoomEnabled = value
-    self.mapView.gestures.options.doubleTapToZoomInEnabled = value
-    self.mapView.gestures.options.pinchZoomEnabled = value
+    self.zoomEnabled = value
+    changed(.zoomEnabled)
+  }
+
+  func applyZoomEnabled() {
+    if let value = zoomEnabled {
+      self.mapView.gestures.options.quickZoomEnabled = value
+      self.mapView.gestures.options.doubleTapToZoomInEnabled = value
+      self.mapView.gestures.options.pinchZoomEnabled = value
+    }
   }
 
   var scrollEnabled: Bool? = nil


### PR DESCRIPTION
## Description

Fixes a bug where setting the `zoomEnabled` prop on `MapView` before the native component is created would cause a crash.

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

I'm afraid I'm unable to get the example app to build. I've done the following:

- Run `yarn generate` and `yarn build` in the root directory of the repo
- Change to `/example`
- Run `yarn install` and `cd ios; pod install --repo-update`
- Build and run from Xcode
- Run `yarn start`

I get the following error message when I run the app. If I can work out how to fix this I can produce a test case. Any help would be much appreciated:

![CleanShot 2023-12-13 at 17 06 10](https://github.com/rnmapbox/maps/assets/231655/25b056e9-126f-4834-8ae9-fbb6d06acbc8)
