### PR TITLE
fix(andorid,newarch): setHandledMapChangedEvents issue

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/NativeMapViewModule.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/NativeMapViewModule.kt
@@ -152,6 +152,14 @@ class NativeMapViewModule(context: ReactApplicationContext, val viewTagResolver:
         }
     }
 
+    public fun setHandledMapChangedEvents(
+        viewRef: Double?,
+        events: ReadableArray,
+        promise: Promise
+    ) {
+        setHandledMapChangedEvents(viewRef?.toInt(), events, promise)
+    }
+
     override fun clearData(viewRef: ViewRefTag?, promise: Promise) {
         withMapViewOnUIThread(viewRef, promise) {
             it.clearData(createCommandResponse(promise))


### PR DESCRIPTION
Fixes: #3518 , #3522 

Sound like an RN 0.74 Codegen bug to me.

For now adding a workaround implementing method with Double as first arg too.

In `/src/specs/NativeMapViewModule.ts`
```java
  setHandledMapChangedEvents: (
    viewRef: Int32 | null,
    events: ReadonlyArray<string>,
  ) => Promise<Object>;
```

in android/build/generated/source/codegen/jni/rnmapbox_maps_specs-generated.cpp:
```cpp
static facebook::jsi::Value __hostFunction_NativeMapViewModuleSpecJSI_setHandledMapChangedEvents(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
  static jmethodID cachedMethodId = nullptr;
  return static_cast<JavaTurboModule &>(turboModule).invokeJavaMethod(rt, PromiseKind, "setHandledMapChangedEvents", "(Ljava/lang/Double;Lcom/facebook/react/bridge/ReadableArray;Lcom/facebook/react/bridge/Promise;)V", args, count, cachedMethodId);
}
```

In android/src/main/old-arch/com/rnmapbox/rnmbx/NativeMapViewModuleSpec.java
```java
  @ReactMethod
  @DoNotStrip
  public abstract void setHandledMapChangedEvents(@Nullable Integer viewRef, ReadableArray events, Promise promise);
```

So on the c++ side it generates code expecting a `Ljava/lang/Double` and on java side it generates a code expecting a @Nullable Integer. 