### PR TITLE
feat(ios): enable setSourceVisibility for Mapbox 11

### DIFF
--- a/ios/RNMBX/RNMBXMapView.swift
+++ b/ios/RNMBX/RNMBXMapView.swift
@@ -1416,6 +1416,30 @@ extension RNMBXMapView {
   }
 }
 
+#if RNMBX_11
+func getLayerSourceDetails(layer: (any Layer)?) -> (source: String?, sourceLayer: String?)? {
+    if let circleLayer = layer as? CircleLayer {
+        return (circleLayer.source, circleLayer.sourceLayer)
+    } else if let fillExtrusionLayer = layer as? FillExtrusionLayer {
+        return (fillExtrusionLayer.source, fillExtrusionLayer.sourceLayer)
+    } else if let fillLayer = layer as? FillLayer {
+        return (fillLayer.source, fillLayer.sourceLayer)
+    } else if let heatmapLayer = layer as? HeatmapLayer {
+        return (heatmapLayer.source, heatmapLayer.sourceLayer)
+    } else if let hillshadeLayer = layer as? HillshadeLayer {
+        return (hillshadeLayer.source, hillshadeLayer.sourceLayer)
+    } else if let lineLayer = layer as? LineLayer {
+        return (lineLayer.source, lineLayer.sourceLayer)
+    } else if let rasterLayer = layer as? RasterLayer {
+        return (rasterLayer.source, rasterLayer.sourceLayer)
+    } else if let symbolLayer = layer as? SymbolLayer {
+        return (symbolLayer.source, symbolLayer.sourceLayer)
+    } else {
+        return nil
+    }
+}
+#endif
+
 extension RNMBXMapView {
   func setSourceVisibility(_ visible: Bool, sourceId: String, sourceLayerId: String?) -> Void {
     let style = self.mapboxMap.style
@@ -1424,14 +1448,18 @@ extension RNMBXMapView {
       let layer = logged("setSourceVisibility.layer", info: { "\(layerInfo.id)" }) {
         try style.layer(withId: layerInfo.id)
       }
+
       #if RNMBX_11
-      // RNMBX_11_TODO
+        let sourceDetails = getLayerSourceDetails(layer: layer)
       #else
-      if let layer = layer {
-        if layer.source == sourceId {
+        let sourceDetails = (layer?.source, layer?.sourceLayer)
+      #endif
+
+      if let layer = layer, let sourceDetails = sourceDetails {
+        if sourceDetails.source == sourceId {
           var good = true
           if let sourceLayerId = sourceLayerId {
-            if sourceLayerId != layer.sourceLayer {
+            if sourceLayerId != sourceDetails.sourceLayer {
               good = false
             }
           }
@@ -1444,7 +1472,6 @@ extension RNMBXMapView {
           }
         }
       }
-      #endif
     }
   }
 }


### PR DESCRIPTION
## Description

Fixes #3614

The reason this function stopped working in Mapbox 11 seems because of the change [noted here](https://docs.mapbox.com/ios/maps/api/11.0.0/documentation/mapboxmaps/migrate-to-v11/#2123). This is my first attempt at fixing it. We are already using the fix in our project.

I'm on some hard deadlines, so need some external help with:

* Making this code more proper (I'm not Swift developer, this is my best attempt)
* Testing w/ the example app.

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [x] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

Please compare with the video in #3614 

https://github.com/user-attachments/assets/9cc40bcd-4e25-43d2-9434-6cf324671571

## Component to reproduce the issue you're fixing

See the component in #3614
