### PR TITLE
chore: update Position type document with correct coordinate order

### DIFF
--- a/src/types/Position.ts
+++ b/src/types/Position.ts
@@ -1,4 +1,4 @@
 /**
- * Position is a tuple of latitude and longitude.
+ * Position is a tuple of longitude and latitude, e.g. [longitude, latitude]
  */
 export type Position = [number, number] | number[];


### PR DESCRIPTION
## Description

I revised the doc comment of type `Position` because it caused confusing for me when using `coordinate` props of `MapMarker`. The current comment indicated `latitude and longitude` so I put the values as `[latitude, longitude]` which resulted in a crash in my Android app without any error. I was stuck for a while and later discovered that when running iOS app, it showed exceeded value range of `longitude`. I hope this minor update might help Maps newbies save their time on this one.

## Checklist

- [x] I've read `CONTRIBUTING.md`