### PR TITLE
fix(ios,fabric): fix set camera signature

### DIFF
--- a/android/src/main/old-arch/com/rnmapbox/rnmbx/NativeRNMBXCameraModuleSpec.java
+++ b/android/src/main/old-arch/com/rnmapbox/rnmbx/NativeRNMBXCameraModuleSpec.java
@@ -37,5 +37,5 @@ public abstract class NativeRNMBXCameraModuleSpec extends ReactContextBaseJavaMo
 
   @ReactMethod
   @DoNotStrip
-  public abstract void updateCameraStop(@Nullable Double viewRef, ReadableMap stops, Promise promise);
+  public abstract void updateCameraStop(@Nullable Double viewRef, ReadableMap stop, Promise promise);
 }

--- a/src/specs/NativeRNMBXCameraModule.ts
+++ b/src/specs/NativeRNMBXCameraModule.ts
@@ -30,7 +30,7 @@ type NativeAnimationMode = 'flight' | 'ease' | 'linear' | 'none' | 'move';
 type ObjectOr<T> = Object;
 
 export interface Spec extends TurboModule {
-  updateCameraStop(viewRef: ViewRef, stops: ObjectOr<Stop>): Promise<void>;
+  updateCameraStop(viewRef: ViewRef, stop: ObjectOr<Stop>): Promise<void>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('RNMBXCameraModule');


### PR DESCRIPTION
iOS and Fabric setCamera methods were not working due to `stop` and `stops` difference in signature. This was introduced in #3376