### PR TITLE
fix(ios,fabric): do not apply camera stops on render unless stops wer…

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/camera/CameraStop.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/camera/CameraStop.kt
@@ -30,6 +30,9 @@ class CameraStop {
     private var mMode = CameraMode.EASE
     private var mDuration = 2000
     private var mCallback: Animator.AnimatorListener? = null
+
+    var ts: Int? = null
+
     fun setBearing(bearing: Double) {
         mBearing = bearing
     }
@@ -152,6 +155,10 @@ class CameraStop {
             callback: Animator.AnimatorListener?
         ): CameraStop {
             val stop = CameraStop()
+
+            if (readableMap.hasKey("__updateTS")) {
+                stop.ts = readableMap.getInt("__updateTS")
+            }
 
             if (readableMap.hasKey("pitch")) {
                 stop.setTilt(readableMap.getDouble("pitch"))

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXCamera.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXCamera.kt
@@ -72,6 +72,9 @@ class RNMBXCamera(private val mContext: Context, private val mManager: RNMBXCame
     private var mMaxBounds: LatLngBounds? = null
 
 
+    var ts: Int? = null;
+
+
     private val mCameraCallback: Animator.AnimatorListener = object : Animator.AnimatorListener {
         override fun onAnimationStart(animator: Animator) {}
         override fun onAnimationEnd(animator: Animator) {
@@ -110,10 +113,12 @@ class RNMBXCamera(private val mContext: Context, private val mManager: RNMBXCame
         }
     }
     fun setStop(stop: CameraStop) {
-        mCameraStop = stop
-        stop.setCallback(mCameraCallback)
-        if (mMapView != null) {
-            stop.let { updateCamera(it) }
+        if (stop.ts != mCameraStop?.ts) {
+            mCameraStop = stop
+            stop.setCallback(mCameraCallback)
+            if (mMapView != null) {
+                stop.let { updateCamera(it) }
+            }
         }
     }
 

--- a/ios/RNMBX/RNMBXCameraComponentView.mm
+++ b/ios/RNMBX/RNMBXCameraComponentView.mm
@@ -69,58 +69,62 @@ using namespace facebook::react;
 
 - (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
-  const auto &newProps = static_cast<const RNMBXCameraProps &>(*props);
-    id maxBounds = RNMBXConvertFollyDynamicToId(newProps.maxBounds);
+    const auto &oldViewProps = static_cast<const RNMBXCameraProps &>(*oldProps);
+    const auto &newViewProps = static_cast<const RNMBXCameraProps &>(*props);
+    id maxBounds = RNMBXConvertFollyDynamicToId(newViewProps.maxBounds);
     if (maxBounds != nil) {
         _view.maxBounds = maxBounds;
     }
-    id animationDuration = RNMBXConvertFollyDynamicToId(newProps.animationDuration);
+    id animationDuration = RNMBXConvertFollyDynamicToId(newViewProps.animationDuration);
     if (animationDuration != nil) {
         _view.animationDuration = animationDuration;
     }
-    id animationMode = RNMBXConvertFollyDynamicToId(newProps.animationMode);
+    id animationMode = RNMBXConvertFollyDynamicToId(newViewProps.animationMode);
     if (animationMode != nil) {
         _view.animationMode = animationMode;
     }
-    id defaultStop = RNMBXConvertFollyDynamicToId(newProps.defaultStop);
+    id defaultStop = RNMBXConvertFollyDynamicToId(newViewProps.defaultStop);
     if (defaultStop != nil) {
         _view.defaultStop = defaultStop;
     }
-    id followUserLocation = RNMBXConvertFollyDynamicToId(newProps.followUserLocation);
+    id followUserLocation = RNMBXConvertFollyDynamicToId(newViewProps.followUserLocation);
     if (followUserLocation != nil) {
         _view.followUserLocation = followUserLocation;
     }
-    id followUserMode = RNMBXConvertFollyDynamicToId(newProps.followUserMode);
+    id followUserMode = RNMBXConvertFollyDynamicToId(newViewProps.followUserMode);
     if (followUserMode != nil) {
         _view.followUserMode = followUserMode;
     }
-    id followZoomLevel = RNMBXConvertFollyDynamicToId(newProps.followZoomLevel);
+    id followZoomLevel = RNMBXConvertFollyDynamicToId(newViewProps.followZoomLevel);
     if (followZoomLevel != nil) {
         _view.followZoomLevel = followZoomLevel;
     }
-    id followPitch = RNMBXConvertFollyDynamicToId(newProps.followPitch);
+    id followPitch = RNMBXConvertFollyDynamicToId(newViewProps.followPitch);
     if (followPitch != nil) {
         _view.followPitch = followPitch;
     }
-    id followHeading = RNMBXConvertFollyDynamicToId(newProps.followHeading);
+    id followHeading = RNMBXConvertFollyDynamicToId(newViewProps.followHeading);
     if (followHeading != nil) {
         _view.followHeading = followHeading;
     }
-    id followPadding = RNMBXConvertFollyDynamicToId(newProps.followPadding);
+    id followPadding = RNMBXConvertFollyDynamicToId(newViewProps.followPadding);
     if (followPadding != nil) {
         _view.followPadding = followPadding;
     }
-    id maxZoomLevel = RNMBXConvertFollyDynamicToId(newProps.maxZoomLevel);
+    id maxZoomLevel = RNMBXConvertFollyDynamicToId(newViewProps.maxZoomLevel);
     if (maxZoomLevel != nil) {
         _view.maxZoomLevel = maxZoomLevel;
     }
-    id minZoomLevel = RNMBXConvertFollyDynamicToId(newProps.minZoomLevel);
+    id minZoomLevel = RNMBXConvertFollyDynamicToId(newViewProps.minZoomLevel);
     if (minZoomLevel != nil) {
         _view.minZoomLevel = minZoomLevel;
     }
-    id stop = RNMBXConvertFollyDynamicToId(newProps.stop);
-    if (stop != nil) {
+
+    if (!oldProps || oldViewProps.stop != newViewProps.stop) {
+      id stop = RNMBXConvertFollyDynamicToId(newViewProps.stop);
+      if (stop != nil) {
         _view.stop = stop;
+      }
     }
   [super updateProps:props oldProps:oldProps];
 }

--- a/src/components/Camera.tsx
+++ b/src/components/Camera.tsx
@@ -380,6 +380,8 @@ export const Camera = memo(
           return;
         }
 
+        lastTS += 1;
+
         if (!config.type)
           // @ts-expect-error The compiler doesn't understand that the `config` union type is guaranteed
           // to be an object type.
@@ -398,13 +400,15 @@ export const Camera = memo(
               _nativeStops = [..._nativeStops, _nativeStop];
             }
             nativeCamera.current?.setNativeProps({
-              stop: { stops: _nativeStops },
+              stop: { stops: _nativeStops, __updateTS: lastTS },
             });
           }
         } else if (config.type === 'CameraStop') {
           const _nativeStop = buildNativeStop(config);
           if (_nativeStop) {
-            nativeCamera.current?.setNativeProps({ stop: _nativeStop });
+            nativeCamera.current?.setNativeProps({
+              stop: { __updateTS: lastTS, ..._nativeStop },
+            });
           }
         }
       };
@@ -589,6 +593,8 @@ export const Camera = memo(
     },
   ),
 );
+
+let lastTS = 0;
 
 const RNMBXCamera = NativeCameraView;
 


### PR DESCRIPTION
…e changed

Used the following component to reproduce the issue:


- Press fly to
- Use pan gesture to change camera
- Press Re-Render this will cause a re-render a camera change

```jsx
import React, { useRef } from 'react';
import { Button, Text } from 'react-native';
import { MapView, Camera } from '@rnmapbox/maps';

function App() {
  let camerRef = useRef(null);
  let [counter, setCounter] = React.useState(0);
  return (
    <>
      <Button
        title="Fly to"
        onPress={() => {
          camerRef.current.flyTo([-74.10597, 41.71427]);
        }}
      />
      <Button
        title="Re-render"
        onPress={() => {
          setCounter(counter + 1);
        }}
      />
      <Text>Counter: {counter}</Text>
      <MapView style={{ flex: 1 }}>
        <Camera
          defaultSettings={{
            centerCoordinate: [-74.00597, 40.71427],
            zoomLevel: 15,
          }}
          ref={camerRef}
        />
      </MapView>
    </>
  );
}

export default App;
```