### PR TITLE
Remove AbortController test mock

### DIFF
--- a/setup-jest.js
+++ b/setup-jest.js
@@ -206,9 +206,3 @@ NativeModules.RNMBXChangeLineOffsetsShapeAnimatorModule = {
 NativeModules.RNMBXLogging = nativeModule({
   setLogLevel: jest.fn(),
 });
-
-// Mock for global AbortController
-global.AbortController = class {
-  signal = 'test-signal';
-  abort = jest.fn();
-};


### PR DESCRIPTION
## Description

This library includes an `AbortController` test mock, which doesn't work in places that expect a real one. For example, I was writing an unrelated test that tried to cancel a `fetch()` which failed because the `AbortController`'s `signal` property was invalid.

Because [`AbortController` is in all supported Node versions][0], we can safely remove this mock and rely on the real thing.

This should only affect tests.

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [ ] ~~I updated the doc/other generated code with running `yarn generate` in the root folder~~
- [ ] ~~I have tested the new feature on `/example` app.~~
- [ ] ~~I added/updated a sample - if a new feature was implemented (`/example`)~~

## Reproduction

This test fails before this change:

```js
test("AbortController has an AbortSignal", () => {
  const abortController = new AbortController();
  expect(abortController.signal).toBeInstanceOf(AbortSignal);
});
```

[0]: https://developer.mozilla.org/en-US/docs/Web/API/AbortController#browser_compatibility
