### PR TITLE
fix(ci,ios): use macOS-13 for ci

### DIFF
--- a/.github/workflows/ios-actions.yml
+++ b/.github/workflows/ios-actions.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   build:
     name: iOS Example Build ${{ inputs.NEW_ARCH && 'Fabric' || 'Paper' }} ${{ inputs.MAP_IMPL }}
-    runs-on: macos-12
+    runs-on: macos-13
     timeout-minutes: 55
     environment: ${{ inputs.env_name }}
 

--- a/example/.detoxrc.js
+++ b/example/.detoxrc.js
@@ -18,7 +18,7 @@ module.exports = {
     },
     "ios.debug.ci": {
       type: "ios.app",
-      build: "FORCE_BUNDLING=1 xcodebuild -quiet -workspace ios/RNMapboxGLExample.xcworkspace -configuration Debug -scheme RNMapboxGLExample DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=1 GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS DEBUG_RCT_BUNDLE=1' -sdk iphonesimulator -derivedDataPath ios/build -destination 'platform=iOS Simulator,OS=16.2,name=iPhone SE (3rd generation)'",
+      build: "FORCE_BUNDLING=1 xcodebuild -quiet -workspace ios/RNMapboxGLExample.xcworkspace -configuration Debug -scheme RNMapboxGLExample DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=1 GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS DEBUG_RCT_BUNDLE=1' -sdk iphonesimulator -derivedDataPath ios/build -destination 'platform=iOS Simulator,OS=17.2,name=iPhone SE (3rd generation)'",
       binaryPath: "ios/build/Build/Products/Debug-iphonesimulator/RNMapboxGLExample.app"
     },
   },
@@ -34,7 +34,7 @@ module.exports = {
       type: "ios.simulator",
       device: {
         type: "iPhone SE (3rd generation)",
-        os: "16.2"
+        os: "17.2"
       }
     },
   },


### PR DESCRIPTION
Fix CI issue 

```
==> Installing applesimutils from wix/brew
==> Pouring applesimutils-0.9.10.catalina.bottle.tar.gz
🍺  /usr/local/Cellar/applesimutils/0.9.10: 2 files, 646.3KB
xcbeautify 1.6.0 is already installed but outdated (so it will be upgraded).
xcbeautify: A full installation of Xcode.app 15.0 is required to compile
this software. Installing just the Command Line Tools is not sufficient.

Xcode 15.0 cannot be installed on macOS 12.
You must upgrade your version of macOS.
Error: xcbeautify: An unsatisfied requirement failed this build.
Error: Process completed with exit code 1.
```