### PR TITLE
chore: upgrade default mapbox maps releases - 10.18.0 and 10.18.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 def defaultMapboxMapsImpl = "mapbox"
-def defaultMapboxMapsVersion = "10.17.0"
+def defaultMapboxMapsVersion = "10.18.0"
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback

--- a/android/install.md
+++ b/android/install.md
@@ -46,7 +46,7 @@ Set `RNMapboxMapsVersion` in `android/build.gradle > buildscript > ext` section
 ```groovy
 buildscript {
     ext {
-        RNMapboxMapsVersion = '11.3.0'
+        RNMapboxMapsVersion = '11.4.1'
     }
 }
 ```
@@ -70,7 +70,7 @@ buildscript {
 ```groovy
 buildscript {
     ext {
-        RNMapboxMapsVersion = '11.3.0'
+        RNMapboxMapsVersion = '11.4.1'
     }
 }
 ```

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -8,10 +8,10 @@ buildscript {
             RNMapboxMapsImpl = "mapbox"
             kotlinVersion = '1.6.21'
         } else if (System.getenv('CI_MAP_IMPL').equals('mapbox11')) {
-            RNMapboxMapsVersion = '11.3.0'
+            RNMapboxMapsVersion = '11.4.1'
             RNMapboxMapsImpl = "mapbox"
         } else if (project.hasProperty('RNMBX11') && project.getProperty('RNMBX11').toBoolean()) {
-            RNMapboxMapsVersion = '11.3.0'
+            RNMapboxMapsVersion = '11.4.1'
         }
 
         // Mapbox deps

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -20,7 +20,7 @@ if ENV['CI_MAP_IMPL']
     $RNMapboxMapsImpl = 'mapbox'
   when 'mapbox11'
     $RNMapboxMapsImpl = 'mapbox'
-    $RNMapboxMapsVersion = '= 11.3.0'
+    $RNMapboxMapsVersion = '= 11.4.0'
   else
     fail "Invalid CI_MAP_IMPL value: #{ENV['CI_MAP_IMPL']}"
   end

--- a/ios/install.md
+++ b/ios/install.md
@@ -69,7 +69,7 @@ We have support for mapbox 11.
 Add the following to your Podfile:
 
 ```ruby
-$RNMapboxMapsVersion = '= 11.3.0'
+$RNMapboxMapsVersion = '= 11.4.0'
 ```
 
 If using expo managed workflow, set the "RNMapboxMapsVersion" variable. See the [expo guide](/plugin/install.md)

--- a/plugin/install.md
+++ b/plugin/install.md
@@ -20,7 +20,7 @@ After installing this package, add the [config plugin](https://docs.expo.io/guid
       [
         "@rnmapbox/maps",
         {
-          "RNMapboxMapsVersion": "11.3.0"
+          "RNMapboxMapsVersion": "11.4.0"
         }
       ]
     ]
@@ -93,7 +93,7 @@ To use V11 just set the version to a 11 version, see [the ios guide](/ios/instal
       [
         "@rnmapbox/maps",
         {
-          "RNMapboxMapsVersion": "11.3.0",
+          "RNMapboxMapsVersion": "11.4.0",
           "RNMapboxMapsDownloadToken": "sk.ey...qg",
         }
       ]

--- a/rnmapbox-maps.podspec
+++ b/rnmapbox-maps.podspec
@@ -20,7 +20,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 ## Warning: these lines are scanned by autogenerate.js
-rnMapboxMapsDefaultMapboxVersion = '~> 10.17.0'
+rnMapboxMapsDefaultMapboxVersion = '~> 10.18.2'
 
 rnMapboxMapsDefaultImpl = 'mapbox'
 
@@ -75,7 +75,7 @@ else
 end
 
 if $RNMapboxMapsUseV11 != nil
-  warn "WARNING: $RNMapboxMapsUseV11 is deprecated just set $RNMapboxMapsVersion to '= 11.0.0"
+  warn "WARNING: $RNMapboxMapsUseV11 is deprecated just set $RNMapboxMapsVersion to '= 11.4.0"
 end
 
 if $MapboxImplVersion =~ /(~>|>=|=|>)?\S*11\./


### PR DESCRIPTION
Up android to 10.18.0 and iOS to 10.18.2