### PR TITLE
Add corepack compatibility for v1 yarn...yarn@1 still is super slow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ package-lock.json
 /example/package-lock.json
 yarn.lock
 /example/yarn.lock
+.yarn/install-state.gz
 
 # Expo
 .expo

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,5 @@
+enableTelemetry: false
+
+nodeLinker: node-modules
+
+yarnPath: .yarn/releases/yarn-1.22.22.cjs

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     "expo": ">=47.0.0",
     "mapbox-gl": "^2.9.0",
     "react": ">=16.6.1",
-    "react-native": ">=0.59.9",
-    "react-dom": ">= 17.0.0"
+    "react-dom": ">= 17.0.0",
+    "react-native": ">=0.59.9"
   },
   "peerDependenciesMeta": {
     "expo": {
@@ -85,11 +85,12 @@
   "devDependencies": {
     "@babel/core": "7.19.1",
     "@babel/eslint-parser": "^7.19.1",
-    "@babel/plugin-proposal-class-properties": "7.18.6",
-    "@babel/helper-split-export-declaration": "7.24.7",
-    "@babel/helper-hoist-variables": "7.24.7",
     "@babel/helper-function-name": "7.24.7",
+    "@babel/helper-hoist-variables": "7.24.7",
+    "@babel/helper-split-export-declaration": "7.24.7",
+    "@babel/plugin-proposal-class-properties": "7.18.6",
     "@babel/runtime": "7.19.0",
+    "@mdx-js/mdx": "^3.0.0",
     "@react-native/eslint-config": "^0.72.2",
     "@sinonjs/fake-timers": "^8.0.1",
     "@testing-library/react-native": "^12.4.0",
@@ -122,8 +123,7 @@
     "react-native-builder-bob": "^0.23.1",
     "react-test-renderer": "18.2.0",
     "ts-node": "10.9.1",
-    "typescript": "5.1.3",
-    "@mdx-js/mdx": "^3.0.0"
+    "typescript": "5.1.3"
   },
   "codegenConfig": {
     "name": "rnmapbox_maps_specs",
@@ -148,5 +148,6 @@
   "eslintIgnore": [
     "node_modules/",
     "lib/"
-  ]
+  ],
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
## Description

- Fixes yarn install issues with corepack. 
- Allows for corepack to point to the yarn v1 dependency
- Adds the whole cjs file for yarn with the command `yarn set version 1.22.22`

Corepack then updates to the correct yarn version by running `corepack use yarn@1.22.22`.

<!-- OR, if you're implementing a new feature: -->

Added `your feature` that allows ...

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here  -->
```jsx

```
