### PR TITLE
Fix error in clusterMaxZoomLevel on new arch

### DIFF
--- a/ios/RNMBX/RNMBXFabricPropConvert.h
+++ b/ios/RNMBX/RNMBXFabricPropConvert.h
@@ -2,7 +2,7 @@
 
 /**
  *
- * 1. Requirest the following prelude
+ * 1. Requires the following prelude
  * const auto &oldViewProps = static_cast<const RNMBXNativeUserLocationProps &>(*oldProps);
  * const auto &newViewProps = static_cast<const RNMBXNativeUserLocationProps &>(*props);
  *
@@ -12,6 +12,7 @@
 NSNumber* RNMBXPropConvert_Optional_BOOL_NSNumber(const folly::dynamic &dyn, NSString* propertyName);
 BOOL RNMBXPropConvert_Optional_BOOL(const folly::dynamic &dyn, NSString* propertyName);
 NSString* RNMBXPropConvert_Optional_NSString(const folly::dynamic &dyn, NSString* propertyName);
+NSNumber* RNMBXPropConvert_Optional_NSNumber(const folly::dynamic &dyn, NSString* propertyName);
 id RNMBXPropConvert_Optional_ExpressionDouble(const folly::dynamic &dyn, NSString* propertyName);
 BOOL RNMBXPropConvert_BOOL(const folly::dynamic &dyn, NSString* propertyName);
 NSDictionary* RNMBXPropConvert_Optional_NSDictionary(const folly::dynamic &dyn, NSString* propertyName);
@@ -29,6 +30,11 @@ NSDictionary* RNMBXPropConvert_Optional_NSDictionary(const folly::dynamic &dyn, 
 #define RNMBX_OPTIONAL_PROP_NSString(name) \
   if ((!oldProps.get() || oldViewProps.name != newViewProps.name) && !newViewProps.name.isNull()) { \
     _view.name = RNMBXPropConvert_Optional_NSString(newViewProps.name, @#name); \
+  }
+
+#define RNMBX_OPTIONAL_PROP_NSNumber(name) \
+  if ((!oldProps.get() || oldViewProps.name != newViewProps.name) && !newViewProps.name.isNull()) { \
+    _view.name = RNMBXPropConvert_Optional_NSNumber(newViewProps.name, @#name); \
   }
 
 #define RNMBX_OPTIONAL_PROP_ExpressionDouble(name) \

--- a/ios/RNMBX/RNMBXFabricPropConvert.mm
+++ b/ios/RNMBX/RNMBXFabricPropConvert.mm
@@ -55,7 +55,7 @@ BOOL RNMBXPropConvert_Optional_BOOL(const folly::dynamic &dyn, NSString* propert
 }
 
 NSString* RNMBXPropConvert_Optional_NSString(const folly::dynamic &dyn, NSString* propertyName) {
-    switch (dyn.type()) {
+  switch (dyn.type()) {
     case folly::dynamic::STRING:
       return [NSString stringWithCString:dyn.getString().c_str() encoding:NSUTF8StringEncoding];
     case folly::dynamic::NULLT:
@@ -72,7 +72,7 @@ NSString* RNMBXPropConvert_Optional_NSString(const folly::dynamic &dyn, NSString
 }
 
 NSNumber* RNMBXPropConvert_Optional_NSNumber(const folly::dynamic &dyn, NSString* propertyName) {
-    switch (dyn.type()) {
+  switch (dyn.type()) {
     case folly::dynamic::INT64:
       return @(dyn.getInt());
     case folly::dynamic::DOUBLE:

--- a/ios/RNMBX/RNMBXFabricPropConvert.mm
+++ b/ios/RNMBX/RNMBXFabricPropConvert.mm
@@ -71,6 +71,26 @@ NSString* RNMBXPropConvert_Optional_NSString(const folly::dynamic &dyn, NSString
   }
 }
 
+NSNumber* RNMBXPropConvert_Optional_NSNumber(const folly::dynamic &dyn, NSString* propertyName) {
+    switch (dyn.type()) {
+    case folly::dynamic::INT64:
+      return @(dyn.getInt());
+    case folly::dynamic::DOUBLE:
+      return @(dyn.getDouble());
+    case folly::dynamic::NULLT:
+      return nil;
+    default:
+      std::stringstream ss;
+      ss << dyn;
+      [RNMBXLogger error:[NSString stringWithFormat:@"Property %@ expected to be a number or nil but was: %s",
+                          propertyName,
+                          ss.str().c_str()
+                         ]];
+      return nil;
+  }
+}
+
+
 
 id RNMBXPropConvert_ID(const folly::dynamic &dyn)
 {

--- a/ios/RNMBX/RNMBXShapeSourceComponentView.mm
+++ b/ios/RNMBX/RNMBXShapeSourceComponentView.mm
@@ -2,6 +2,7 @@
 
 #import "RNMBXShapeSourceComponentView.h"
 #import "RNMBXFabricHelpers.h"
+#import "RNMBXFabricPropConvert.h"
 
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
@@ -85,62 +86,23 @@ using namespace facebook::react;
 
 - (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
-    const auto &oldShapeSourceProps = static_cast<const RNMBXShapeSourceProps &>(*_props);
-    const auto &newShapeSourceProps = static_cast<const RNMBXShapeSourceProps &>(*props);
-    id idx = RNMBXConvertFollyDynamicToId(newShapeSourceProps.id);
-    if (idx != nil) {
-        _view.id = idx;
-    }
-    id existing = RNMBXConvertFollyDynamicToId(newShapeSourceProps.existing);
-    if (existing != nil) {
-        _view.existing = existing;
-    }
-    id shape = RNMBXConvertFollyDynamicToId(newShapeSourceProps.shape);
-    if (shape != nil) {
-        _view.shape = shape;
-    }
-    id cluster = RNMBXConvertFollyDynamicToId(newShapeSourceProps.cluster);
-    if (cluster != nil) {
-        _view.cluster = cluster;
-    }
-    id clusterRadius = RNMBXConvertFollyDynamicToId(newShapeSourceProps.clusterRadius);
-    if (clusterRadius != nil) {
-        _view.clusterRadius = clusterRadius;
-    }
-    if (oldShapeSourceProps.clusterMaxZoomLevel != newShapeSourceProps.clusterMaxZoomLevel) {
-        id clusterMaxZoomLevel = RNMBXConvertFollyDynamicToId(newShapeSourceProps.clusterMaxZoomLevel);
-        if (clusterMaxZoomLevel != nil) {
-            _view.clusterMaxZoomLevel = clusterMaxZoomLevel;
-        }
-    }
-    id clusterProperties = RNMBXConvertFollyDynamicToId(newShapeSourceProps.clusterProperties);
-    if (clusterProperties != nil) {
-        _view.clusterProperties = clusterProperties;
-    }
-    id maxZoomLevel = RNMBXConvertFollyDynamicToId(newShapeSourceProps.maxZoomLevel);
-    if (maxZoomLevel != nil) {
-        _view.maxZoomLevel = maxZoomLevel;
-    }
-    id buffer = RNMBXConvertFollyDynamicToId(newShapeSourceProps.buffer);
-    if (buffer != nil) {
-        _view.buffer = buffer;
-    }
-    id tolerance = RNMBXConvertFollyDynamicToId(newShapeSourceProps.tolerance);
-    if (tolerance != nil) {
-        _view.tolerance = tolerance;
-    }
-    id lineMetrics = RNMBXConvertFollyDynamicToId(newShapeSourceProps.lineMetrics);
-    if (lineMetrics != nil) {
-        _view.lineMetrics = lineMetrics;
-    }
-    id hasPressListener = RNMBXConvertFollyDynamicToId(newShapeSourceProps.hasPressListener);
-    if (hasPressListener != nil) {
-        _view.hasPressListener = hasPressListener;
-    }
-    id hitbox = RNMBXConvertFollyDynamicToId(newShapeSourceProps.hitbox);
-    if (hitbox != nil) {
-        _view.hitbox = hitbox;
-    }
+  const auto &oldViewProps = static_cast<const RNMBXShapeSourceProps &>(*_props);
+  const auto &newViewProps = static_cast<const RNMBXShapeSourceProps &>(*props);
+
+  RNMBX_OPTIONAL_PROP_NSString(id)
+  RNMBX_OPTIONAL_PROP_BOOL(existing)
+  RNMBX_OPTIONAL_PROP_NSString(shape)
+  RNMBX_OPTIONAL_PROP_NSNumber(cluster)
+  RNMBX_OPTIONAL_PROP_NSNumber(clusterRadius)
+  RNMBX_OPTIONAL_PROP_NSNumber(clusterMaxZoomLevel)
+  RNMBX_OPTIONAL_PROP_NSDictionary(clusterProperties)
+  RNMBX_OPTIONAL_PROP_NSNumber(maxZoomLevel)
+  RNMBX_OPTIONAL_PROP_NSNumber(buffer)
+  RNMBX_OPTIONAL_PROP_NSNumber(tolerance)
+  RNMBX_OPTIONAL_PROP_NSNumber(lineMetrics)
+  RNMBX_OPTIONAL_PROP_BOOL(hasPressListener)
+  RNMBX_OPTIONAL_PROP_NSDictionary(hitbox)
+  
   [super updateProps:props oldProps:oldProps];
 }
 

--- a/ios/RNMBX/RNMBXShapeSourceComponentView.mm
+++ b/ios/RNMBX/RNMBXShapeSourceComponentView.mm
@@ -85,56 +85,59 @@ using namespace facebook::react;
 
 - (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
-  const auto &newProps = static_cast<const RNMBXShapeSourceProps &>(*props);
-    id idx = RNMBXConvertFollyDynamicToId(newProps.id);
+    const auto &oldShapeSourceProps = static_cast<const RNMBXShapeSourceProps &>(*_props);
+    const auto &newShapeSourceProps = static_cast<const RNMBXShapeSourceProps &>(*props);
+    id idx = RNMBXConvertFollyDynamicToId(newShapeSourceProps.id);
     if (idx != nil) {
         _view.id = idx;
     }
-    id existing = RNMBXConvertFollyDynamicToId(newProps.existing);
+    id existing = RNMBXConvertFollyDynamicToId(newShapeSourceProps.existing);
     if (existing != nil) {
         _view.existing = existing;
     }
-    id shape = RNMBXConvertFollyDynamicToId(newProps.shape);
+    id shape = RNMBXConvertFollyDynamicToId(newShapeSourceProps.shape);
     if (shape != nil) {
         _view.shape = shape;
     }
-    id cluster = RNMBXConvertFollyDynamicToId(newProps.cluster);
+    id cluster = RNMBXConvertFollyDynamicToId(newShapeSourceProps.cluster);
     if (cluster != nil) {
         _view.cluster = cluster;
     }
-    id clusterRadius = RNMBXConvertFollyDynamicToId(newProps.clusterRadius);
+    id clusterRadius = RNMBXConvertFollyDynamicToId(newShapeSourceProps.clusterRadius);
     if (clusterRadius != nil) {
         _view.clusterRadius = clusterRadius;
     }
-    id clusterMaxZoomLevel = RNMBXConvertFollyDynamicToId(newProps.clusterMaxZoomLevel);
-    if (clusterMaxZoomLevel != nil) {
-        _view.clusterMaxZoomLevel = clusterMaxZoomLevel;
+    if (oldShapeSourceProps.clusterMaxZoomLevel != newShapeSourceProps.clusterMaxZoomLevel) {
+        id clusterMaxZoomLevel = RNMBXConvertFollyDynamicToId(newShapeSourceProps.clusterMaxZoomLevel);
+        if (clusterMaxZoomLevel != nil) {
+            _view.clusterMaxZoomLevel = clusterMaxZoomLevel;
+        }
     }
-    id clusterProperties = RNMBXConvertFollyDynamicToId(newProps.clusterProperties);
+    id clusterProperties = RNMBXConvertFollyDynamicToId(newShapeSourceProps.clusterProperties);
     if (clusterProperties != nil) {
         _view.clusterProperties = clusterProperties;
     }
-    id maxZoomLevel = RNMBXConvertFollyDynamicToId(newProps.maxZoomLevel);
+    id maxZoomLevel = RNMBXConvertFollyDynamicToId(newShapeSourceProps.maxZoomLevel);
     if (maxZoomLevel != nil) {
         _view.maxZoomLevel = maxZoomLevel;
     }
-    id buffer = RNMBXConvertFollyDynamicToId(newProps.buffer);
+    id buffer = RNMBXConvertFollyDynamicToId(newShapeSourceProps.buffer);
     if (buffer != nil) {
         _view.buffer = buffer;
     }
-    id tolerance = RNMBXConvertFollyDynamicToId(newProps.tolerance);
+    id tolerance = RNMBXConvertFollyDynamicToId(newShapeSourceProps.tolerance);
     if (tolerance != nil) {
         _view.tolerance = tolerance;
     }
-    id lineMetrics = RNMBXConvertFollyDynamicToId(newProps.lineMetrics);
+    id lineMetrics = RNMBXConvertFollyDynamicToId(newShapeSourceProps.lineMetrics);
     if (lineMetrics != nil) {
         _view.lineMetrics = lineMetrics;
     }
-    id hasPressListener = RNMBXConvertFollyDynamicToId(newProps.hasPressListener);
+    id hasPressListener = RNMBXConvertFollyDynamicToId(newShapeSourceProps.hasPressListener);
     if (hasPressListener != nil) {
         _view.hasPressListener = hasPressListener;
     }
-    id hitbox = RNMBXConvertFollyDynamicToId(newProps.hitbox);
+    id hitbox = RNMBXConvertFollyDynamicToId(newShapeSourceProps.hitbox);
     if (hitbox != nil) {
         _view.hitbox = hitbox;
     }


### PR DESCRIPTION
## Description

On new arch when the map re-renders it causes the following error when using the `clusterMaxZoomLevel` prop. This is because this prop cannot be updated in mapbox-ios. This isn't a problem in the old architecture since the prop handler is only called when the prop changes, in the new arch it needs to be handled manually by comparing the props values.

```
Mapbox [error] RNMBXShapeSource | clusterMaxZoomLevel  Cannot set property clusterMaxZoom for the source symbolLocationSource
```

After this the error no longer appears, unless actually changing the value of `clusterMaxZoom`.

It might be a good pattern to adopt generally for all components and props, but I thought it was out of scope of this since it would become a pretty big refactor.

Tested this change in an app that makes use of clustering.

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here  -->
```jsx

```
