### PR TITLE
feat: add support for offline downloading of tilesets

### DIFF
--- a/android/src/main/mapbox-v11-compat/v10/com/rnmapbox/rnmbx/v11compat/OfflineManager.kt
+++ b/android/src/main/mapbox-v11-compat/v10/com/rnmapbox/rnmbx/v11compat/OfflineManager.kt
@@ -6,6 +6,10 @@ import com.mapbox.common.toValue
 import com.mapbox.maps.OfflineManager
 import com.mapbox.maps.OfflineRegionManager
 import com.mapbox.maps.ResourceOptions
+import com.mapbox.maps.StylePackLoadOptions
+import com.mapbox.maps.TilesetDescriptorOptions
+import com.mapbox.maps.TilesetDescriptorOptionsForTilesets
+import com.mapbox.common.TilesetDescriptor
 
 fun getOfflineRegionManager(getAccessToken: () -> String): OfflineRegionManager {
   return OfflineRegionManager(ResourceOptions.Builder().accessToken(getAccessToken()).build())
@@ -18,6 +22,28 @@ fun getOfflineManager(tileStore: TileStore, getAccessToken: () -> String): Offli
         tileStore
       ).build()
   )
+}
+
+fun getTilesetDescriptors(offlineManager: OfflineManager, styleURI: String, minZoom: Byte, maxZoom: Byte, stylePackOptions: StylePackLoadOptions, tilesets: List<String>): ArrayList<TilesetDescriptor>{
+  val descriptorOptions = TilesetDescriptorOptions.Builder()
+    .styleURI(styleURI)
+    .minZoom(minZoom)
+    .maxZoom(maxZoom)
+    .stylePackOptions(stylePackOptions)
+    .pixelRatio(2.0f)
+    .build()
+  val descriptor = offlineManager.createTilesetDescriptor(descriptorOptions)
+  val tilesetDescriptorOptions = TilesetDescriptorOptionsForTilesets.Builder()
+    .tilesets(tilesets)
+    .minZoom(minZoom)
+    .maxZoom(maxZoom)
+    .build()
+  val tilesetDescriptor = offlineManager.createTilesetDescriptor(tilesetDescriptorOptions)
+  val descriptors = arrayListOf(descriptor)
+  if (tilesets.isNotEmpty()) {
+    descriptors.add(tilesetDescriptor)
+  }
+  return descriptors
 }
 
 fun TileStore.setAccessToken(token: String) {

--- a/android/src/main/mapbox-v11-compat/v11/com/rnmapbox/rnmbx/v11compat/OfflineManager.kt
+++ b/android/src/main/mapbox-v11-compat/v11/com/rnmapbox/rnmbx/v11compat/OfflineManager.kt
@@ -4,13 +4,45 @@ import com.mapbox.common.MapboxOptions
 import com.mapbox.common.TileStore
 import com.mapbox.maps.OfflineManager
 import com.mapbox.maps.OfflineRegionManager
+import com.mapbox.maps.StylePackLoadOptions
+import com.mapbox.maps.TilesetDescriptorOptions
+import com.mapbox.common.TilesetDescriptor
 
 fun getOfflineRegionManager(getAccessToken: () -> String): OfflineRegionManager {
   return OfflineRegionManager()
 }
+
 fun getOfflineManager(tileStore: TileStore, getAccessToken: () -> String): OfflineManager {
   return OfflineManager()
 }
+
+fun getTilesetDescriptors(offlineManager: OfflineManager, styleURI: String, minZoom: Byte, maxZoom: Byte, stylePackOptions: StylePackLoadOptions, tilesets: List<String>): ArrayList<TilesetDescriptor>{
+  if (tilesets.isNotEmpty()) {
+    val descriptorOptions = TilesetDescriptorOptions.Builder()
+      .styleURI(styleURI)
+      .minZoom(minZoom)
+      .maxZoom(maxZoom)
+//    TODO: When tilesets is passed in the mappack doesn't save -- not sure why
+//      .tilesets(tilesets)
+      .stylePackOptions(stylePackOptions)
+      .pixelRatio(2.0f)
+      .build()
+    val descriptor = offlineManager.createTilesetDescriptor(descriptorOptions)
+    val descriptors = arrayListOf(descriptor)
+    return descriptors
+  }
+  val descriptorOptions = TilesetDescriptorOptions.Builder()
+    .styleURI(styleURI)
+    .minZoom(minZoom)
+    .maxZoom(maxZoom)
+    .stylePackOptions(stylePackOptions)
+    .pixelRatio(2.0f)
+    .build()
+  val descriptor = offlineManager.createTilesetDescriptor(descriptorOptions)
+  val descriptors = arrayListOf(descriptor)
+  return descriptors
+}
+
 fun TileStore.setAccessToken(token: String) {
   MapboxOptions.accessToken = token
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -22,7 +22,7 @@ org.gradle.jvmargs=-Xmx2560m -XX:MaxMetaspaceSize=1024m
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 
-RNMBX11=false
+RNMBX11=true
 
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,12 +1,12 @@
 PODS:
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.75.0-rc.3)
+  - FBLazyVector (0.75.1)
   - fmt (9.1.0)
   - glog (0.3.5)
-  - hermes-engine (0.75.0-rc.3):
-    - hermes-engine/Pre-built (= 0.75.0-rc.3)
-  - hermes-engine/Pre-built (0.75.0-rc.3)
+  - hermes-engine (0.75.1):
+    - hermes-engine/Pre-built (= 0.75.1)
+  - hermes-engine/Pre-built (0.75.1)
   - MapboxCommon (24.4.0)
   - MapboxCoreMaps (11.4.0):
     - MapboxCommon (~> 24.4)
@@ -30,32 +30,32 @@ PODS:
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-  - RCTDeprecation (0.75.0-rc.3)
-  - RCTRequired (0.75.0-rc.3)
-  - RCTTypeSafety (0.75.0-rc.3):
-    - FBLazyVector (= 0.75.0-rc.3)
-    - RCTRequired (= 0.75.0-rc.3)
-    - React-Core (= 0.75.0-rc.3)
-  - React (0.75.0-rc.3):
-    - React-Core (= 0.75.0-rc.3)
-    - React-Core/DevSupport (= 0.75.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.75.0-rc.3)
-    - React-RCTActionSheet (= 0.75.0-rc.3)
-    - React-RCTAnimation (= 0.75.0-rc.3)
-    - React-RCTBlob (= 0.75.0-rc.3)
-    - React-RCTImage (= 0.75.0-rc.3)
-    - React-RCTLinking (= 0.75.0-rc.3)
-    - React-RCTNetwork (= 0.75.0-rc.3)
-    - React-RCTSettings (= 0.75.0-rc.3)
-    - React-RCTText (= 0.75.0-rc.3)
-    - React-RCTVibration (= 0.75.0-rc.3)
-  - React-callinvoker (0.75.0-rc.3)
-  - React-Core (0.75.0-rc.3):
+  - RCTDeprecation (0.75.1)
+  - RCTRequired (0.75.1)
+  - RCTTypeSafety (0.75.1):
+    - FBLazyVector (= 0.75.1)
+    - RCTRequired (= 0.75.1)
+    - React-Core (= 0.75.1)
+  - React (0.75.1):
+    - React-Core (= 0.75.1)
+    - React-Core/DevSupport (= 0.75.1)
+    - React-Core/RCTWebSocket (= 0.75.1)
+    - React-RCTActionSheet (= 0.75.1)
+    - React-RCTAnimation (= 0.75.1)
+    - React-RCTBlob (= 0.75.1)
+    - React-RCTImage (= 0.75.1)
+    - React-RCTLinking (= 0.75.1)
+    - React-RCTNetwork (= 0.75.1)
+    - React-RCTSettings (= 0.75.1)
+    - React-RCTText (= 0.75.1)
+    - React-RCTVibration (= 0.75.1)
+  - React-callinvoker (0.75.1)
+  - React-Core (0.75.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.75.0-rc.3)
+    - React-Core/Default (= 0.75.1)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -67,58 +67,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.75.0-rc.3):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/Default (0.75.0-rc.3):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/DevSupport (0.75.0-rc.3):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-Core/Default (= 0.75.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.75.0-rc.3)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.75.0-rc.3):
+  - React-Core/CoreModulesHeaders (0.75.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -135,7 +84,41 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.75.0-rc.3):
+  - React-Core/Default (0.75.1):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-Core/DevSupport (0.75.1):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.75.1)
+    - React-Core/RCTWebSocket (= 0.75.1)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.75.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -152,7 +135,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.75.0-rc.3):
+  - React-Core/RCTAnimationHeaders (0.75.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -169,7 +152,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTImageHeaders (0.75.0-rc.3):
+  - React-Core/RCTBlobHeaders (0.75.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -186,7 +169,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.75.0-rc.3):
+  - React-Core/RCTImageHeaders (0.75.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -203,7 +186,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.75.0-rc.3):
+  - React-Core/RCTLinkingHeaders (0.75.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -220,7 +203,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.75.0-rc.3):
+  - React-Core/RCTNetworkHeaders (0.75.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -237,7 +220,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTTextHeaders (0.75.0-rc.3):
+  - React-Core/RCTSettingsHeaders (0.75.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -254,7 +237,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.75.0-rc.3):
+  - React-Core/RCTTextHeaders (0.75.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -271,12 +254,12 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTWebSocket (0.75.0-rc.3):
+  - React-Core/RCTVibrationHeaders (0.75.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.75.0-rc.3)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -288,36 +271,53 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-CoreModules (0.75.0-rc.3):
+  - React-Core/RCTWebSocket (0.75.1):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.75.1)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-CoreModules (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - RCT-Folly (= 2024.01.01.00)
-    - RCTTypeSafety (= 0.75.0-rc.3)
-    - React-Core/CoreModulesHeaders (= 0.75.0-rc.3)
-    - React-jsi (= 0.75.0-rc.3)
+    - RCTTypeSafety (= 0.75.1)
+    - React-Core/CoreModulesHeaders (= 0.75.1)
+    - React-jsi (= 0.75.1)
     - React-jsinspector
     - React-NativeModulesApple
     - React-RCTBlob
-    - React-RCTImage (= 0.75.0-rc.3)
+    - React-RCTImage (= 0.75.1)
     - ReactCodegen
     - ReactCommon
     - SocketRocket (= 0.7.0)
-  - React-cxxreact (0.75.0-rc.3):
+  - React-cxxreact (0.75.1):
     - boost
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.75.0-rc.3)
-    - React-debug (= 0.75.0-rc.3)
-    - React-jsi (= 0.75.0-rc.3)
+    - React-callinvoker (= 0.75.1)
+    - React-debug (= 0.75.1)
+    - React-jsi (= 0.75.1)
     - React-jsinspector
-    - React-logger (= 0.75.0-rc.3)
-    - React-perflogger (= 0.75.0-rc.3)
-    - React-runtimeexecutor (= 0.75.0-rc.3)
-  - React-debug (0.75.0-rc.3)
-  - React-defaultsnativemodule (0.75.0-rc.3):
+    - React-logger (= 0.75.1)
+    - React-perflogger (= 0.75.1)
+    - React-runtimeexecutor (= 0.75.1)
+  - React-debug (0.75.1)
+  - React-defaultsnativemodule (0.75.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -342,7 +342,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-domnativemodule (0.75.0-rc.3):
+  - React-domnativemodule (0.75.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -364,7 +364,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric (0.75.0-rc.3):
+  - React-Fabric (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -375,21 +375,21 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.75.0-rc.3)
-    - React-Fabric/attributedstring (= 0.75.0-rc.3)
-    - React-Fabric/componentregistry (= 0.75.0-rc.3)
-    - React-Fabric/componentregistrynative (= 0.75.0-rc.3)
-    - React-Fabric/components (= 0.75.0-rc.3)
-    - React-Fabric/core (= 0.75.0-rc.3)
-    - React-Fabric/dom (= 0.75.0-rc.3)
-    - React-Fabric/imagemanager (= 0.75.0-rc.3)
-    - React-Fabric/leakchecker (= 0.75.0-rc.3)
-    - React-Fabric/mounting (= 0.75.0-rc.3)
-    - React-Fabric/observers (= 0.75.0-rc.3)
-    - React-Fabric/scheduler (= 0.75.0-rc.3)
-    - React-Fabric/telemetry (= 0.75.0-rc.3)
-    - React-Fabric/templateprocessor (= 0.75.0-rc.3)
-    - React-Fabric/uimanager (= 0.75.0-rc.3)
+    - React-Fabric/animations (= 0.75.1)
+    - React-Fabric/attributedstring (= 0.75.1)
+    - React-Fabric/componentregistry (= 0.75.1)
+    - React-Fabric/componentregistrynative (= 0.75.1)
+    - React-Fabric/components (= 0.75.1)
+    - React-Fabric/core (= 0.75.1)
+    - React-Fabric/dom (= 0.75.1)
+    - React-Fabric/imagemanager (= 0.75.1)
+    - React-Fabric/leakchecker (= 0.75.1)
+    - React-Fabric/mounting (= 0.75.1)
+    - React-Fabric/observers (= 0.75.1)
+    - React-Fabric/scheduler (= 0.75.1)
+    - React-Fabric/telemetry (= 0.75.1)
+    - React-Fabric/templateprocessor (= 0.75.1)
+    - React-Fabric/uimanager (= 0.75.1)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -399,27 +399,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.75.0-rc.3):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.75.0-rc.3):
+  - React-Fabric/animations (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -439,7 +419,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.75.0-rc.3):
+  - React-Fabric/attributedstring (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -459,7 +439,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.75.0-rc.3):
+  - React-Fabric/componentregistry (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -479,30 +459,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.75.0-rc.3):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.75.0-rc.3)
-    - React-Fabric/components/root (= 0.75.0-rc.3)
-    - React-Fabric/components/view (= 0.75.0-rc.3)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.75.0-rc.3):
+  - React-Fabric/componentregistrynative (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -522,7 +479,30 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.75.0-rc.3):
+  - React-Fabric/components (0.75.1):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.75.1)
+    - React-Fabric/components/root (= 0.75.1)
+    - React-Fabric/components/view (= 0.75.1)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/legacyviewmanagerinterop (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -542,7 +522,27 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.75.0-rc.3):
+  - React-Fabric/components/root (0.75.1):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/view (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -563,7 +563,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/core (0.75.0-rc.3):
+  - React-Fabric/core (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -583,7 +583,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/dom (0.75.0-rc.3):
+  - React-Fabric/dom (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -603,7 +603,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.75.0-rc.3):
+  - React-Fabric/imagemanager (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -623,7 +623,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.75.0-rc.3):
+  - React-Fabric/leakchecker (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -643,7 +643,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.75.0-rc.3):
+  - React-Fabric/mounting (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -663,7 +663,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers (0.75.0-rc.3):
+  - React-Fabric/observers (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -674,7 +674,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.75.0-rc.3)
+    - React-Fabric/observers/events (= 0.75.1)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -684,7 +684,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers/events (0.75.0-rc.3):
+  - React-Fabric/observers/events (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -704,7 +704,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.75.0-rc.3):
+  - React-Fabric/scheduler (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -726,7 +726,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.75.0-rc.3):
+  - React-Fabric/telemetry (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -746,7 +746,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.75.0-rc.3):
+  - React-Fabric/templateprocessor (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -766,7 +766,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.75.0-rc.3):
+  - React-Fabric/uimanager (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -777,28 +777,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.75.0-rc.3)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererconsistency
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager/consistency (0.75.0-rc.3):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
+    - React-Fabric/uimanager/consistency (= 0.75.1)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -809,7 +788,28 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricComponents (0.75.0-rc.3):
+  - React-Fabric/uimanager/consistency (0.75.1):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererconsistency
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-FabricComponents (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -821,8 +821,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.75.0-rc.3)
-    - React-FabricComponents/textlayoutmanager (= 0.75.0-rc.3)
+    - React-FabricComponents/components (= 0.75.1)
+    - React-FabricComponents/textlayoutmanager (= 0.75.1)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -834,7 +834,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components (0.75.0-rc.3):
+  - React-FabricComponents/components (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -846,15 +846,15 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.75.0-rc.3)
-    - React-FabricComponents/components/iostextinput (= 0.75.0-rc.3)
-    - React-FabricComponents/components/modal (= 0.75.0-rc.3)
-    - React-FabricComponents/components/rncore (= 0.75.0-rc.3)
-    - React-FabricComponents/components/safeareaview (= 0.75.0-rc.3)
-    - React-FabricComponents/components/scrollview (= 0.75.0-rc.3)
-    - React-FabricComponents/components/text (= 0.75.0-rc.3)
-    - React-FabricComponents/components/textinput (= 0.75.0-rc.3)
-    - React-FabricComponents/components/unimplementedview (= 0.75.0-rc.3)
+    - React-FabricComponents/components/inputaccessory (= 0.75.1)
+    - React-FabricComponents/components/iostextinput (= 0.75.1)
+    - React-FabricComponents/components/modal (= 0.75.1)
+    - React-FabricComponents/components/rncore (= 0.75.1)
+    - React-FabricComponents/components/safeareaview (= 0.75.1)
+    - React-FabricComponents/components/scrollview (= 0.75.1)
+    - React-FabricComponents/components/text (= 0.75.1)
+    - React-FabricComponents/components/textinput (= 0.75.1)
+    - React-FabricComponents/components/unimplementedview (= 0.75.1)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -866,53 +866,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.75.0-rc.3):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.75.0-rc.3):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/modal (0.75.0-rc.3):
+  - React-FabricComponents/components/inputaccessory (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -935,7 +889,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/rncore (0.75.0-rc.3):
+  - React-FabricComponents/components/iostextinput (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -958,7 +912,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.75.0-rc.3):
+  - React-FabricComponents/components/modal (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -981,7 +935,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/scrollview (0.75.0-rc.3):
+  - React-FabricComponents/components/rncore (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1004,7 +958,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/text (0.75.0-rc.3):
+  - React-FabricComponents/components/safeareaview (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1027,7 +981,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/textinput (0.75.0-rc.3):
+  - React-FabricComponents/components/scrollview (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1050,7 +1004,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.75.0-rc.3):
+  - React-FabricComponents/components/text (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1073,7 +1027,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.75.0-rc.3):
+  - React-FabricComponents/components/textinput (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1096,26 +1050,72 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricImage (0.75.0-rc.3):
+  - React-FabricComponents/components/unimplementedview (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired (= 0.75.0-rc.3)
-    - RCTTypeSafety (= 0.75.0-rc.3)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricComponents/textlayoutmanager (0.75.1):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricImage (0.75.1):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired (= 0.75.1)
+    - RCTTypeSafety (= 0.75.1)
     - React-Fabric
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.75.0-rc.3)
+    - React-jsiexecutor (= 0.75.1)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-featureflags (0.75.0-rc.3)
-  - React-featureflagsnativemodule (0.75.0-rc.3):
+  - React-featureflags (0.75.1)
+  - React-featureflagsnativemodule (0.75.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1136,7 +1136,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-graphics (0.75.0-rc.3):
+  - React-graphics (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -1144,19 +1144,19 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-utils
-  - React-hermes (0.75.0-rc.3):
+  - React-hermes (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-cxxreact (= 0.75.0-rc.3)
+    - React-cxxreact (= 0.75.1)
     - React-jsi
-    - React-jsiexecutor (= 0.75.0-rc.3)
+    - React-jsiexecutor (= 0.75.1)
     - React-jsinspector
-    - React-perflogger (= 0.75.0-rc.3)
+    - React-perflogger (= 0.75.1)
     - React-runtimeexecutor
-  - React-idlecallbacksnativemodule (0.75.0-rc.3):
+  - React-idlecallbacksnativemodule (0.75.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1178,7 +1178,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-ImageManager (0.75.0-rc.3):
+  - React-ImageManager (0.75.1):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -1187,43 +1187,43 @@ PODS:
     - React-graphics
     - React-rendererdebug
     - React-utils
-  - React-jserrorhandler (0.75.0-rc.3):
+  - React-jserrorhandler (0.75.1):
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-debug
     - React-jsi
-  - React-jsi (0.75.0-rc.3):
+  - React-jsi (0.75.1):
     - boost
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-  - React-jsiexecutor (0.75.0-rc.3):
+  - React-jsiexecutor (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-cxxreact (= 0.75.0-rc.3)
-    - React-jsi (= 0.75.0-rc.3)
+    - React-cxxreact (= 0.75.1)
+    - React-jsi (= 0.75.1)
     - React-jsinspector
-    - React-perflogger (= 0.75.0-rc.3)
-  - React-jsinspector (0.75.0-rc.3):
+    - React-perflogger (= 0.75.1)
+  - React-jsinspector (0.75.1):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - React-featureflags
     - React-jsi
-    - React-runtimeexecutor (= 0.75.0-rc.3)
-  - React-jsitracing (0.75.0-rc.3):
+    - React-runtimeexecutor (= 0.75.1)
+  - React-jsitracing (0.75.1):
     - React-jsi
-  - React-logger (0.75.0-rc.3):
+  - React-logger (0.75.1):
     - glog
-  - React-Mapbuffer (0.75.0-rc.3):
+  - React-Mapbuffer (0.75.1):
     - glog
     - React-debug
-  - React-microtasksnativemodule (0.75.0-rc.3):
+  - React-microtasksnativemodule (0.75.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1244,74 +1244,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-safe-area-context (4.10.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
+  - react-native-safe-area-context (4.10.9):
     - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - react-native-safe-area-context/common (= 4.10.4)
-    - react-native-safe-area-context/fabric (= 4.10.4)
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - react-native-safe-area-context/common (4.10.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - react-native-safe-area-context/fabric (4.10.4):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - react-native-safe-area-context/common
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-nativeconfig (0.75.0-rc.3)
-  - React-NativeModulesApple (0.75.0-rc.3):
+  - React-nativeconfig (0.75.1)
+  - React-NativeModulesApple (0.75.1):
     - glog
     - hermes-engine
     - React-callinvoker
@@ -1322,13 +1258,13 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.75.0-rc.3)
-  - React-performancetimeline (0.75.0-rc.3):
+  - React-perflogger (0.75.1)
+  - React-performancetimeline (0.75.1):
     - RCT-Folly (= 2024.01.01.00)
     - React-cxxreact
-  - React-RCTActionSheet (0.75.0-rc.3):
-    - React-Core/RCTActionSheetHeaders (= 0.75.0-rc.3)
-  - React-RCTAnimation (0.75.0-rc.3):
+  - React-RCTActionSheet (0.75.1):
+    - React-Core/RCTActionSheetHeaders (= 0.75.1)
+  - React-RCTAnimation (0.75.1):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Core/RCTAnimationHeaders
@@ -1336,7 +1272,7 @@ PODS:
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-  - React-RCTAppDelegate (0.75.0-rc.3):
+  - React-RCTAppDelegate (0.75.1):
     - RCT-Folly (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
@@ -1361,7 +1297,7 @@ PODS:
     - React-utils
     - ReactCodegen
     - ReactCommon
-  - React-RCTBlob (0.75.0-rc.3):
+  - React-RCTBlob (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - hermes-engine
@@ -1374,7 +1310,7 @@ PODS:
     - React-RCTNetwork
     - ReactCodegen
     - ReactCommon
-  - React-RCTFabric (0.75.0-rc.3):
+  - React-RCTFabric (0.75.1):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
@@ -1397,7 +1333,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTImage (0.75.0-rc.3):
+  - React-RCTImage (0.75.1):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Core/RCTImageHeaders
@@ -1406,14 +1342,14 @@ PODS:
     - React-RCTNetwork
     - ReactCodegen
     - ReactCommon
-  - React-RCTLinking (0.75.0-rc.3):
-    - React-Core/RCTLinkingHeaders (= 0.75.0-rc.3)
-    - React-jsi (= 0.75.0-rc.3)
+  - React-RCTLinking (0.75.1):
+    - React-Core/RCTLinkingHeaders (= 0.75.1)
+    - React-jsi (= 0.75.1)
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.75.0-rc.3)
-  - React-RCTNetwork (0.75.0-rc.3):
+    - ReactCommon/turbomodule/core (= 0.75.1)
+  - React-RCTNetwork (0.75.1):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Core/RCTNetworkHeaders
@@ -1421,7 +1357,7 @@ PODS:
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-  - React-RCTSettings (0.75.0-rc.3):
+  - React-RCTSettings (0.75.1):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Core/RCTSettingsHeaders
@@ -1429,24 +1365,24 @@ PODS:
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-  - React-RCTText (0.75.0-rc.3):
-    - React-Core/RCTTextHeaders (= 0.75.0-rc.3)
+  - React-RCTText (0.75.1):
+    - React-Core/RCTTextHeaders (= 0.75.1)
     - Yoga
-  - React-RCTVibration (0.75.0-rc.3):
+  - React-RCTVibration (0.75.1):
     - RCT-Folly (= 2024.01.01.00)
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
     - ReactCodegen
     - ReactCommon
-  - React-rendererconsistency (0.75.0-rc.3)
-  - React-rendererdebug (0.75.0-rc.3):
+  - React-rendererconsistency (0.75.1)
+  - React-rendererdebug (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - RCT-Folly (= 2024.01.01.00)
     - React-debug
-  - React-rncore (0.75.0-rc.3)
-  - React-RuntimeApple (0.75.0-rc.3):
+  - React-rncore (0.75.1)
+  - React-RuntimeApple (0.75.1):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-callinvoker
@@ -1463,8 +1399,9 @@ PODS:
     - React-RuntimeCore
     - React-runtimeexecutor
     - React-RuntimeHermes
+    - React-runtimescheduler
     - React-utils
-  - React-RuntimeCore (0.75.0-rc.3):
+  - React-RuntimeCore (0.75.1):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
@@ -1477,9 +1414,9 @@ PODS:
     - React-runtimeexecutor
     - React-runtimescheduler
     - React-utils
-  - React-runtimeexecutor (0.75.0-rc.3):
-    - React-jsi (= 0.75.0-rc.3)
-  - React-RuntimeHermes (0.75.0-rc.3):
+  - React-runtimeexecutor (0.75.1):
+    - React-jsi (= 0.75.1)
+  - React-RuntimeHermes (0.75.1):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-featureflags
@@ -1490,7 +1427,7 @@ PODS:
     - React-nativeconfig
     - React-RuntimeCore
     - React-utils
-  - React-runtimescheduler (0.75.0-rc.3):
+  - React-runtimescheduler (0.75.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -1503,13 +1440,13 @@ PODS:
     - React-rendererdebug
     - React-runtimeexecutor
     - React-utils
-  - React-utils (0.75.0-rc.3):
+  - React-utils (0.75.1):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - React-debug
-    - React-jsi (= 0.75.0-rc.3)
-  - ReactCodegen (0.75.0-rc.3):
+    - React-jsi (= 0.75.1)
+  - ReactCodegen (0.75.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1529,116 +1466,60 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - ReactCommon (0.75.0-rc.3):
-    - ReactCommon/turbomodule (= 0.75.0-rc.3)
-  - ReactCommon/turbomodule (0.75.0-rc.3):
+  - ReactCommon (0.75.1):
+    - ReactCommon/turbomodule (= 0.75.1)
+  - ReactCommon/turbomodule (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.75.0-rc.3)
-    - React-cxxreact (= 0.75.0-rc.3)
-    - React-jsi (= 0.75.0-rc.3)
-    - React-logger (= 0.75.0-rc.3)
-    - React-perflogger (= 0.75.0-rc.3)
-    - ReactCommon/turbomodule/bridging (= 0.75.0-rc.3)
-    - ReactCommon/turbomodule/core (= 0.75.0-rc.3)
-  - ReactCommon/turbomodule/bridging (0.75.0-rc.3):
+    - React-callinvoker (= 0.75.1)
+    - React-cxxreact (= 0.75.1)
+    - React-jsi (= 0.75.1)
+    - React-logger (= 0.75.1)
+    - React-perflogger (= 0.75.1)
+    - ReactCommon/turbomodule/bridging (= 0.75.1)
+    - ReactCommon/turbomodule/core (= 0.75.1)
+  - ReactCommon/turbomodule/bridging (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.75.0-rc.3)
-    - React-cxxreact (= 0.75.0-rc.3)
-    - React-jsi (= 0.75.0-rc.3)
-    - React-logger (= 0.75.0-rc.3)
-    - React-perflogger (= 0.75.0-rc.3)
-  - ReactCommon/turbomodule/core (0.75.0-rc.3):
+    - React-callinvoker (= 0.75.1)
+    - React-cxxreact (= 0.75.1)
+    - React-jsi (= 0.75.1)
+    - React-logger (= 0.75.1)
+    - React-perflogger (= 0.75.1)
+  - ReactCommon/turbomodule/core (0.75.1):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.75.0-rc.3)
-    - React-cxxreact (= 0.75.0-rc.3)
-    - React-debug (= 0.75.0-rc.3)
-    - React-featureflags (= 0.75.0-rc.3)
-    - React-jsi (= 0.75.0-rc.3)
-    - React-logger (= 0.75.0-rc.3)
-    - React-perflogger (= 0.75.0-rc.3)
-    - React-utils (= 0.75.0-rc.3)
-  - RNCAsyncStorage (1.23.1):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
+    - React-callinvoker (= 0.75.1)
+    - React-cxxreact (= 0.75.1)
+    - React-debug (= 0.75.1)
+    - React-featureflags (= 0.75.1)
+    - React-jsi (= 0.75.1)
+    - React-logger (= 0.75.1)
+    - React-perflogger (= 0.75.1)
+    - React-utils (= 0.75.1)
+  - RNCAsyncStorage (1.24.0):
     - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - rnmapbox-maps (10.1.27):
+  - rnmapbox-maps (10.1.31):
     - MapboxMaps (= 11.4.0)
     - React
     - React-Core
-    - rnmapbox-maps/DynamicLibrary (= 10.1.27)
+    - rnmapbox-maps/DynamicLibrary (= 10.1.31)
     - Turf
-  - rnmapbox-maps/DynamicLibrary (10.1.27):
-    - DoubleConversion
-    - hermes-engine
+  - rnmapbox-maps/DynamicLibrary (10.1.31):
     - MapboxMaps (= 11.4.0)
-    - RCT-Folly
-    - RCTRequired
-    - RCTTypeSafety
     - React
     - React-Core
-    - React-featureflags
-    - React-ImageManager
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
     - Turf
-    - Yoga
-  - RNScreens (3.31.1):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-ImageManager
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-RCTImage
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - RNScreens/common (= 3.31.1)
-    - Yoga
-  - RNScreens/common (3.31.1):
+  - RNScreens (3.34.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1758,7 +1639,7 @@ EXTERNAL SOURCES:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
-    :tag: hermes-2024-07-01-RNv0.75.0-1edbe36ce92fef2c4d427f5c4e104f2758f4b692
+    :tag: hermes-2024-08-15-RNv0.75.1-4b3bf912cc0f705b51b71ce1a5b8bd79b93a451b
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTDeprecation:
@@ -1885,77 +1766,77 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 4cb898d0bf20404aab1850c656dcea009429d6c1
   DoubleConversion: 76ab83afb40bddeeee456813d9c04f67f78771b5
-  FBLazyVector: 3f9fedca03da2c31f478e3c0afcd498a56316cbe
+  FBLazyVector: a3071c12f1650bfa84f2815e9982426256a0aae1
   fmt: 4c2741a687cc09f0634a2e2c72a838b99f1ff120
-  glog: fdfdfe5479092de0c4bdbebedd9056951f092c4f
-  hermes-engine: 842ece76c29e70ef94475762fcaa0d65569561e4
+  glog: 69ef571f3de08433d766d614c73a9838a06bf7eb
+  hermes-engine: e949b1da40409c52aa7bd79ff32cec045f5b4650
   MapboxCommon: 6acbd8ff41d66abf498e1558b0739f25c562945a
   MapboxCoreMaps: f306bb1b10ebe995a2247b40e99322ab7f9b8071
   MapboxMaps: 82044383ae19ec124ff444ec4b5d3ce82cb36ba5
-  RCT-Folly: 02617c592a293bd6d418e0a88ff4ee1f88329b47
-  RCTDeprecation: 9ad4d424717be9cb71718b12e5792867d826a29c
-  RCTRequired: 4b1f764a07145db51f7dc480dfb589b66686ac46
-  RCTTypeSafety: ec4cd8e84d967376bac9dd1c8e651596543238cb
-  React: b256cdda2009039bfdc572ae5858fa03f87478b7
-  React-callinvoker: d94496da3e2a0cbefdb2029fe3a10dfc77187ac2
-  React-Core: afda46df2291f1aae314cc9e257225f201ffb70b
-  React-CoreModules: a021a3b56f94b6fa4687fcab3174e65f5d80cad8
-  React-cxxreact: f2b518aecdf52281a7b4de1268ab5b8229373380
-  React-debug: d9fdd480a68a95f4b62de6094b403d1c50d17c69
-  React-defaultsnativemodule: f8c8946d2b2f37cc27f674011ec5604ae263c0e5
-  React-domnativemodule: 8b32a8cc3448e3bcd3177883b9e715ab89d2a8d3
-  React-Fabric: 3bda440362cbdc6cfe087d64067d3f0e7d39ceac
-  React-FabricComponents: ae04ce9d7c2faa2fe4fd8f77d9a440dbd2404445
-  React-FabricImage: 93c63dbaea8b3534482613085f1f00a92aef0376
-  React-featureflags: 191288f0ed37113acd2b5b342323bf4383e67e82
-  React-featureflagsnativemodule: 7aaf578336ea79a22996a1e0088ab270be7dde90
-  React-graphics: 905d6ba035f897c8c4131db84f338b034ffa073c
-  React-hermes: 5f442d852c7383fd6b8c6c0c82dd4f5ba7293070
-  React-idlecallbacksnativemodule: 3298754c775bc4a27478274d246f22c8ec790f01
-  React-ImageManager: 30846b47474aacf437080a2f7dfea6c925286c2c
-  React-jserrorhandler: c3286228a97d201800a1052082058ec587672df6
-  React-jsi: 36920e549164f57aacfcfe3a35e17694e8947bfd
-  React-jsiexecutor: 17e53fab8db222517c7a6522986be5726fa7efdb
-  React-jsinspector: a446e057cb98430d6224f5f16625ff58b07f8c24
-  React-jsitracing: dfce0845b202574237ead3ac8955bc2a47dc9bc5
-  React-logger: 25e306a41268de8c114dbf719783128bf9d148f7
-  React-Mapbuffer: 91fecb6fcfb24080faeda2ca53c86cc202801ed1
-  React-microtasksnativemodule: 22388ad9f03b4ec87ccb0838a4598db04449cdce
-  react-native-safe-area-context: 1e8741af95748c0210be8c08318d3ffd16955cb6
-  React-nativeconfig: f66d9f340cd1034cf9174717906339a1f16ba84d
-  React-NativeModulesApple: eaf0e2f7d2e89722b4d00e9cfe62c1318a62b84d
-  React-perflogger: 8d544f6f08826132c17c977dd4e2d22013da4b49
-  React-performancetimeline: a6db630741fe5b2cb06fbeb67a8a81fe87b9028d
-  React-RCTActionSheet: 3c650d15849e011f1a2daa684cd15238773da0d5
-  React-RCTAnimation: 94be30c394afc88b476d438fc43b5cb632765773
-  React-RCTAppDelegate: 85eb20b5688a8e92cb9cee32f3a402bedacde826
-  React-RCTBlob: 01e262665cdd25031aa56c53185d704f5cedeee3
-  React-RCTFabric: 03582f8fc1055bb5af8a2ecf9fa9a36e7b4201aa
-  React-RCTImage: fb1ff37b88a804418d429985dca72834e5f82f45
-  React-RCTLinking: 9f490438736c34af6b53e97a4ab073d1cdfdd364
-  React-RCTNetwork: 51c331d4083b227f202f261fba05d915647c0ddc
-  React-RCTSettings: 7c2ea63c20aed02f1f3a4a8be6182c4196186225
-  React-RCTText: b5d6a0c101d010e570d09730d3b2791261631417
-  React-RCTVibration: 0b9042f812764da52268b3c8d441fd4ae6546344
-  React-rendererconsistency: 500f2a2efd77cfc8dc5ff9830aa1376304ab2593
-  React-rendererdebug: f3e9ebbc371859e9073963fa9a20cc9e5326e0c2
-  React-rncore: 7f5301b0783cd67a27c930dd3abcb8389a8d5e20
-  React-RuntimeApple: ff0f37c1d94ba4f2f1fdcf240e8e9cec3ffc7a89
-  React-RuntimeCore: 162c19c159df8f3a7fd1332397bcc1231679b533
-  React-runtimeexecutor: edeeef0a40036445eede446cb4c43118e0059c29
-  React-RuntimeHermes: a288b47b56e790cba031021009a98d25b8162f25
-  React-runtimescheduler: b55eede6f6aa794545bd7090726e19ac22a68f80
-  React-utils: b0cff31137fe3feb0d675106f47293bdb3ee32c6
-  ReactCodegen: 3ca064fa159883d1c88374d8de0bd4ce6a0b997b
-  ReactCommon: 6e50c26db2dfacc49cb8bdc4e29b093dd737f01b
-  RNCAsyncStorage: a927b768986f83467b635cf6d7559e6edb46db7a
-  rnmapbox-maps: aa6ad2058f5917d5866c1dd71d654df53260cb39
-  RNScreens: 5a7e006d99a0611f758a723d37171e8e865ec0c8
+  RCT-Folly: 4464f4d875961fce86008d45f4ecf6cef6de0740
+  RCTDeprecation: bc01aeeb7acc314fc615a092001050d2e97c353a
+  RCTRequired: a511d4665e1f7ac044aad6486aa19d061bd2d365
+  RCTTypeSafety: e77969bb08d920251de98b1fc1df223d7039c1ff
+  React: d7184b3f39c367504fe746f26b9d68a1dff0085b
+  React-callinvoker: 45fca04012bbc94978d3655007339dcf1a5232fd
+  React-Core: 1f79ea2071f8ac48ff56b2aff9b849a5ef25292a
+  React-CoreModules: 67f22193aa2ada01f1497a68f16ee940f69661e5
+  React-cxxreact: 8ec017ccd74352fb814501707f81ba011d37459f
+  React-debug: 352c197132c626eddc6a1cd76e2697d1f2c8aaf2
+  React-defaultsnativemodule: 794b7b45463b7eb6550194d24dfab90ed6c6d240
+  React-domnativemodule: a25e07b5a169ff01847d46c51b66be67e9805fb9
+  React-Fabric: 2dfa25f9dc66beb09d2ed0d0d05061c2f42ba352
+  React-FabricComponents: f4551cba79793f3996265dfd56ca8031a75c091f
+  React-FabricImage: d464ec4461429c5d6aae9cda11635b4519aeb17b
+  React-featureflags: eb9f39413a653bd71a3eade6cafcefbc90bf7453
+  React-featureflagsnativemodule: e2dea6751669d670ed11ba3fda37ef0756cb2adb
+  React-graphics: ec9d045f0f25e588d97899f6f5b92aee3dbcca8d
+  React-hermes: 3a250e0191116de7ef757b74d39386e83c609775
+  React-idlecallbacksnativemodule: a401d60bda48a7cdbe2d4c5dc9e968dc37e2cc65
+  React-ImageManager: 4ea61bac6827c3339ded2e3ec0752865975a1b40
+  React-jserrorhandler: dd8ceb17410423e1b0f92742b105d8a4e30a988e
+  React-jsi: 66a12cec67ef950655b881d545018f08fa38a2d9
+  React-jsiexecutor: 79d2789093ab9b821ceee0e15a79b21115cdbd4d
+  React-jsinspector: 929691bef04499c30fca9374ed6954ca30919cff
+  React-jsitracing: 8003b1956692fdd34b737a95ffd8efbb12f9986f
+  React-logger: 0a81d1a40650bbdafb255fe4616edb83feed0ee9
+  React-Mapbuffer: b758bec0d9994c10a2841dfd5ec70673665fd3e2
+  React-microtasksnativemodule: f25dba9c8c3f8be0b3368d52b99abd6e381dee1d
+  react-native-safe-area-context: ab8f4a3d8180913bd78ae75dd599c94cce3d5e9a
+  React-nativeconfig: 7af2ccce165f86b233a9f9d63295f6207e62640e
+  React-NativeModulesApple: db1c1ee9dda26c9e58d824b4100fed83add82ae9
+  React-perflogger: 7c4e97b47d8bc58c03fad1a6b97d96181b59aa41
+  React-performancetimeline: ff6c906204f8efe69a43385389179812124fee3e
+  React-RCTActionSheet: 4d320d60f7343d15c681b4a3cb44fcf1e1d319a7
+  React-RCTAnimation: 523261cf9e7852bb627d12f89e423ee4839428fb
+  React-RCTAppDelegate: f0bcfe72d53195d16defd6b4cd8ce0591190c4a1
+  React-RCTBlob: c9aa6336d7a0195fa8960cdae1806a80d1a56083
+  React-RCTFabric: ff72c45356b1089ffc9d241618a04cbe0302ae0d
+  React-RCTImage: 2c4f61a43046c6098c17ed998189729b78e2c9e1
+  React-RCTLinking: 17fc004f09b77265e34351afc4a501d5dc3a4d17
+  React-RCTNetwork: 1590882206f723a2b50e7a492b592696e28dc05e
+  React-RCTSettings: bca2756c3b9ad9fefc789276be734fc49c3287fc
+  React-RCTText: ec488070f17fbab655abb3e102b79d1b1dc7b007
+  React-RCTVibration: d84f562d6b14a6cb2b082225f55f47cbd190482f
+  React-rendererconsistency: 10d49d3d663e52b28fac749543473207f0dd411e
+  React-rendererdebug: f3f5b36ae16b859ae4fc3354dc4436067265fff9
+  React-rncore: 2f9b482f627d8854a0b247e78119764d73d42335
+  React-RuntimeApple: 4749c1ffc84765252ee2d2f8d8fd0b01e4d5e63a
+  React-RuntimeCore: 1d44cd3189d61fa91ae6bb46e374c097ce5d8873
+  React-runtimeexecutor: 7f3bb572e57574f0e45338f2e33339d1b712e7ea
+  React-RuntimeHermes: 11f77829525f1371b2b9aad060f6bf31fafd60a1
+  React-runtimescheduler: 5bdbfb4e9c4efc508f9f1da8ef0a9e62362d9713
+  React-utils: 0ae17a2fe87b43a939826410d2fcbb28d44f1bfc
+  ReactCodegen: e9156d86a166f3e10dc8fb6160764048df3528bc
+  ReactCommon: 3ae48fa4cfa7052a270c2150ececfc94e541fb8a
+  RNCAsyncStorage: ec53e44dc3e75b44aa2a9f37618a49c3bc080a7a
+  rnmapbox-maps: 961b998761de9672c448aa17144b987410890992
+  RNScreens: 19719a9c326e925498ac3b2d35c4e50fe87afc06
   RNVectorIcons: fcc2f6cb32f5735b586e66d14103a74ce6ad61f8
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Turf: aa2ede4298009639d10db36aba1a7ebaad072a5e
-  Yoga: 443d55f29b54b0af35987cd13af8284f8cf8f31a
+  Yoga: 06fc4b2c3664ae0e278964b8fbcb0ee9d21f0a5a
 
 PODFILE CHECKSUM: 5532acdf047df467480d1d9f3a3bba674d33d8c2
 
-COCOAPODS: 1.14.2
+COCOAPODS: 1.15.2

--- a/example/ios/RNMapboxGLExample.xcodeproj/project.pbxproj
+++ b/example/ios/RNMapboxGLExample.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		414C0719E539AA79660FB51C /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = E25ADBA51759ED101B3FC90F /* PrivacyInfo.xcprivacy */; };
 		51C0260825301F99008C5283 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 51C0260725301F99008C5283 /* LaunchScreen.storyboard */; };
 		D8E751FC2B4D755200FEFCF7 /* DebugWorkaround.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E751FB2B4D755200FEFCF7 /* DebugWorkaround.swift */; };
 /* End PBXBuildFile section */
@@ -44,6 +45,7 @@
 		CC44ECBD0B2A438C84D89432 /* Ionicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Ionicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Ionicons.ttf"; sourceTree = "<group>"; };
 		D8E751FB2B4D755200FEFCF7 /* DebugWorkaround.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DebugWorkaround.swift; path = RNMapboxGLExample/DebugWorkaround.swift; sourceTree = "<group>"; };
 		E164F01DAD324AE386612513 /* EvilIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = EvilIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf"; sourceTree = "<group>"; };
+		E25ADBA51759ED101B3FC90F /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = RNMapboxGLExample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 		ED2971642150620600B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
 		FB39D57B6FFB431886261B00 /* MaterialIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = MaterialIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/MaterialIcons.ttf"; sourceTree = "<group>"; };
@@ -90,6 +92,7 @@
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				13B07FB71A68108700A75B9A /* main.m */,
 				D8E751FB2B4D755200FEFCF7 /* DebugWorkaround.swift */,
+				E25ADBA51759ED101B3FC90F /* PrivacyInfo.xcprivacy */,
 			);
 			name = RNMapboxGLExample;
 			sourceTree = "<group>";
@@ -227,6 +230,7 @@
 			files = (
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 				51C0260825301F99008C5283 /* LaunchScreen.storyboard in Resources */,
+				414C0719E539AA79660FB51C /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -258,24 +262,16 @@
 				"${PODS_ROOT}/Target Support Files/Pods-RNMapboxGLExample/Pods-RNMapboxGLExample-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/MapboxMaps/MapboxMaps.framework",
 				"${BUILT_PRODUCTS_DIR}/Turf/Turf.framework",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/Flipper-DoubleConversion/double-conversion.framework/double-conversion",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/Flipper-Glog/glog.framework/glog",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/MapboxCommon/MapboxCommon.framework/MapboxCommon",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/MapboxCoreMaps/MapboxCoreMaps.framework/MapboxCoreMaps",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/MapboxMobileEvents/MapboxMobileEvents.framework/MapboxMobileEvents",
-				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL-Universal/OpenSSL.framework/OpenSSL",
 				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermes.framework/hermes",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxMaps.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Turf.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/double-conversion.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/glog.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxCommon.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxCoreMaps.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MapboxMobileEvents.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermes.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -312,6 +308,8 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-RNMapboxGLExample/Pods-RNMapboxGLExample-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/RCT-Folly/RCT-Folly_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/RNCAsyncStorage/RNCAsyncStorage_resources.bundle",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/AntDesign.ttf",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Entypo.ttf",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf",
@@ -328,10 +326,15 @@
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Octicons.ttf",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/SimpleLineIcons.ttf",
 				"${PODS_ROOT}/../../node_modules/react-native-vector-icons/Fonts/Zocial.ttf",
-				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/React-Core_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-cxxreact/React-cxxreact_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/boost/boost_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/glog/glog_privacy.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCT-Folly_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RNCAsyncStorage_resources.bundle",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AntDesign.ttf",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Entypo.ttf",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EvilIcons.ttf",
@@ -348,7 +351,10 @@
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Octicons.ttf",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SimpleLineIcons.ttf",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Zocial.ttf",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-Core_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-cxxreact_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/boost_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/glog_privacy.bundle",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -526,6 +532,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CC = "";
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -552,6 +559,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				CXX = "";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = i386;
@@ -571,6 +579,8 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
+				LD = "";
+				LDPLUSPLUS = "";
 				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
 				LIBRARY_SEARCH_PATHS = (
 					"$(SDKROOT)/usr/lib/swift",
@@ -581,13 +591,10 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
 				SWIFT_VERSION = 5.0;
 				USE_HERMES = true;
 			};
@@ -597,6 +604,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CC = "";
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -623,6 +631,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
+				CXX = "";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = i386;
@@ -635,6 +644,8 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
+				LD = "";
+				LDPLUSPLUS = "";
 				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
 				LIBRARY_SEARCH_PATHS = (
 					"$(SDKROOT)/usr/lib/swift",
@@ -644,11 +655,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_CPLUSPLUSFLAGS = "$(inherited)";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-Wl",
-					"-ld_classic",
-				);
+				OTHER_LDFLAGS = "$(inherited)";
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.0;

--- a/example/ios/RNMapboxGLExample/PrivacyInfo.xcprivacy
+++ b/example/ios/RNMapboxGLExample/PrivacyInfo.xcprivacy
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/example/src/examples/Map/OfflineExample.tsx
+++ b/example/src/examples/Map/OfflineExample.tsx
@@ -106,6 +106,11 @@ const OfflineExample = () => {
           const options = {
             name: packName,
             styleURL: STYLE_URL,
+            tilesets: [
+              'mapbox://mapbox.mapbox-streets-v8',
+              'mapbox://mapbox.mapbox-terrain-dem-v1',
+              'mapbox://mapbox.country-boundaries-v1',
+            ], // Any tilesets that should be included in the offline download
             bounds: [
               [bounds[0], bounds[1]],
               [bounds[2], bounds[3]],

--- a/src/modules/offline/OfflineCreatePackOptions.ts
+++ b/src/modules/offline/OfflineCreatePackOptions.ts
@@ -5,6 +5,7 @@ export type OfflineCreatePackOptionsArgs = {
   name: string;
   styleURL: string;
   bounds: [GeoJSON.Position, GeoJSON.Position];
+  tilesets?: string[];
   minZoom?: number;
   maxZoom?: number;
   metadata?: Record<string, unknown>;
@@ -13,6 +14,7 @@ export type OfflineCreatePackOptionsArgs = {
 class OfflineCreatePackOptions {
   public readonly name: string;
   public readonly styleURL: string;
+  public readonly tilesets: string[] | undefined;
   public readonly bounds: string;
   public readonly minZoom: number | undefined;
   public readonly maxZoom: number | undefined;
@@ -27,6 +29,7 @@ class OfflineCreatePackOptions {
     this.minZoom = options.minZoom;
     this.maxZoom = options.maxZoom;
     this.metadata = this._makeMetadata(options.metadata);
+    this.tilesets = options.tilesets;
   }
 
   _assert(options: OfflineCreatePackOptionsArgs) {


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

<!-- OR, if you're implementing a new feature: -->

Added `tileset offline download`. Offline map packs can now include tilesets.

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [x] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [x] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios - TODO: Appears to be working on v10 only
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android - TODO: Appears to be working on v10 only
  - [ ] In New Architecture mode/android
- [x] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

Tilesets argument can now be passed into the offline download create pack call like this:

```jsx
const options = {
  name: packName,
  styleURL: STYLE_URL,
  tilesets: [
    'mapbox://mapbox.mapbox-streets-v8',
    'mapbox://mapbox.mapbox-terrain-dem-v1',
    'mapbox://mapbox.country-boundaries-v1',
  ], // Any tilesets that should be included in the offline download
  bounds: [
    [bounds[0], bounds[1]],
    [bounds[2], bounds[3]],
  ] as [[number, number], [number, number]],
  minZoom: 10,
  maxZoom: 20,
  metadata: {
    whatIsThat: 'foo',
  },
};
offlineManager.createPack(options, (region, status) =>
  console.log('=> progress callback region:', 'status: ', status),
);
```
