### PR TITLE
fix(ios,camera): apply camera changes when no center or bounds specified

### DIFF
--- a/ios/RNMBX/RNMBXCamera.swift
+++ b/ios/RNMBX/RNMBXCamera.swift
@@ -459,6 +459,15 @@ open class RNMBXCamera : RNMBXMapComponentBase {
           pitch: pitch ?? map.mapboxMap.cameraState.pitch
         )
       }
+    } else {
+      camera = CameraOptions(
+        center: nil,
+        padding: padding,
+        anchor: nil,
+        zoom: zoom,
+        bearing: heading,
+        pitch: pitch
+      )
     }
 
     guard let camera = camera else {


### PR DESCRIPTION
Fixes: #3413


Issue was caused by change: #3354

Example to repro was:

```jsx
import React, { useRef, useEffect } from 'react';
import { Button } from 'react-native';
import { MapView, ShapeSource, LineLayer, Camera } from '@rnmapbox/maps';

const aLine = {
  type: 'LineString',
  coordinates: [
    [-74.00597, 40.71427],
    [-74.00697, 40.71527],
  ],
};

const BugReportExample = () => {
  const cameraRef = useRef();
  useEffect(() => {
    setTimeout(() => cameraRef.current?.setCamera({ heading: 90 }), 2000);
  }, []);
  return (
    <>
      <Button
        onPress={() => cameraRef.current?.setCamera({ heading: 90 })}
        title="Set heading to 90"
      />
      <MapView style={{ flex: 1 }}>
        <Camera
          defaultSettings={{
            centerCoordinate: [-74.00597, 40.71427],
            heading: 30,
            zoomLevel: 14,
          }}
          ref={cameraRef}
        />
        <ShapeSource id="idStreetLayer" shape={aLine}>
          <LineLayer id="idStreetLayer" />
        </ShapeSource>
      </MapView>
    </>
  );
};

export default BugReportExample;
```