### PR TITLE
Add null check to execute method in CameraUpdateQueue

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/camera/CameraUpdateQueue.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/camera/CameraUpdateQueue.kt
@@ -59,6 +59,9 @@ class CameraUpdateQueue {
             return
         }
         val stop = mQueue.poll() ?: return
+        if (map == null) {
+            return
+        }
         val item = stop.toCameraUpdate(map!!)
         item.run()
         execute(map)


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes a `NullPointerException` that we are seeing in our production app. We are getting a number of reports with the following stack trace:
```
Exception java.lang.NullPointerException:
  at com.rnmapbox.rnmbx.components.camera.CameraUpdateQueue.execute (CameraUpdateQueue.kt:62)
  at com.rnmapbox.rnmbx.components.camera.RNMBXCamera.updateCamera (RNMBXCamera.kt:205)
  at com.rnmapbox.rnmbx.components.camera.RNMBXCamera.access$updateCamera (RNMBXCamera.kt:41)
  at com.rnmapbox.rnmbx.components.camera.RNMBXCamera$addToMap$1.invoke (RNMBXCamera.kt:104)
  at com.rnmapbox.rnmbx.components.camera.RNMBXCamera$addToMap$1.invoke (RNMBXCamera.kt:101)
  at com.rnmapbox.rnmbx.components.mapview.RNMBXLifeCycle.afterAttachFromLooper (RNMBXMapView.kt:178)
  at com.rnmapbox.rnmbx.components.mapview.RNMBXMapView.onAttachedToWindow$lambda$26 (RNMBXMapView.kt:1477)
  at com.rnmapbox.rnmbx.components.mapview.RNMBXMapView.$r8$lambda$5oEp4uR9fWYfY6VAbOGSD-HxZi0
  at com.rnmapbox.rnmbx.components.mapview.RNMBXMapView$$ExternalSyntheticLambda6.run
  at android.os.Handler.handleCallback (Handler.java:958)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:230)
  at android.os.Looper.loop (Looper.java:319)
  at android.app.ActivityThread.main (ActivityThread.java:8919)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:578)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1103)
```



## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [x] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)
