### PR TITLE
Support for iOS 12.4 with Mapbox Maps SDK v11

### DIFF
--- a/README-v10.md
+++ b/README-v10.md
@@ -58,7 +58,7 @@ code ios/Podfile
   # change these
   $RNMapboxMapsImpl = 'mapbox'
 
-  platform :ios, '13.0'
+  platform :ios, min_ios_version_supported
 
   ...
 

--- a/rnmapbox-maps.podspec
+++ b/rnmapbox-maps.podspec
@@ -223,7 +223,7 @@ Pod::Spec.new do |s|
   s.source      	= { :git => "https://github.com/rnmapbox/maps.git" }
   s.license     	= "MIT"
   if $RNMapboxMapsUseV11
-    s.platform    	= :ios, "13.0"
+    s.platform    	= :ios, "12.4"
   else
     s.platform    	= :ios, "11.0"
   end


### PR DESCRIPTION
## Description

Fixes #3432

```
[!] CocoaPods could not find compatible versions for pod "rnmapbox-maps":
  In Podfile:
    rnmapbox-maps (from `../node_modules/@rnmapbox/maps`)

Specs satisfying the `rnmapbox-maps (from `../node_modules/@rnmapbox/maps`)` dependency were found, but they required a higher minimum deployment target.
```

- Change the requirement of Mapbox v11 from iOS 13.0 down to 12.4
- Also changed the documentation to encourage supporting lower iOS versions. Each react-native release has a minimum predefined that we should use.

I don't see any downside to lowering the requirement yet.

## Checklist
- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code by running `yarn generate` in the root folder
- [x] I have tested the new feature on `/example` app without Flipper.
  - [x] In V11 mode/ios with React-Native 0.72.11 target ios 12.4
  - [x] In V10 mode/ios with React-Native 0.72.11 target ios 12.4
  - [x] In V11 mode/ios with React-Native 0.73.0 target ios 13.4
  - [x] In V10 mode/ios with React-Native 0.73.0 target ios 13.4
  - [x] In New Architecture V11 mode/ios
  - [x] In V11 mode/android
  - [x] In V10 mode/android
  - [x] In New Architecture V11 mode/android
