### PR TITLE
Fix scaleBarEnabled on new arch

### DIFF
--- a/ios/RNMBX/RNMBXFabricPropConvert.h
+++ b/ios/RNMBX/RNMBXFabricPropConvert.h
@@ -21,10 +21,12 @@ NSDictionary* RNMBXPropConvert_Optional_NSDictionary(const folly::dynamic &dyn, 
     _view.name = RNMBXPropConvert_Optional_BOOL_NSNumber(newViewProps.name, @#name); \
   }
 
-#define RNMBX_OPTIONAL_PROP_BOOL(name) \
+#define RNMBX_REMAP_OPTIONAL_PROP_BOOL(name, viewName) \
   if ((!oldProps.get() || oldViewProps.name != newViewProps.name) && !newViewProps.name.isNull()) { \
-    _view.name = RNMBXPropConvert_Optional_BOOL(newViewProps.name, @#name); \
+    _view.viewName = RNMBXPropConvert_Optional_BOOL(newViewProps.name, @#name); \
   }
+
+#define RNMBX_OPTIONAL_PROP_BOOL(name) RNMBX_REMAP_OPTIONAL_PROP_BOOL(name, name)
 
 #define RNMBX_OPTIONAL_PROP_NSString(name) \
   if ((!oldProps.get() || oldViewProps.name != newViewProps.name) && !newViewProps.name.isNull()) { \

--- a/ios/RNMBX/RNMBXMapViewComponentView.mm
+++ b/ios/RNMBX/RNMBXMapViewComponentView.mm
@@ -181,10 +181,7 @@ using namespace facebook::react;
         _view.reactCompassImage = compassImage;
     }
 
-    id scaleBarEnabled = RNMBXConvertFollyDynamicToId(newViewProps.scaleBarEnabled);
-    if (scaleBarEnabled != nil) {
-        _view.reactScaleBarEnabled = scaleBarEnabled;
-    }
+    RNMBX_REMAP_OPTIONAL_PROP_BOOL(scaleBarEnabled, reactScaleBarEnabled)
 
     id scaleBarPosition = RNMBXConvertFollyDynamicToId(newViewProps.scaleBarPosition);
     if (scaleBarPosition != nil) {


### PR DESCRIPTION
## Description

This fixes `scaleBarEnabled={false}` on new arch. `RNMBXConvertFollyDynamicToId` converts to NSBoolean * so when assigning to a Bool prop it is always true. To fix it I used the `RNMBX_OPTIONAL_PROP_BOOL` macro which handles deferencing the pointer properly.

Tested in an app using new arch, before the change the scale bar is always visible even when setting `scaleBarEnabled={false}`. After the scale bar is properly hidden.

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here  -->
```jsx

```
