### PR TITLE
[docs] Add warning about download token exposure relates to #3605 and #3396

### DIFF
--- a/android/install.md
+++ b/android/install.md
@@ -36,6 +36,35 @@ allprojects {
 }
 ```
 
+#### Maven Token with keychain
+
+For a more secure approach on an macOS device, consider leveraging apple's keychain android could use a gradle keychain reader function. And directly use that variable within top level android/build.gradle.
+
+```groovy
+def getPassword(String currentUser, String keyChain) {
+    def stdout = new ByteArrayOutputStream()
+    def stderr = new ByteArrayOutputStream()
+    exec {
+        commandLine 'security', '-q', 'find-generic-password', '-a', currentUser, '-s', keyChain, '-w'
+        standardOutput = stdout
+        errorOutput = stderr
+        ignoreExitValue true
+    }
+    //noinspection GroovyAssignabilityCheck
+    stdout.toString().trim()
+}
+
+def mapboxDownloadToken = getPassword("<app_name>","<app_name>_mapbox_download_secret")
+// Same config as the first part with this shared keychain secret used instead
+allprojects.repositories.maven {
+    ...(refer to mapbox setup)
+    credentials {
+    ...
+    password = mapboxDownloadToken
+    }
+}
+```
+
 ### Using non default mapbox version
 
 *Warning*: If you set a custom version, make sure you revisit, any time you update @rnmapbox/maps. Setting it to earlier version than what we exepect will likely result in a build error.

--- a/ios/install.md
+++ b/ios/install.md
@@ -27,6 +27,8 @@ Add the following to your `ios/Podfile`:
 
 You will need to authorize your download of the Maps SDK with a secret access token with the `DOWNLOADS:READ` scope. This [guide](https://docs.mapbox.com/ios/maps/guides/install/#configure-credentials) explains how to configure the secret token under section `Configure your secret token`.
 
+For macOS consider using keychain to store secrets instead. There are cocoapods packages that store and allow secret injections for local builds. Something like [keychainaccess](https://cocoapods.org/pods/KeychainAccess) or [cocoapods-keys](https://github.com/orta/cocoapods-keys) could do this.
+
 
 Run `pod install` to download the proper mapbox dependency.
 

--- a/plugin/install.md
+++ b/plugin/install.md
@@ -28,22 +28,33 @@ After installing this package, add the [config plugin](https://docs.expo.io/guid
 }
 ```
 
+### Setup Download Token
+
 You'll need to provide `RNMapboxMapsDownloadToken` as well. This secret token requires the `DOWNLOADS:READ` scope. You can refer to the [iOS guide](https://docs.mapbox.com/ios/maps/guides/install/#configure-credentials), which explains how to configure this token under the section `Configure your secret token`.
 
-```json
-{
-  "expo": {
-    "plugins": [
-      [
-        "@rnmapbox/maps",
-        {
-          "RNMapboxMapsDownloadToken": "sk.ey...qg"
-        }
-      ]
-    ]
-  }
-}
-```
+1. Recommended Approach. Follow the guidelines listed in the offical mapbox-gl guide for [iOS](https://docs.mapbox.com/ios/maps/guides/install/#configure-credentials) and [android](https://docs.mapbox.com/android/maps/guides/install/).
+    - For internal docs go to [ios-install](../ios/install.md) [android-install](../android/install.md)
+  
+2. Alternative approach **for private repos only**.
+    - :warning: If this is a public repo **DO NOT follow this approach as this will expose the mapbox download token**. Furthermore if the token has addition permissions (which it should not) it could lead to a monitary cost, security risk (stolen tiles etc) :warning:.
+      - **FYI** _Publicizing this private download token is against mapbox policy._
+    - Running expo prebuild, a require step, will statically generate the token within ios/Podfile and android/build.gradle. These files typically need to be committed for functionality so be sure that you are okay with sharing these tokens with your **private** team.
+
+    ```json
+    {
+      "expo": {
+        <!-- "plugins": [ -->
+          [
+            "@rnmapbox/maps",
+            {
+              <!-- WARNING This WILL BE PUBLIC if on a public repo -->
+              "RNMapboxMapsDownloadToken": "sk.ey...qg"
+            }
+          ]
+        ]
+      }
+    }
+    ```
 
 If you want to show the user's current location on the map with the [UserLocation](../docs/UserLocation.md) component, you can use the [expo-location](https://docs.expo.dev/versions/latest/sdk/location/) plugin to configure the required `NSLocationWhenInUseUsageDescription` property. Install the plugin with `npx expo install expo-location` and add its config plugin to the plugins array of your `app.{json,config.js,config.ts}`:
 


### PR DESCRIPTION
## Description
Fixes #3605 #3396
- warnings about tokens for public repos using expo which auto generates the keys within some critical files.
- Reference to the android and iOS mapbox token setup guides for token creation and mention this is the recommended solution for public repos otherwise it violates mapbox private download token policies
- Add alternative keychain solution for android which completely abstracts the key and removes risk of token theft via plain text.

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [x] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)
