### PR TITLE
fix(ios): fix custome location provider add/remove

### DIFF
--- a/ios/RNMBX/RNMBXCustomLocationProvider.swift
+++ b/ios/RNMBX/RNMBXCustomLocationProvider.swift
@@ -1,5 +1,7 @@
 import MapboxMaps
 
+let TAG = "RNMBXCustomLocationProvider"
+
 @objc
 public class RNMBXCustomLocationProvider: UIView, RNMBXMapComponent {
   var map: RNMBXMapView? = nil
@@ -118,16 +120,21 @@ extension RNMBXCustomLocationProvider {
       let customLocationProvider = CustomLocationProvider()
       self.customLocationProvider = customLocationProvider
       if let locationModule = RNMBXLocationModule.shared {
-        locationModule.override(for: mapView.location)
         locationModule.locationProvider = customLocationProvider
-        // mapView.location.overrideLocationProvider(with: customLocationProvider!)
+        locationModule.override(for: mapView.location)
+      } else {
+        Logger.error(TAG, "RNMBXLocationModule.shared is nil")
+        mapView.location.overrideLocationProvider(with: customLocationProvider)
       }
       
     }
   }
   
   func removeCustomLocationProvider(mapView: MapView) {
-    if let provider = defaultLocationProvider {
+    if let locationModule = RNMBXLocationModule.shared {
+      locationModule.resetLocationProvider()
+      locationModule.override(for: mapView.location)
+    } else if let provider = defaultLocationProvider {
       mapView.location.overrideLocationProvider(with: provider)
     }
     customLocationProvider = nil

--- a/ios/RNMBX/RNMBXLocationModule.swift
+++ b/ios/RNMBX/RNMBXLocationModule.swift
@@ -460,6 +460,7 @@ class RNMBXLocationModule: RCTEventEmitter, LocationProviderRNMBXDelegate {
   var hasListener = false
   
   var locationProvider : LocationProvider
+  var defaultLocationProvider : LocationProvider? = nil
   
   var locationEventThrottle : (
     waitBetweenEvents: Double?,
@@ -471,6 +472,7 @@ class RNMBXLocationModule: RCTEventEmitter, LocationProviderRNMBXDelegate {
 
   override init() {
     locationProvider = LocationProviderRNMBX()
+    defaultLocationProvider = locationProvider
     super.init()
     if let locationProvider = locationProvider as? LocationProviderRNMBX {
       locationProvider.delegate = self
@@ -568,6 +570,12 @@ class RNMBXLocationModule: RCTEventEmitter, LocationProviderRNMBXDelegate {
     }
   }
   
+  func resetLocationProvider() {
+    if let defaultLocationProvider = defaultLocationProvider {
+      self.locationProvider = defaultLocationProvider
+    }
+  }
+
   // MARK: - location event throttle
   @objc
   func setLocationEventThrottle(_ throttleValue:NSNumber) {

--- a/ios/RNMBX/RNMBXLogging.swift
+++ b/ios/RNMBX/RNMBXLogging.swift
@@ -78,6 +78,10 @@ public class Logger {
     }
   }
   
+  public static func error(_ tag: String, _ message: String) {
+    log(level: .error, tag: tag, message: message)
+  }
+
   public static func error(_ message: String) {
     log(level: .error, message: message)
   }


### PR DESCRIPTION
Closes: #3411


https://github.com/rnmapbox/maps/assets/52435/ed1419ca-90b0-42e7-8e33-3642f379614f



Example:
```jsx
import React, { useRef, useEffect } from 'react';
import { Switch, View, Text } from 'react-native';
import {
  MapView,
  Camera,
  CustomLocationProvider,
  LocationPuck,
  Viewport,
} from '@rnmapbox/maps';

export default function BugReportExample() {
  const [location, setLocation] = React.useState([-74.00597, 40.71427]);
  const [useCustomLocation, setUseCustomLocation] = React.useState(false);
  useEffect(() => {
    const interval = setInterval(() => {
      setLocation((location) => [location[0] + 0.0001, location[1] + 0.0001]);
    }, 500);
    return () => clearInterval(interval);
  }, []);
  const viewportRef = useRef();

  return (
    <>
      <View style={{ flexDirection: 'row', alignItems: 'center' }}>
        <Text>Emulate Location</Text>
        <Switch
          value={useCustomLocation}
          onChange={() => setUseCustomLocation(!useCustomLocation)}
        />
      </View>

      <MapView
        style={{ flex: 1 }}
        onDidFinishLoadingStyle={() => {
          viewportRef.current.transitionTo(
            { kind: 'followPuck', zoom: 16 },
            { kind: 'default' },
          );
        }}
      >
        <Camera
          defaultSettings={{
            centerCoordinate: [-74.00597, 40.71427],
            zoomLevel: 14,
          }}
          followZoomLevel={14}
          followUserLocation={true}
        />
        <Viewport ref={viewportRef} />
        {useCustomLocation && <CustomLocationProvider coordinate={location} />}
        <LocationPuck visible={true} />
      </MapView>
    </>
  );
}

```