### PR TITLE
fix(ios): setTelemetryEnabled

### DIFF
--- a/ios/RNMBX/RNMBXModule.swift
+++ b/ios/RNMBX/RNMBXModule.swift
@@ -103,9 +103,7 @@ class RNMBXModule : NSObject {
   }
   
   @objc func setTelemetryEnabled(_ telemetryEnabled: Bool) {
-    #if !RNMBX_11 // RNMBX_11_TODO
-    UserDefaults.mme_configuration().mme_isCollectionEnabled = telemetryEnabled
-    #endif
+    UserDefaults.standard.set(telemetryEnabled, forKey: "MGLMapboxMetricsEnabled")
   }
 
   @objc func setWellKnownTileServer(_ tileServer: String) {


### PR DESCRIPTION
## Description

Fixes: setTelemetryEnabled did not work in iOS

Tested on v10.1.3 and v11

To test:
`Mapbox.setTelemetryEnabled(false);`
or
`Mapbox.setTelemetryEnabled(true);`

and press attribution icon -> mapbox telemetry (text is "you are helping..." -> true or "you can help..." -> false)