### PR TITLE
Fix - iOS NativeUserLocation puckBearing logic typo and puck image updates not being applied properly

### DIFF
--- a/ios/RNMBX/RNMBXNativeUserLocation.swift
+++ b/ios/RNMBX/RNMBXNativeUserLocation.swift
@@ -68,7 +68,7 @@ public class RNMBXNativeUserLocation: UIView, RNMBXMapComponent {
       case nil:
         _puckBearing = nil
       default:
-        Logger.error("RNMBXNativeUserLocation puckBearing is uncrecognized: \(String(describing: value))")
+        Logger.error("RNMBXNativeUserLocation puckBearing is uncrecognized: \(optional: value)")
         _puckBearing = nil
       }
     }

--- a/ios/RNMBX/RNMBXNativeUserLocation.swift
+++ b/ios/RNMBX/RNMBXNativeUserLocation.swift
@@ -122,7 +122,7 @@ public class RNMBXNativeUserLocation: UIView, RNMBXMapComponent {
         return Value.constant(0.0)
       }
     default:
-      Logger.error("toDoubleValue: \(name): has unknown type: \(type(of:value)) \(String(describing: value)) ")
+      Logger.error("toDoubleValue: \(name): has unknown type: \(type(of:value)) \(optional: value) ")
       return .constant(1.0)
     }
   }


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes:

- Incorrect puckBearing name in switch case
- Resolved warnings in Xcode
- Puck images not being fetched after initial addToMap
- Puck images not being correctly applied when changed on the fly

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [x] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reprocuce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here  -->
```jsx
<Mapbox.MapView>
  <Mapbox.Images
          images={{ mapNavPuck: media.mapNavigationPuck }}
          onImageMissing={(imageKey: string) => console.log('=> on image missing', imageKey)}
        />
  <Mapbox.LocationPuck
            puckBearing={
              USER_TRACKING_MODES[userTrackingMode].key === 'followCourse'
                ? 'course'
                : 'heading'
            }
            puckBearingEnabled={true}
            topImage={
              USER_TRACKING_MODES[userTrackingMode].key === 'followCourse' ? 'mapNavPuck' : undefined
            }
          />
</Mapbox.MapView>
```
