### PR TITLE
Call `resolve()` to fix pending callbacks warning

### DIFF
--- a/ios/RNMBX/RNMBXCameraModule.mm
+++ b/ios/RNMBX/RNMBXCameraModule.mm
@@ -60,7 +60,8 @@ RCT_EXPORT_METHOD(updateCameraStop:(nonnull NSNumber *)viewRef
                    reject:(RCTPromiseRejectBlock)reject)
 {
     [self withCamera:viewRef block:^(RNMBXCamera *view) {
-      [view updateCameraStop: stop];
+        [view updateCameraStop: stop];
+        resolve(@true);
     } reject:reject methodName:@"someMethod"];
 }
 


### PR DESCRIPTION
## Description

After moving the camera more than 500 times in quick succession, the native produces the warning

> Excessive number of pending callbacks

I discovered a missing invocation of the `resolve` callback in `updateCameraStop`. This change fixes the issue.

(Also see https://github.com/rnmapbox/maps/issues/2087).