### PR TITLE
Fix issues with rn 0.74 bridgeless

### DIFF
--- a/src/RNMBXModule.ts
+++ b/src/RNMBXModule.ts
@@ -37,7 +37,7 @@ interface RNMBXModule {
   setConnected(connected: boolean): void;
 }
 
-const RNMBXModule: RNMBXModule = { ...NativeModules.RNMBXModule };
+const RNMBXModule: RNMBXModule = NativeModules.RNMBXModule;
 if (NativeModules.RNMBXModule == null) {
   if ((global as { expo?: unknown }).expo != null) {
     // global.expo.modules.ExponentConstants;

--- a/src/RNMBXModule.ts
+++ b/src/RNMBXModule.ts
@@ -37,6 +37,7 @@ interface RNMBXModule {
   setConnected(connected: boolean): void;
 }
 
+// eslint-disable-next-line prefer-destructuring
 const RNMBXModule: RNMBXModule = NativeModules.RNMBXModule;
 if (NativeModules.RNMBXModule == null) {
   if ((global as { expo?: unknown }).expo != null) {

--- a/src/specs/RNMBXMapViewNativeComponent.ts
+++ b/src/specs/RNMBXMapViewNativeComponent.ts
@@ -1,6 +1,7 @@
 import type { HostComponent, ViewProps } from 'react-native';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import {
+  BubblingEventHandler,
   DirectEventHandler,
   Int32,
 } from 'react-native/Libraries/Types/CodegenTypes';
@@ -72,7 +73,7 @@ export interface NativeProps extends ViewProps {
   // iOS only
   compassImage?: OptionalProp<string>;
 
-  onPress?: DirectEventHandler<OnPressEventType>;
+  onPress?: BubblingEventHandler<OnPressEventType>;
   onLongPress?: DirectEventHandler<OnPressEventType>;
   onMapChange?: DirectEventHandler<OnMapChangeEventType>;
   onCameraChanged?: DirectEventHandler<OnCameraChangedEventType>;


### PR DESCRIPTION
## Description

On RN 0.74 with new arch enabled (bridgeless) I encountered 2 errors.

The first one is because of the copy of the native module object. With new arch bridgeless the native module are proxy objects so copying it just results in an empty object, which resulted in my app crashing when calling `setAccessToken`.

The 2nd one is related to codegen: `Invariant Violation: Event cannot be both direct and bubbling: topPress`. This seems to happen because we extend `ViewProps` and it already defines a onPress prop that is a `BubblingEventHandler`. Changing it to `BubblingEventHandler` fixes it.

Tested in the example app by enabling bridgeless and testing that Show click example still works.

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [x] I have tested the new feature on `/example` app.
  - [x] In V11 mode/ios
  - [x] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

N/A

## Component to reproduce the issue you're fixing

N/A
