### PR TITLE
fix(android): error when clearing followUserLocation

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXCamera.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXCamera.kt
@@ -59,7 +59,7 @@ class RNMBXCamera(private val mContext: Context, private val mManager: RNMBXCame
     private val mAnimated = false
     private val mHeading = 0.0
 
-    private var mFollowUserLocation = false
+    private var mFollowUserLocation = defaultFollowUserLocation
     private var mFollowUserMode: String? = null
     private var mFollowZoomLevel : Double? = null
     private var mFollowPitch : Double? = null
@@ -126,8 +126,8 @@ class RNMBXCamera(private val mContext: Context, private val mManager: RNMBXCame
         _updateViewportState()
     }
 
-    fun setFollowUserLocation(value: Boolean) {
-        mFollowUserLocation = value
+    fun setFollowUserLocation(value: Boolean?) {
+        mFollowUserLocation = value ?: defaultFollowUserLocation
         _updateViewportState()
     }
 
@@ -559,5 +559,7 @@ class RNMBXCamera(private val mContext: Context, private val mManager: RNMBXCame
         const val minimumZoomLevelForUserTracking = 10.5
         const val defaultZoomLevelForUserTracking = 14.0
         const val LOG_TAG = "RNMBXCamera"
+
+        const val defaultFollowUserLocation = false
     }
 }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXCameraManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXCameraManager.kt
@@ -9,7 +9,7 @@ import com.mapbox.geojson.FeatureCollection
 import com.rnmapbox.rnmbx.components.AbstractEventEmitter
 import com.rnmapbox.rnmbx.components.camera.CameraStop.Companion.fromReadableMap
 import com.rnmapbox.rnmbx.utils.GeoJSONUtils.toLatLngBounds
-
+import com.rnmapbox.rnmbx.utils.extensions.asBooleanOrNull
 
 class RNMBXCameraManager(private val mContext: ReactApplicationContext) :
     AbstractEventEmitter<RNMBXCamera?>(
@@ -66,7 +66,7 @@ class RNMBXCameraManager(private val mContext: ReactApplicationContext) :
 
     @ReactProp(name = "followUserLocation")
     override fun setFollowUserLocation(camera: RNMBXCamera, value: Dynamic) {
-        camera.setFollowUserLocation(value.asBoolean())
+        camera.setFollowUserLocation(value.asBooleanOrNull())
     }
 
     @ReactProp(name = "followUserMode")

--- a/android/src/main/java/com/rnmapbox/rnmbx/utils/extensions/Dynamic.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/utils/extensions/Dynamic.kt
@@ -55,3 +55,11 @@ fun Dynamic.toValue(): Value {
         ReadableType.Map -> asMap().toValue()
     }
 }
+
+fun Dynamic.asBooleanOrNull(): Boolean? {
+    return if (isNull) {
+        null
+    } else {
+        asBoolean()
+    }
+}


### PR DESCRIPTION
Render1:
```jsx
<Camera followUserLocation={false} ... />
```

Render2:
```jsx
<Camera />
```


Was causing exception on null on android:

![image](https://github.com/rnmapbox/maps/assets/52435/d56a0cee-f824-473a-951d-b6131f3403e3)
