### PR TITLE
iOS(fabric): fix markerview

### DIFF
--- a/ios/RNMBX/RNMBXMarkerViewComponentView.mm
+++ b/ios/RNMBX/RNMBXMarkerViewComponentView.mm
@@ -25,7 +25,7 @@ using namespace facebook::react;
   if (self = [super initWithFrame:frame]) {
     static const auto defaultProps = std::make_shared<const RNMBXMarkerViewProps>();
     _props = defaultProps;
-      [self prepareView];
+    [self prepareView];
   }
 
   return self;
@@ -39,26 +39,18 @@ using namespace facebook::react;
 
 - (void)prepareForRecycle
 {
-    [super prepareForRecycle];
-    [self prepareView];
+  [super prepareForRecycle];
+  [self prepareView];
 }
 
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
-    if ([childComponentView isKindOfClass:[RCTViewComponentView class]] && ((RCTViewComponentView *)childComponentView).contentView != nil) {
-        [_view insertSubview:((RCTViewComponentView *)childComponentView).contentView atIndex:index];
-    } else {
-        [_view insertSubview:childComponentView atIndex:index];
-    }
+  [_view insertSubview:childComponentView atIndex:index];
 }
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
-    if ([childComponentView isKindOfClass:[RCTViewComponentView class]] && ((RCTViewComponentView *)childComponentView).contentView != nil) {
-        [((RCTViewComponentView *)childComponentView).contentView removeFromSuperview];
-    } else {
-        [childComponentView removeFromSuperview];
-    }
+  [childComponentView removeFromSuperview];
 }
 
 #pragma mark - RCTComponentViewProtocol

--- a/ios/RNMBX/RNMBXMarkerViewContentComponentView.mm
+++ b/ios/RNMBX/RNMBXMarkerViewContentComponentView.mm
@@ -17,25 +17,18 @@ using namespace facebook::react;
 @end
 
 @implementation RNMBXMarkerViewContentComponentView {
-  RNMBXMarkerView *_view;
+  UIView *_view;
   CGRect _frame;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const RNMBXMarkerViewProps>();
+    static const auto defaultProps = std::make_shared<const RNMBXMarkerViewContentProps>();
     _props = defaultProps;
     _frame = frame;
-    [self prepareView];
   }
   return self;
-}
-
-- (void)prepareView
-{
-  _view =  [[RNMBXMarkerView alloc] initWithFrame:_frame];
-  self.contentView = _view;
 }
 
 #pragma mark - RCTComponentViewProtocol


### PR DESCRIPTION
Fixes:
- [x] Marker views are not visible
- [x] Events(Taps) are not processed
- [x] Raises 'RCTComponentViewRegistry: Attempt to recycle a mounted view.' when closing the component

<img width="311" alt="image" src="https://github.com/rnmapbox/maps/assets/52435/9b6c624d-a7a5-4600-b900-5f8077230561">


<img width="217" alt="image" src="https://github.com/rnmapbox/maps/assets/52435/c392551c-3780-4fc9-9073-4525f7fec76f">
