### PR TITLE
Fix camera method and address deprecations

### DIFF
--- a/ios/RNMBX/RNMBXCamera.swift
+++ b/ios/RNMBX/RNMBXCamera.swift
@@ -447,17 +447,33 @@ open class RNMBXCamera : RNMBXMapComponentBase {
       
       withMapView { map in
         #if RNMBX_11
-        let bounds = [sw, ne]
+        do {
+          let bounds: [CLLocationCoordinate2D] = [sw, ne]
+          camera = try map.mapboxMap.camera(
+            for: bounds,
+            camera: .init(cameraState: .init(
+              center: .init(),
+              padding: .zero,
+              zoom: zoom ?? 0,
+              bearing: heading ?? map.mapboxMap.cameraState.bearing,
+              pitch: pitch ?? map.mapboxMap.cameraState.pitch
+            )),
+            coordinatesPadding: padding,
+            maxZoom: nil,
+            offset: nil
+          )
+        } catch {
+          Logger.log(level: .error, message: "RNMBXCamera.toUpdateItem: Failed to build camera configuration: \(error)")
+        }
         #else
         let bounds = CoordinateBounds(southwest: sw, northeast: ne)
-        #endif
-
         camera = map.mapboxMap.camera(
           for: bounds,
           padding: padding,
           bearing: heading ?? map.mapboxMap.cameraState.bearing,
           pitch: pitch ?? map.mapboxMap.cameraState.pitch
         )
+        #endif
       }
     } else {
       camera = CameraOptions(


### PR DESCRIPTION
## Description

Fixes camera bounds-with-padding bug in v11 described in https://github.com/mapbox/mapbox-maps-ios/issues/2134.

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [x] I have tested the new feature on `/example` app.
  - [x] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] ~In V11 mode/android~
  - [ ] ~In New Architecture mode/android~
- [ ] ~I added/updated a sample - if a new feature was implemented (`/example`)~