### PR TITLE
refactor(android): camera bounds, zoom, and animation mode handling

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/camera/CameraStop.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/camera/CameraStop.kt
@@ -95,12 +95,10 @@ class CameraStop {
     fun toCameraUpdate(mapView: RNMBXMapView): CameraUpdateItem {
         val map = mapView.getMapboxMap()
         val currentCamera = map.cameraState
+
         val builder = CameraOptions.Builder()
         builder.center(currentCamera.center)
         builder.bearing(currentCamera.bearing)
-
-        val currentPadding = currentCamera.padding
-
         builder.padding(currentCamera.padding)
         builder.zoom(currentCamera.zoom)
         if (mBearing != null) {
@@ -109,7 +107,11 @@ class CameraStop {
         if (mTilt != null) {
             builder.pitch(mTilt)
         }
+        if (mZoom != null) {
+            builder.zoom(mZoom)
+        }
 
+        val currentPadding = currentCamera.padding
         val paddingLeft: Int = mPaddingLeft ?: currentPadding.left.toInt()
         val paddingTop: Int = mPaddingTop ?: currentPadding.top.toInt()
         val paddingRight: Int = mPaddingRight ?: currentPadding.right.toInt()
@@ -117,10 +119,10 @@ class CameraStop {
         val cameraPadding = intArrayOf(paddingLeft, paddingTop, paddingRight, paddingBottom)
         val cameraPaddingClipped = clippedPadding(cameraPadding, mapView)
         val cameraPaddingEdgeInsets = convert(cameraPaddingClipped)
+        builder.padding(cameraPaddingEdgeInsets)
 
         if (mLatLng != null) {
             builder.center(mLatLng!!.point)
-            builder.padding(cameraPaddingEdgeInsets)
         } else if (mBounds != null) {
             val tilt = if (mTilt != null) mTilt!! else currentCamera.pitch
             val bearing = if (mBearing != null) mBearing!! else currentCamera.bearing
@@ -131,15 +133,12 @@ class CameraStop {
                 bearing,
                 tilt
             )
-
             builder.center(boundsCamera.center)
             builder.anchor(boundsCamera.anchor)
             builder.zoom(boundsCamera.zoom)
+            builder.bearing(boundsCamera.bearing)
+            builder.pitch(boundsCamera.pitch)
             builder.padding(boundsCamera.padding)
-        }
-
-        if (mZoom != null) {
-            builder.zoom(mZoom)
         }
 
         return CameraUpdateItem(map, builder.build(), mDuration, mCallback, mMode)
@@ -195,6 +194,7 @@ class CameraStop {
                 when (readableMap.getInt("mode")) {
                     CameraMode.FLIGHT -> stop.setMode(CameraMode.FLIGHT)
                     CameraMode.LINEAR -> stop.setMode(CameraMode.LINEAR)
+                    CameraMode.MOVE -> stop.setMode(CameraMode.MOVE)
                     CameraMode.NONE -> stop.setMode(CameraMode.NONE)
                     else -> stop.setMode(CameraMode.EASE)
                 }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/camera/CameraUpdateItem.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/camera/CameraUpdateItem.kt
@@ -83,7 +83,7 @@ class CameraUpdateItem(
         val animationOptions = MapAnimationOptions.Builder();
 
         // animateCamera / easeCamera only allows positive duration
-        if (duration == 0 || mCameraMode == CameraMode.NONE) {
+        if (duration == 0 || mCameraMode == CameraMode.MOVE || mCameraMode == CameraMode.NONE) {
             map.flyToV11(mCameraUpdate, animationOptions.apply {
                 duration(0)
             },
@@ -109,7 +109,6 @@ class CameraUpdateItem(
                 callback
             )
         }
-        null
     }
 
     override fun cancel(mayInterruptIfRunning: Boolean): Boolean {

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXCamera.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXCamera.kt
@@ -3,7 +3,6 @@ package com.rnmapbox.rnmbx.components.camera
 import android.animation.Animator
 import android.content.Context
 import android.location.Location
-import android.util.Log
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableMap
 import com.mapbox.maps.plugin.gestures.gestures

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXCamera.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXCamera.kt
@@ -180,11 +180,14 @@ class RNMBXCamera(private val mContext: Context, private val mManager: RNMBXCame
         withMapView { mapView ->
             val map = mapView.getMapboxMap()
             val maxBounds = mMaxBounds
-            val builder = CameraBoundsOptions.Builder()
 
+            val builder = CameraBoundsOptions.Builder()
             if (maxBounds != null) {
                 builder.bounds(maxBounds.toBounds())
+            } else {
+                builder.bounds(null)
             }
+
             mMinZoomLevel?.let { builder.minZoom(it) }
             mMaxZoomLevel?.let { builder.maxZoom(it) }
             map.setBounds(builder.build())

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXCamera.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXCamera.kt
@@ -3,6 +3,7 @@ package com.rnmapbox.rnmbx.components.camera
 import android.animation.Animator
 import android.content.Context
 import android.location.Location
+import android.util.Log
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableMap
 import com.mapbox.maps.plugin.gestures.gestures
@@ -179,18 +180,12 @@ class RNMBXCamera(private val mContext: Context, private val mManager: RNMBXCame
     private fun updateMaxBounds() {
         withMapView { mapView ->
             val map = mapView.getMapboxMap()
-            val maxBounds = mMaxBounds
-
             val builder = CameraBoundsOptions.Builder()
-            if (maxBounds != null) {
-                builder.bounds(maxBounds.toBounds())
-            } else {
-                builder.bounds(null)
-            }
-
-            mMinZoomLevel?.let { builder.minZoom(it) }
-            mMaxZoomLevel?.let { builder.maxZoom(it) }
+            builder.bounds(mMaxBounds?.toBounds())
+            builder.minZoom(mMinZoomLevel ?: 0.0) // Passing null does not reset this value.
+            builder.maxZoom(mMaxZoomLevel ?: 25.0) // Passing null does not reset this value.
             map.setBounds(builder.build())
+            mCameraStop?.let { updateCamera(it) }
         }
     }
 

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXCameraManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXCameraManager.kt
@@ -59,12 +59,12 @@ class RNMBXCameraManager(private val mContext: ReactApplicationContext, val view
 
     @ReactProp(name = "minZoomLevel")
     override fun setMinZoomLevel(camera: RNMBXCamera, value: Dynamic) {
-        camera.setMinZoomLevel(value.asDouble())
+        camera.setMinZoomLevel(value.asDoubleOrNull())
     }
 
     @ReactProp(name = "maxZoomLevel")
     override fun setMaxZoomLevel(camera: RNMBXCamera, value: Dynamic) {
-        camera.setMaxZoomLevel(value.asDouble())
+        camera.setMaxZoomLevel(value.asDoubleOrNull())
     }
 
     @ReactProp(name = "followUserLocation")

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/camera/constants/CameraMode.java
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/camera/constants/CameraMode.java
@@ -7,12 +7,13 @@ import java.lang.annotation.RetentionPolicy;
 
 public class CameraMode {
 
-    @IntDef({ FLIGHT, EASE, LINEAR, NONE })
+    @IntDef({ FLIGHT, EASE, LINEAR, MOVE, NONE })
     @Retention(RetentionPolicy.SOURCE)
     public @interface Mode {}
 
     public static final int FLIGHT = 1;
     public static final int EASE = 2;
     public static final int LINEAR = 3;
-    public static final int NONE = 4;
+    public static final int MOVE = 4;
+    public static final int NONE = 5;
 }

--- a/android/src/main/java/com/rnmapbox/rnmbx/modules/RNMBXModule.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/modules/RNMBXModule.kt
@@ -90,6 +90,7 @@ class RNMBXModule(private val mReactContext: ReactApplicationContext) : ReactCon
         cameraModes["Flight"] = CameraMode.FLIGHT
         cameraModes["Ease"] = CameraMode.EASE
         cameraModes["Linear"] = CameraMode.LINEAR
+        cameraModes["Move"] = CameraMode.MOVE
         cameraModes["None"] = CameraMode.NONE
 
         // offline region download states

--- a/example/src/examples/V10/CameraAnimation.tsx
+++ b/example/src/examples/V10/CameraAnimation.tsx
@@ -50,6 +50,7 @@ const CameraAnimation = () => {
   const [paddingRight, setPaddingRight] = useState(0);
   const [paddingTop, setPaddingTop] = useState(0);
   const [paddingBottom, setPaddingBottom] = useState(0);
+  const [zoom, setZoom] = useState(10);
   const [minZoom, setMinZoom] = useState<number | undefined>(undefined);
   const [maxZoom, setMaxZoom] = useState<number | undefined>(undefined);
 
@@ -153,6 +154,34 @@ const CameraAnimation = () => {
     [easing],
   );
 
+  const zoomCounter = useMemo(() => {
+    const disabled = coordinates.length > 1;
+
+    return (
+      <View style={{ flex: 1, paddingHorizontal: 10 }}>
+        <View style={{ flex: 0, alignItems: 'center' }}>
+          <Text style={{ fontWeight: 'bold', opacity: disabled ? 0.4 : 1 }}>
+            {zoom}
+          </Text>
+        </View>
+        <Slider
+          thumbStyle={[
+            styles.thumb,
+            { backgroundColor: disabled ? 'lightgray' : 'black' },
+          ]}
+          trackStyle={{ opacity: disabled ? 0.1 : 1 }}
+          value={zoom}
+          disabled={disabled}
+          minimumValue={1}
+          maximumValue={20}
+          onSlidingComplete={(_value) => {
+            setZoom(Math.round(_value));
+          }}
+        />
+      </View>
+    );
+  }, [coordinates.length, zoom]);
+
   const paddingCounter = useCallback(
     (value: number, setValue: (value: number) => void, label: string) => {
       return (
@@ -162,11 +191,7 @@ const CameraAnimation = () => {
             <Text style={{ fontWeight: 'bold' }}>{`${Math.round(value)}`}</Text>
           </View>
           <Slider
-            thumbStyle={{
-              backgroundColor: 'black',
-              width: 15,
-              height: 15,
-            }}
+            thumbStyle={styles.thumb}
             value={value}
             minimumValue={0}
             maximumValue={500}
@@ -188,16 +213,12 @@ const CameraAnimation = () => {
         <View style={{ flex: 1, paddingHorizontal: 10 }}>
           <View style={{ flex: 0, alignItems: 'center' }}>
             <Text>{label}</Text>
-            <Text style={{ fontWeight: 'bold' }}>{`${
-              value ?? 'Not set'
-            }`}</Text>
+            <Text style={{ fontWeight: 'bold' }}>
+              {`${value ?? 'Not set'}`}
+            </Text>
           </View>
           <Slider
-            thumbStyle={{
-              backgroundColor: 'black',
-              width: 15,
-              height: 15,
-            }}
+            thumbStyle={styles.thumb}
             value={value}
             minimumValue={-1}
             maximumValue={20}
@@ -220,7 +241,7 @@ const CameraAnimation = () => {
       <MapView style={styles.map}>
         <Camera
           {...centerOrBounds}
-          zoomLevel={12}
+          zoomLevel={zoom}
           minZoomLevel={minZoom}
           maxZoomLevel={maxZoom}
           padding={{
@@ -260,6 +281,13 @@ const CameraAnimation = () => {
               {easingCheckBox('linearTo', 'Linear')}
               {easingCheckBox('flyTo', 'Fly')}
               {easingCheckBox('moveTo', 'Move')}
+            </View>
+
+            <Divider style={styles.divider} />
+
+            <Text style={styles.sectionText}>Zoom</Text>
+            <View style={[styles.buttonRow, { marginBottom: -6 }]}>
+              {zoomCounter}
             </View>
 
             <Divider style={styles.divider} />
@@ -308,6 +336,11 @@ const styles = StyleSheet.create({
   },
   divider: {
     marginVertical: 8,
+  },
+  thumb: {
+    backgroundColor: 'black',
+    width: 15,
+    height: 15,
   },
 });
 


### PR DESCRIPTION
This is a refactor to fix bounds and zoom handling on Android, similar to #3354 on iOS.

There wasn't a double-padding issue like on iOS, but Android did have these problems:

- couldn't zero out min or max zoom levels
- the zoom value was getting overridden after setting bounds
- the "move" camera animation mode just fell back to easing

See before and after (using example at [this commit](https://github.com/rnmapbox/maps/blob/24edfeb19dd2666574684942958825b07810bc80/example/src/examples/V10/CameraAnimation.tsx)):

Before:

https://github.com/rnmapbox/maps/assets/2423291/1e47eda5-c455-4775-acb9-c5978f2fd4ed

After:

https://github.com/rnmapbox/maps/assets/2423291/0a9c6802-df32-444c-9344-86b7903de24c
