### PR TITLE
fix(android): uppercase conversion in getEnumName() method

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -165,4 +165,15 @@ dependencies {
         implementation "com.squareup.okhttp3:okhttp:4.9.0"
         implementation "com.squareup.okhttp3:okhttp-urlconnection:4.9.0"
     }
+
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+    testImplementation 'org.jetbrains.kotlin:kotlin-test'
+    testImplementation "org.mockito.kotlin:mockito-kotlin:5.2.1"
+}
+
+
+tasks.withType(Test).configureEach {
+    useJUnitPlatform()
 }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/RNMBXStyleValue.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/RNMBXStyleValue.kt
@@ -40,7 +40,7 @@ class RNMBXStyleValue(config: ReadableMap) {
     }
 
     fun getEnumName(): String {
-        return mPayload!!.getString("value")!!.toUpperCase().replace("-", "_")
+        return mPayload!!.getString("value")!!.uppercase(Locale.US).replace("-", "_")
     }
 
     fun getDouble(key: String?): Double {

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/RNMBXStyleValue.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/RNMBXStyleValue.kt
@@ -40,7 +40,7 @@ class RNMBXStyleValue(config: ReadableMap) {
     }
 
     fun getEnumName(): String {
-        return mPayload!!.getString("value")!!.uppercase(Locale.US).replace("-", "_")
+        return mPayload!!.getString("value")!!.uppercase().replace("-", "_")
     }
 
     fun getDouble(key: String?): Double {

--- a/android/src/test/kotlin/com/rnmapbox/rnmbx/components/styles/RNMBXStyleValueTest.kt
+++ b/android/src/test/kotlin/com/rnmapbox/rnmbx/components/styles/RNMBXStyleValueTest.kt
@@ -1,0 +1,47 @@
+import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.ReadableMap
+import com.rnmapbox.rnmbx.components.styles.RNMBXStyleValue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+import org.mockito.Mockito
+import java.util.Locale
+
+class RNMBXStyleValueTest {
+
+    private lateinit var mockConfig: ReadableMap
+    private lateinit var mockPayload: ReadableMap
+    private lateinit var mockDynamic: Dynamic
+
+    @BeforeEach
+    fun setup() {
+        mockConfig = Mockito.mock(ReadableMap::class.java)
+        mockPayload = Mockito.mock(ReadableMap::class.java)
+        mockDynamic = Mockito.mock(Dynamic::class.java)
+
+        Mockito.`when`(mockConfig.getMap("stylevalue")).thenReturn(mockPayload)
+        Mockito.`when`(mockPayload.getDynamic("value")).thenReturn(mockDynamic)
+    }
+
+    @Test
+    fun `getEnumName returns correct enum name`() {
+        Mockito.`when`(mockPayload.getString("value")).thenReturn("test-value")
+
+        val styleValue = RNMBXStyleValue(mockConfig)
+
+        assertEquals("TEST_VALUE", styleValue.getEnumName())
+    }
+
+    @Test
+    fun `getEnumName handles Turkish locale correctly`() {
+        Mockito.`when`(mockPayload.getString("value")).thenReturn("miter")
+
+        val styleValue = RNMBXStyleValue(mockConfig)
+
+        Locale.setDefault(Locale("tr", "TR"))
+
+        assertEquals("MITER", styleValue.getEnumName())
+
+        Locale.setDefault(Locale.getDefault())
+    }
+}


### PR DESCRIPTION
## Description

Fixed a bug affecting locales such as
Turkish, where lowercase 'i' was incorrectly converted to 'İ' instead of 'I'. Now, the US locale is explicitly used for enum name conversion to ensure correct character mapping.

Fixes #3255 

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [X] I've read `CONTRIBUTING.md`
- [X] I updated the doc/other generated code with running `yarn generate` in the root folder
- [X] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [X] In V11 mode/android
  - [X] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

