### PR TITLE
fix CustomLocationProvider v10 ios

### DIFF
--- a/ios/RNMBX/RNMBXCustomLocationProvider.swift
+++ b/ios/RNMBX/RNMBXCustomLocationProvider.swift
@@ -117,12 +117,7 @@ extension RNMBXCustomLocationProvider {
       }
       let customLocationProvider = CustomLocationProvider()
       self.customLocationProvider = customLocationProvider
-      if let locationModule = RNMBXLocationModule.shared {
-        locationModule.override(for: mapView.location)
-        locationModule.locationProvider = customLocationProvider
-        // mapView.location.overrideLocationProvider(with: customLocationProvider!)
-      }
-      
+      mapView.location.overrideLocationProvider(with: customLocationProvider)
     }
   }
   


### PR DESCRIPTION
## Description

Fixes CustomLocationProvider for mapbox V10 on ios.
before: using CustomLocationProvider would not update location on map, and after removing CustomLocationProvider no location updates would be received until app reload.
after: Location updates as expected, removing the provider restores default provider and location updates are received

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [X] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

I Couldn't find an example using CustomLocationProvider, but I have tested it in my own project which needs this feature.
