### PR TITLE
Fixed markdown spacing after example method links

### DIFF
--- a/scripts/autogenHelpers/globals.mjs
+++ b/scripts/autogenHelpers/globals.mjs
@@ -602,7 +602,8 @@ export function exampleMethodLinks(method, component) {
       .map(({ groupName, name, title }) => {
         return `[${title}](../examples/${groupName}/${name})`;
       })
-      .join(', ');
+      .join(', ')
+      .concat('\n\n');
   }
   return '';
 }


### PR DESCRIPTION
Fixes the markdown spacing after example method links.

**Please regenerate the documentation**