### PR TITLE
iOS - handle potential nil-reference exceptions when accessing map instance

### DIFF
--- a/ios/RNMBX/RNMBXCamera.swift
+++ b/ios/RNMBX/RNMBXCamera.swift
@@ -49,7 +49,9 @@ struct CameraUpdateItem {
       case .linear:
         map.mapView.camera.ease(to: camera, duration: duration ?? 0, curve: .linear, completion: nil)
       default:
-        map.mapboxMap.setCamera(to: camera)
+        if let mapboxMap = map.mapboxMap {
+          mapboxMap.setCamera(to: camera)
+        }
       }
     }
   }

--- a/ios/RNMBX/RNMBXImageSource.swift
+++ b/ios/RNMBX/RNMBXImageSource.swift
@@ -53,12 +53,13 @@ public class RNMBXImageSource : RNMBXSource {
   
   func doUpdate(_ update:(Style) -> Void) {
     guard let map = self.map,
+          let mapboxMap = map.mapboxMap,
           let _ = self.source,
-          map.mapboxMap.style.sourceExists(withId: id) else {
+          mapboxMap.style.sourceExists(withId: id) else {
       return
     }
     
-    let style = map.mapboxMap.style
+    let style = mapboxMap.style
     update(style)
   }
   

--- a/ios/RNMBX/RNMBXInteractiveElement.swift
+++ b/ios/RNMBX/RNMBXInteractiveElement.swift
@@ -24,7 +24,7 @@ public class RNMBXInteractiveElement : UIView, RNMBXMapComponent {
     }
     didSet {
       if oldValue != nil && oldValue != id {
-        if let map = map { addToMap(map, style: map.mapboxMap.style) }
+        if let map = map, let mapboxMap = map.mapboxMap { addToMap(map, style: mapboxMap.style) }
       }
     }
   }

--- a/ios/RNMBX/RNMBXLayer.swift
+++ b/ios/RNMBX/RNMBXLayer.swift
@@ -322,7 +322,10 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
   }
 
   public func removeFromMap(_ map: RNMBXMapView, reason: RemovalReason) -> Bool {
-    removeFromMap(map.mapboxMap.style)
+      if let mapboxMap = map.mapboxMap {
+          removeFromMap(mapboxMap.style)
+      }
+    
     return true
   }
   

--- a/ios/RNMBX/RNMBXMapViewModule.mm
+++ b/ios/RNMBX/RNMBXMapViewModule.mm
@@ -87,7 +87,7 @@ RCT_EXPORT_METHOD(getPointInView:(nonnull NSNumber*)viewRef atCoordinate:(NSArra
 
 RCT_EXPORT_METHOD(getVisibleBounds:(nonnull NSNumber*)viewRef resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     [self withMapView:viewRef block:^(RNMBXMapView *view) {
-        [RNMBXMapViewManager getVisibleBounds:view resolver:resolve];
+        [RNMBXMapViewManager getVisibleBounds:view resolver:resolve rejecter: reject];
     } reject:reject methodName:@"getVisibleBounds"];
 }
 

--- a/ios/RNMBX/RNMBXPointAnnotation.swift
+++ b/ios/RNMBX/RNMBXPointAnnotation.swift
@@ -155,10 +155,12 @@ public class RNMBXPointAnnotation : RNMBXInteractiveElement {
     return image
   }
   
-  func makeEvent(isSelect: Bool, deselectAnnotationOnMapTap: Bool = false) -> RNMBXEvent {
+  func makeEvent(isSelect: Bool, deselectAnnotationOnMapTap: Bool = false) -> RNMBXEvent? {
+    guard let map = map, let mapboxMap = map.mapboxMap else { return nil }
+
     let position = superview?.convert(layer.position, to: nil)
-    let location = map?.mapboxMap.coordinate(for: position!)
-    var geojson = Feature(geometry: .point(Point(location!)))
+    let location = mapboxMap.coordinate(for: position!)
+    var geojson = Feature(geometry: .point(Point(location)))
     geojson.identifier = .string(id)
     var properties : [String: JSONValue?] = [
       "screenPointX": .number(Double(position!.x)),
@@ -173,17 +175,19 @@ public class RNMBXPointAnnotation : RNMBXInteractiveElement {
   }
   
   func doSelect() {
-    let event = makeEvent(isSelect: true)
-    if let onSelected = onSelected {
-      onSelected(event.toJSON())
+    if let event = makeEvent(isSelect: true) {
+      if let onSelected = onSelected {
+        onSelected(event.toJSON())
+      }
     }
     onSelect()
   }
   
   func doDeselect(deselectAnnotationOnMapTap: Bool = false) {
-    let event = makeEvent(isSelect: false, deselectAnnotationOnMapTap: deselectAnnotationOnMapTap)
-    if let onDeselected = onDeselected {
-      onDeselected(event.toJSON())
+    if let event = makeEvent(isSelect: false, deselectAnnotationOnMapTap: deselectAnnotationOnMapTap) {
+      if let onDeselected = onDeselected {
+        onDeselected(event.toJSON())
+      }
     }
     onDeselect()
   }

--- a/ios/RNMBX/RNMBXShapeSource.swift
+++ b/ios/RNMBX/RNMBXShapeSource.swift
@@ -156,12 +156,13 @@ public class RNMBXShapeSource : RNMBXSource {
 
   func doUpdate(_ update:(Style) -> Void) {
     guard let map = self.map,
+          let mapboxMap = map.mapboxMap,
           let _ = self.source,
-          map.mapboxMap.style.sourceExists(withId: id) else {
+      mapboxMap.style.sourceExists(withId: id) else {
       return
     }
 
-    let style = map.mapboxMap.style
+      let style = mapboxMap.style
     update(style)
   }
 

--- a/ios/RNMBX/RNMBXSource.swift
+++ b/ios/RNMBX/RNMBXSource.swift
@@ -38,13 +38,13 @@ public class RNMBXSource : RNMBXInteractiveElement {
     
     @objc public func insertReactSubviewInternal(_ subview: UIView!, at atIndex: Int) {
         if let layer = subview as? RNMBXSourceConsumer {
-          if let map = map {
-            layer.addToMap(map, style: map.mapboxMap.style)
-          }
+            if let map = map, let mapboxMap = map.mapboxMap {
+                layer.addToMap(map, style: mapboxMap.style)
+            }
           layers.append(layer)
         } else if let component = subview as? RNMBXMapComponent {
-          if let map = map {
-            component.addToMap(map, style: map.mapboxMap.style)
+            if let map = map, let mapboxMap = map.mapboxMap {
+              component.addToMap(map, style: mapboxMap.style)
           }
           components.append(component)
         }
@@ -57,8 +57,8 @@ public class RNMBXSource : RNMBXInteractiveElement {
     
     @objc public func removeReactSubviewInternal(_ subview: UIView!) {
         if let layer : RNMBXSourceConsumer = subview as? RNMBXSourceConsumer {
-          if let map = map {
-            layer.removeFromMap(map, style: map.mapboxMap.style)
+          if let map = map, let mapboxMap = map.mapboxMap {
+            layer.removeFromMap(map, style: mapboxMap.style)
           }
           layers.removeAll { $0 as AnyObject === layer }
         } else if let component = subview as? RNMBXMapComponent {
@@ -99,29 +99,35 @@ public class RNMBXSource : RNMBXInteractiveElement {
         #endif
       }
     }
+      if let mapboxMap = map.mapboxMap {
+          for layer in self.layers {
 
-    for layer in self.layers {
-      layer.addToMap(map, style: map.mapboxMap.style)
-    }
-    for component in self.components {
-      component.addToMap(map, style: map.mapboxMap.style)
-    }
+              layer.addToMap(map, style: mapboxMap.style)
+          }
+          for component in self.components {
+              component.addToMap(map, style: mapboxMap.style)
+          }
+      }
   }
 
   public override func removeFromMap(_ map: RNMBXMapView, reason: RemovalReason) -> Bool {
     self.map = nil
 
-    for layer in self.layers {
-      layer.removeFromMap(map, style: map.mapboxMap.style)
-    }
+      if let mapboxMap = map.mapboxMap {
+          for layer in self.layers {
+              layer.removeFromMap(map, style: mapboxMap.style)
+          }
 
-    if self.ownsSource {
-      let style = map.mapboxMap.style
-      logged("StyleSource.removeFromMap", info: { "id: \(optional: self.id)"}) {
-        try style.removeSource(withId: id)
+          if self.ownsSource {
+              let style = mapboxMap.style
+              logged("StyleSource.removeFromMap", info: { "id: \(optional: self.id)"}) {
+                  try style.removeSource(withId: id)
+              }
+              self.ownsSource = false
+          }
       }
-      self.ownsSource = false
-    }
+
+   
     return true
   }
 }


### PR DESCRIPTION
## Description

This introduces nil-checks on multiple places in iOS native code to prevent app crashes when accessing the map component from the React Native code.

Fixes #3331

## Checklist

- [X] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [X] I have tested the new feature on `/example` app.
  - [x] In V11 mode/ios
  - [x] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)