### PR TITLE
Fixed mapbox-gl style

### DIFF
--- a/src/web/index.js
+++ b/src/web/index.js
@@ -1,3 +1,5 @@
+import 'mapbox-gl/dist/mapbox-gl.css';
+
 import MapboxModule from './MapboxModule';
 import Camera from './components/Camera';
 import MapView from './components/MapView';
@@ -16,5 +18,5 @@ const Mapbox = {
   ...ExportedComponents,
 };
 
-export { Camera, MapView, Logger, MarkerView };
+export { Camera, Logger, MapView, MarkerView };
 export default Mapbox;


### PR DESCRIPTION
## Description

Mapbox-gl needs its css to be loaded in order to display the attribution (and maybe other things) correctly.

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I have tested the new feature

## Screenshot OR Video

<img width="793" alt="image" src="https://github.com/rnmapbox/maps/assets/42102008/faf67830-ec2f-421a-a553-d2fdb6076fb5">
