### PR TITLE
fix(android): initial centerCoordinate should apply

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXCamera.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXCamera.kt
@@ -113,7 +113,7 @@ class RNMBXCamera(private val mContext: Context, private val mManager: RNMBXCame
         }
     }
     fun setStop(stop: CameraStop) {
-        if (stop.ts != mCameraStop?.ts) {
+        if ((stop.ts != mCameraStop?.ts) || (mCameraStop == null)) {
             mCameraStop = stop
             stop.setCallback(mCameraCallback)
             if (mMapView != null) {


### PR DESCRIPTION
Fixes: #3371

Uses this component to repro/test:

```jsx
import React from 'react';
import { Button } from 'react-native';
import { MapView, ShapeSource, LineLayer, Camera } from '@rnmapbox/maps';

class BugReportExample extends React.Component {
  state = {
    center: [-74.00597, 40.71427],
    count: 0,
  };

  render() {
    return (
      <>
        <Button
          title="Change location"
          onPress={() => this.setState({ center: [-74.01597, 40.71427] })}
        />
        <Button
          title={`Counter: ${this.state.count}`}
          onPress={() => this.setState({ count: this.state.count + 1 })}
        />
        <MapView style={{ flex: 1 }}>
          <Camera centerCoordinate={this.state.center} zoomLevel={14} />
        </MapView>
      </>
    );
  }
}

export default BugReportExample;

```