### PR TITLE
[android][v10] Add guard to prevent NRE on map.getStyle().styleLayers

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapView.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapView.kt
@@ -1131,11 +1131,13 @@ open class RNMBXMapView(private val mContext: Context, var mManager: RNMBXMapVie
         }
         val style = mMap.getStyle();
 
-        if (style?.styleLayers == null) {
+        val styleLayers = style?.styleLayers
+        if (styleLayers == null) {
             Logger.e("MapView", "setSourceVisibility, map.getStyle().styleLayers is null")
+            return
         }
 
-        style?.styleLayers?.forEach {
+        styleLayers.forEach {
             val layer = style.getLayer(it.id)
             if ((layer != null) && match(layer, sourceId, sourceLayerId)) {
                 layer.visibility(


### PR DESCRIPTION

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes a crash (I believe it's unreported) that was blocking a google review with sdk `10.1.28` due to the devices running the aab getting this NRE.

## Crash Info

```log
Exception java.lang.NullPointerException:
  at com.rnmapbox.rnmbx.components.mapview.RNMBXMapView.setSourceVisibility (RNMBXMapView.kt:1133)
  at com.rnmapbox.rnmbx.components.mapview.NativeMapViewModule$setSourceVisibility$1.invoke (NativeMapViewModule.kt:66)
  at com.rnmapbox.rnmbx.components.mapview.NativeMapViewModule$setSourceVisibility$1.invoke (NativeMapViewModule.kt:65)
  at com.rnmapbox.rnmbx.utils.ViewTagResolver.withViewResolved$lambda$4 (ViewTagResolver.kt:64)
  at android.os.Handler.handleCallback (Handler.java:938)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage (MessageQueueThreadHandler.java:27)
  at android.os.Looper.loop (Looper.java:223)
  at android.app.ActivityThread.main (ActivityThread.java:7664)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:592)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:947)
```

## Steps to reproduce.

Be on react-native 0.74.3. Build a AAR. Have the mapbox-gl map launch immediately after location permissions are given. The map should not be static, but be reliant on some tiles that could take a bit of time to render.

### About the project

1. This is a map app with two maps overlayed over each-other.
2. First map is is absolutely positioned underneath the other and both are synced.
3. The map loads almost immediately after the onboarding screens, and the data all should exist, but there might be a brief moment or race condition which causes the maps to get that null reference. 

**Cannot replicate on my devices**

- Note 20 ultra
- Z Fold 3, Z Fold 6
- Tablets: Samsung Tab S9+.
- Notably these are ALL running on operating systems flavors of samsung, so it might be an issue with Pixels, and Motorola devices which I believe use stock android. Also all of these devices are high performant, even the note 20 ultra is likely 30-40% faster than these reported devices.

**Reported devices**
- Motorola G20 and a Pixel5 both on SDK 30.

Locally with an emulator I cannot replicate the issue. Maybe network, ram, and cpu throttling would do the trick.

<img width="981" alt="Screenshot 2024-08-24 at 10 07 47 PM" src="https://github.com/user-attachments/assets/3e7e652f-7c6a-44bc-b0b7-2a6b51f84002">


## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here  -->
```jsx

```
