### PR TITLE
fix: fix kotlin corutines to 1.8.0 instead of binding to kotlin version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -143,8 +143,8 @@ dependencies {
     implementation "com.facebook.react:react-native:+"
 
     // kotlin coroutines
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : '1.6.21'}"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : '1.6.21'}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${safeExtGet('kotlinxCoroutinesCoreVersion', '1.8.0')}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${safeExtGet('kotlinxCoroutinesAndroidVersion', '1.8.0')}"
 
     // Mapbox SDK
     customizableDependencies('RNMapboxMapsLibs') {


### PR DESCRIPTION
See https://github.com/rnmapbox/maps/pull/3431/files#r1581840316