### PR TITLE
resolve ambiguous `expression` issue introduced in Xcode 16

### DIFF
--- a/ios/RNMBX/Extensions/Array+asExpressions.swift
+++ b/ios/RNMBX/Extensions/Array+asExpressions.swift
@@ -1,7 +1,7 @@
 import MapboxMaps
 
 internal extension Array where Element == Any {
-  func asExpression() throws -> Expression? {
+  func asExpression() throws -> MapboxMaps.Expression? {
     let filter = self
     if filter.count > 0 {
       let data = try JSONSerialization.data(withJSONObject: filter, options: .prettyPrinted)

--- a/ios/RNMBX/RNMBXLayer.swift
+++ b/ios/RNMBX/RNMBXLayer.swift
@@ -34,13 +34,13 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
       }
     }
   }
-  
+
   var style: Style? = nil
 
   @objc public var filter : Array<Any>? = nil {
     didSet { optionsChanged() }
   }
-  
+
   @objc public var id: String! = nil {
     willSet {
       if id != nil && newValue != id {
@@ -58,7 +58,7 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
   @objc public var sourceID: String? = nil {
     didSet { optionsChanged() }
   }
-  
+
   @objc public var minZoomLevel : NSNumber? = nil {
     didSet { optionsChanged() }
   }
@@ -85,7 +85,7 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
       }
     }
   }
-  
+
   @objc public var layerIndex : NSNumber? = nil {
     didSet {
       if let layerIndex = layerIndex {
@@ -95,13 +95,13 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
       }
     }
   }
-  
+
   @objc public var slot: String? = nil {
     didSet {
       optionsChanged()
     }
   }
-  
+
   @objc weak var map: RNMBXMapView? = nil
 
   deinit {
@@ -110,9 +110,9 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
       self.waitingForID = nil
     }
   }
-  
+
   var styleLayer: Layer? = nil
-  
+
   /// wearther we inserted the layer or we're referring to an existing layer
   var existingLayer = false
 
@@ -120,21 +120,21 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
   public func waitForStyleLoad() -> Bool {
     return true
   }
-  
+
   func removeAndReaddLayer() {
     if let map = map, let style = style {
       self.removeFromMap(style)
       self.addToMap(map, style:style)
     }
   }
-   
+
   /**
     addStyles - adds the styles defined by reactStyle to the current layer, but does not apply to the style to the map style
    */
   func addStyles() {
     fatalError("Subclasses need to implement the `addStyles()` method.")
   }
-  
+
   func addStylesAndUpdate() {
     guard styleLayer != nil else {
       return
@@ -148,15 +148,15 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
       }
     }
   }
-  
+
   func makeLayer(style: Style) throws -> Layer {
     fatalError("Subclasses need to implement the `makeLayer(style:)` method.")
   }
-  
+
   func findLayer(style: Style, id: String) throws -> Layer {
     return try style.layer(withId: id)
   }
-  
+
   func layerType() -> Layer.Type {
     fatalError("Subclasses need to implement the `layerType` method. \(self)")
   }
@@ -188,7 +188,7 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
       return .default
     }
   }
-  
+
   func inserLayer(_ map: RNMBXMapView) {
     if self.style == nil {
       print("inserLayer but style is nil")
@@ -205,7 +205,7 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
       loggedApply(style: style)
     }
   }
-  
+
   func layerWithSourceID<T : Source>(in style: Style) throws -> T  {
     let result = try style.source(withId: self.sourceID!, type: T.self)
     return result
@@ -217,9 +217,9 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
   }
 
   func addedToMap() {
-    
+
   }
-  
+
   public func addToMap(_ map: RNMBXMapView, style: Style) {
     self.map = map
     self.style = style
@@ -239,7 +239,7 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
     } catch {
       Logger.log(level: .error, message: "find/makeLayer failed for layer id=\(id)", error: error)
     }
-    
+
     guard self.styleLayer != nil else {
       Logger.log(level: .error, message: "find/makeLayer retuned nil for layer id=\(id)")
       return
@@ -253,11 +253,11 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
     }
     addedToMap()
   }
-  
+
   func removeFromMap(_ map: RNMBXMapView, style: Style) {
     removeFromMap(style)
   }
-  
+
   #if RNMBX_11
   func _toSlot(_ slot: String) -> Slot? {
     switch slot {
@@ -272,36 +272,36 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
     }
   }
   #endif
-  
+
   func setBaseOptions<T: Layer>(_ layer: inout T) {
     if let minZoom = minZoomLevel {
       layer.minZoom = minZoom.doubleValue
     }
-    
+
     if let maxZoom = maxZoomLevel {
       layer.maxZoom = maxZoom.doubleValue
     }
-    
+
     #if RNMBX_11
     if let slot = slot {
       layer.slot = _toSlot(slot)
     }
     #endif
   }
-  
+
   func setOptions(_ layer: inout Layer) {
     setBaseOptions(&layer)
     #if !RNMBX_11
     if let sourceLayerID = sourceLayerID {
       layer.sourceLayer = sourceLayerID
     }
-    
+
     if let sourceID = sourceID {
       if !(existingLayer && sourceID == DEFAULT_SOURCE_ID) && hasSource() {
         layer.source = sourceID
       }
     }
-    
+
     if let filter = filter, filter.count > 0 {
       do {
         let data = try JSONSerialization.data(withJSONObject: filter, options: .prettyPrinted)
@@ -313,7 +313,7 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
     }
     #endif
   }
-  
+
   private func optionsChanged() {
     if let style = self.style, self.styleLayer != nil {
       self.setOptions(&self.styleLayer!)
@@ -325,7 +325,7 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
     removeFromMap(map.mapboxMap.style)
     return true
   }
-  
+
   private func removeFromMap(_ style: Style) {
     if let waitingForID = waitingForID {
       Logger.log(level:.warn, message: "RNMBXLayer.removeFromMap - unmetPositionDependency: layer: \(optional: id) was waiting for layer: \(optional: waitingForID) but it hasn't added to map")
@@ -337,7 +337,7 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
       Logger.log(level: .error, message: "RNMBXLayer.removeFromMap: removing layer failed for layer \(optional: id): \(error.localizedDescription)")
     }
   }
-  
+
   func insert(_ style: Style, layerPosition: LayerPosition, onInsert: (() -> Void)? = nil) {
     var idToWaitFor: String?
     switch layerPosition {
@@ -350,8 +350,8 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
     default:
       idToWaitFor = nil
     }
-    
-    
+
+
     if let idToWaitFor = idToWaitFor {
       self.waitingForID = idToWaitFor
       map!.waitForLayerWithID(idToWaitFor) { _ in
@@ -362,12 +362,12 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
       self.attemptInsert(style, layerPosition: layerPosition, onInsert: onInsert)
     }
   }
-  
+
   private func attemptInsert(_ style: Style, layerPosition: LayerPosition, onInsert: (() -> Void)? = nil) {
     guard let styleLayer = self.styleLayer else {
       return
     }
-    
+
     do {
       try style.addLayer(styleLayer, layerPosition: layerPosition)
       onInsert?()
@@ -375,7 +375,7 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
       Logger.log(level: .error, message: "inserting layer failed at position \(layerPosition): \(error.localizedDescription)")
     }
   }
-  
+
   internal func hasSource() -> Bool {
     return true
   }
@@ -385,10 +385,10 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
 protocol LayerWithSource : Layer {
   var source: String? { get set }
   var sourceLayer: String? { get set }
-  var filter: Expression? { get set}
+  var filter: MapboxMaps.Expression? { get set}
 }
 #else
 protocol LayerWithSource : Layer {
-  
+
 }
 #endif

--- a/ios/RNMBX/RNMBXStyleValue.swift
+++ b/ios/RNMBX/RNMBXStyleValue.swift
@@ -14,11 +14,11 @@ class RNMBXStyleValue {
   var styleType: String? = nil
   var styleValue: [String:Any]? = nil
   var styleObject: Any? = nil
-  
-  
+
+
   init(value: Any) {
     self.value = value
-  
+
     if let dict = value as? [String:Any] {
       guard let styleType = dict["styletype"] as? String else {
         fatalError("StyleType should be string in \(dict)")
@@ -31,15 +31,15 @@ class RNMBXStyleValue {
       self.styleObject = parse(rawStyleValue: styleValue)
     }
   }
-  
+
   static func make(_ reactStyleValue: Any) ->RNMBXStyleValue {
     return RNMBXStyleValue(value: reactStyleValue)
   }
-  
+
   func isVisible() -> Value<Visibility> {
     return mglStyleValueEnum()
   }
-  
+
   func getTransition() -> StyleTransition {
     guard let dict = styleObject as? [String:Any] else {
       Logger.log(level:.error, message: "Invalid transition value: \(optional: styleObject)")
@@ -54,7 +54,7 @@ class RNMBXStyleValue {
     let millisecondsToSeconds = 1.0/1000.0;
     return StyleTransition(duration: millisecondsToSeconds * (duration?.doubleValue ?? 0.0), delay: millisecondsToSeconds * (delay?.doubleValue ?? 0.0))
   }
-  
+
   func getImageScale() -> Double {
     if let dict = styleObject as? [String:Any] {
       if let scale = dict["scale"] as? NSNumber {
@@ -65,13 +65,13 @@ class RNMBXStyleValue {
     }
     return 1.0
   }
-  
+
   func parse(rawStyleValue: [String:Any]) -> Any
   {
     guard let type = rawStyleValue["type"] as? String else {
       fatalError("type is not a string in \(rawStyleValue)")
     }
-    
+
     let value = rawStyleValue["value"]
     if type == "string" {
       guard let string = value as? String else {
@@ -114,7 +114,7 @@ class RNMBXStyleValue {
       fatalError("unepxected type: \(type)")
     }
   }
-  
+
   static func convert(_ from:[String: Any]) -> Any {
     guard let type = from["type"] as? String else {
       fatalError("Type should be string but was \(optional: from["type"])")
@@ -130,14 +130,14 @@ class RNMBXStyleValue {
       guard let value = from["value"] as? String else {
         fatalError("Value for string should be String")
       }
-      
+
       return value
     }
     else if type == "hashmap" {
       guard let values = from["value"] as? [[Any]] else {
         fatalError("Value for hashmap should be array of array")
       }
-    
+
       let result = values.map { items -> (String,Any) in
         var key = items[0]
         let value = items[1]
@@ -176,11 +176,11 @@ class RNMBXStyleValue {
       fatalError("Unexpected type \(type)")
     }
   }
-  
+
   func mglStyleValueNumber() -> Value<Double> {
     if let value = value as? Dictionary<String,Any> {
       let value = RNMBXStyleValue.convert(value["stylevalue"] as! [String:Any])
-      
+
       if let num = value as? NSNumber {
         return Value.constant(Double(num.doubleValue))
       } else if let num = value as? Double {
@@ -209,9 +209,9 @@ class RNMBXStyleValue {
       Logger.log(level: .error, message: "Invalid value for number: \(value) retuning 0.0")
       return .constant(0.0)
     }
-    
+
     let valueObj = RNMBXStyleValue.convert(value["stylevalue"] as! [String:Any])
-    
+
     if let num = valueObj as? NSNumber {
       return .constant(num.doubleValue)
     } else if let num = valueObj as? Double {
@@ -230,9 +230,9 @@ class RNMBXStyleValue {
       Logger.log(level: .error, message: "Invalid value for number: \(value) retuning 0.0")
       return 0.0
     }
-    
+
     let valueObj = RNMBXStyleValue.convert(value["stylevalue"] as! [String:Any])
-    
+
     if let num = valueObj as? NSNumber {
       return num.doubleValue
     } else if let num = valueObj as? Double {
@@ -259,12 +259,12 @@ class RNMBXStyleValue {
     //return Value.constant(ColorRepresentable(color: UIColor.black))
     if let value = value as? Dictionary<String,Any> {
       let value = RNMBXStyleValue.convert(value["stylevalue"] as! [String:Any])
-      
+
       if let num = value as? Int {
         let uicolor = uicolor(num)
         return Value.constant(StyleColor(uicolor))
       }
-      
+
       let data = try! JSONSerialization.data(withJSONObject: value, options: .prettyPrinted)
 
       let decodedExpression = try! JSONDecoder().decode(Expression.self, from: data)
@@ -273,8 +273,8 @@ class RNMBXStyleValue {
       return Value.constant(StyleColor(UIColor.red))
     }
   }
-  
-  func asExpression(json: [Any]) -> Expression {
+
+  func asExpression(json: [Any]) -> MapboxMaps.Expression {
     let data = try! JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
     let decodedExpression = try! JSONDecoder().decode(Expression.self, from: data)
     return decodedExpression
@@ -313,15 +313,15 @@ class RNMBXStyleValue {
     }
   }
   #endif
-  
+
   func mglStyleValueBoolean() -> Value<Bool> {
     guard let value = value as? Dictionary<String,Any> else {
       Logger.log(level: .error, message: "Invalid value for boolean: \(value)")
       return Value.constant(true)
     }
-    
+
     let valueObj = RNMBXStyleValue.convert(value["stylevalue"] as! [String:Any])
-    
+
     if let valueObj = valueObj as? NSNumber {
       return .constant(valueObj.boolValue)
     } else {
@@ -335,15 +335,15 @@ class RNMBXStyleValue {
       }
     }
   }
-  
+
   func mglStyleValueArrayNumber() -> Value<[Double]> {
     guard let value = value as? Dictionary<String,Any> else {
       Logger.log(level: .error, message: "Invalid value for array number: \(value)")
       return Value.constant([1.0,1.0])
     }
-  
+
     let valueObj = RNMBXStyleValue.convert(value["stylevalue"] as! [String:Any])
-      
+
     if let valueObj = valueObj as? [NSNumber] {
       return .constant(valueObj.map { $0.doubleValue })
     } else {
@@ -355,8 +355,8 @@ class RNMBXStyleValue {
       }
     }
   }
-  
-  private func _toExpressions(_ valueObj: Any) throws -> Expression {
+
+  private func _toExpressions(_ valueObj: Any) throws -> MapboxMaps.Expression {
     if let valueObj = valueObj as? NSNumber {
       throw RNMBXError.parseError("valueObj is a single number and cannot be converted to expressions")
     }
@@ -365,7 +365,7 @@ class RNMBXStyleValue {
     let decodedExpression = try JSONDecoder().decode(Expression.self, from: data)
     return decodedExpression
   }
-  
+
   func mglStyleValueString() -> Value<String> {
     if let value = value as? Dictionary<String,Any> {
       let value = RNMBXStyleValue.convert(value["stylevalue"] as! [String:Any])
@@ -388,7 +388,7 @@ class RNMBXStyleValue {
       return Value.constant("")
     }
   }
-  
+
   func mglStyleValueArrayString() -> Value<[String]> {
     guard let value = value as? Dictionary<String,Any> else {
       Logger.log(level: .error, message: "Invalid value for array of strings: \(value)")
@@ -396,7 +396,7 @@ class RNMBXStyleValue {
     }
 
     let valueObj = RNMBXStyleValue.convert(value["stylevalue"] as! [String:Any])
-      
+
     if let valueObj = valueObj as? [String] {
       return .constant(valueObj)
     } else {
@@ -413,7 +413,7 @@ class RNMBXStyleValue {
       }
     }
   }
-  
+
   func mglStyleValueResolvedImage() -> Value<ResolvedImage> {
     if let exprJSON = styleObject as? [Any] {
       return Value.expression(asExpression(json: exprJSON))
@@ -434,13 +434,13 @@ class RNMBXStyleValue {
   func mglStyleValueLineCap() -> Value<LineCap> {
     return mglStyleValueEnum()
   }
-    
-  func parseExpression(_ expression: [Any]) throws -> Expression {
+
+  func parseExpression(_ expression: [Any]) throws -> MapboxMaps.Expression {
     let data = try JSONSerialization.data(withJSONObject: expression, options: .prettyPrinted)
     let decodedExpression = try JSONDecoder().decode(Expression.self, from: data)
     return decodedExpression
   }
-  
+
   func mglStyleValueEnum<Enum : RawRepresentable>() -> Value<Enum> where Enum.RawValue == String {
     if let value = value as? Dictionary<String,Any> {
       let value = RNMBXStyleValue.convert(value["stylevalue"] as! [String:Any])
@@ -473,11 +473,11 @@ class RNMBXStyleValue {
       return Enum(rawValue: value as! String)!
     }
   }
-  
+
   func mglStyleValueArrayTextWritingMode() -> Value<[TextWritingMode]> {
     return Value.constant([])
   }
-  
+
   #if RNMBX_11
   func mglStyleValueAnchorRaw() -> Value<Anchor> {
     // RNMBX_11 TODO Support expressions
@@ -495,7 +495,7 @@ class RNMBXStyleValue {
     }
     return false
   }
-  
+
   func setImage(
     bridge: RCTBridge,
     style: Style,
@@ -509,7 +509,7 @@ class RNMBXStyleValue {
       setImageOnLayer(self)
     } else {
       let imageURI = getImageURI()
-      
+
       if let oldRawValue = oldValue as? [String:Any] {
         if let oldRawValue = oldRawValue["stylevalue"] as? [String:Any] {
           if let oldValue = parse(rawStyleValue: oldRawValue) as? [String:Any] {
@@ -537,7 +537,7 @@ class RNMBXStyleValue {
       });
     }
   }
-  
+
   func getImageURI(_ dict: [String:Any]) -> String? {
     if let uri = dict["uri"] as? String {
       return uri
@@ -545,7 +545,7 @@ class RNMBXStyleValue {
       return nil
     }
   }
-  
+
   func getImageURI() -> String? {
     if let dict = styleObject as? [String:Any] {
       return getImageURI(dict)
@@ -554,7 +554,7 @@ class RNMBXStyleValue {
     }
     return nil
   }
-  
+
   func mglStyleValueArrayTextVariableAnchor() -> Value<[TextAnchor]> {
     guard let value = value as? Dictionary<String,Any> else {
       Logger.log(level: .error, message: "Invalid value for array of TextAnchor: \(value)")
@@ -579,7 +579,7 @@ class RNMBXStyleValue {
       }
     }
   }
-  
+
   #if RNMBX_11
   func getSphericalPosition() -> Value<[Double]> {
     if let array = styleObject as? [NSNumber] {
@@ -601,15 +601,15 @@ class RNMBXStyleValue {
     return []
   }
   #endif
-  
+
   func mglStyleValueFormatted() -> Value<String> {
     if let value = value as? Dictionary<String,Any> {
       let value = RNMBXStyleValue.convert(value["stylevalue"] as! [String:Any])
-      
+
       if let string = value as? String {
         return Value.constant(string)
       }
-      
+
       let data = try! JSONSerialization.data(withJSONObject: value, options: .prettyPrinted)
 
       let decodedExpression = try! JSONDecoder().decode(Expression.self, from: data)
@@ -618,11 +618,11 @@ class RNMBXStyleValue {
       fatalError("mglStyleValueFormatted - Unpexected value: \(value)")
     }
   }
-  
+
   func mglStyleValueLineJoin() -> Value<LineJoin> {
     return mglStyleValueEnum()
   }
-  
+
   func mglStyleValueLineTranslateAnchor() -> Value<LineTranslateAnchor> {
     return mglStyleValueEnum()
   }


### PR DESCRIPTION
## Description

Fixes the issue where ‘Expression’ is ambiguous for type lookup in Xcode 16. This resolves compilation errors related to ‘Expression’ type ambiguities in RNMBXLayer, RNMBXStyleValue, and other affected components.

## Checklist

- [X] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

![Screenshot 2024-07-01 at 19 39 42](https://github.com/rnmapbox/maps/assets/32784886/1315f476-cfe0-4aa5-ae51-882b0bf3b160)

## Component to reproduce the issue you're fixing

Run the RNMapbox in Xcode 16