### PR TITLE
feat: introduce the 'flyAndZoomTo' event

### DIFF
--- a/src/components/Camera.tsx
+++ b/src/components/Camera.tsx
@@ -100,6 +100,7 @@ export interface CameraRef {
   flyTo: (centerCoordinate: Position, animationDuration?: number) => void;
   moveTo: (centerCoordinate: Position, animationDuration?: number) => void;
   zoomTo: (zoomLevel: number, animationDuration?: number) => void;
+  flyAndZoomTo: (centerCoordinate: Position, zoomLevel: number, animationDuration?: number) => void;
 }
 
 export type CameraStop = {
@@ -202,6 +203,7 @@ export type CameraAnimationMode =
   | 'easeTo'
   | 'linearTo'
   | 'moveTo'
+  | 'flyAndZoomTo'
   | 'none';
 
 /**
@@ -520,6 +522,20 @@ export const Camera = memo(
       };
       const zoomTo = useCallback(_zoomTo, [setCamera]);
 
+      const _flyAndZoomTo: CameraRef['flyAndZoomTo'] = (
+        _centerCoordinate,
+        _zoomLevel,
+        _animationDuration = 2000,
+      ) => {
+        setCamera({
+          type: 'CameraStop',
+          zoomLevel: _zoomLevel,
+          centerCoordinate: _centerCoordinate,
+          animationDuration: _animationDuration,
+        });
+      };
+      const flyAndZoomTo = useCallback(_flyAndZoomTo, [setCamera]);
+
       useImperativeHandle(ref, () => ({
         /**
          * Sets any camera properties, with default fallbacks if unspecified.
@@ -580,6 +596,19 @@ export const Camera = memo(
          * @param {number} animationDuration The transition duration
          */
         zoomTo,
+        /**
+         * Sets the camera to center and zoom around the provided coordinate using a realistic 'travel'
+         * animation, with optional duration.
+         *
+         * @example
+         * camera.flyAndZoomTo([lon, lat], 6);
+         * camera.flyAndZoomTo([lon, lat], 6, 12000);
+         *
+         *  @param {Position} centerCoordinate The coordinate to center in the view
+         *  @param {number} zoomLevel The target zoom
+         *  @param {number} animationDuration The transition duration
+         */
+        flyAndZoomTo,
       }));
 
       return (


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Added `flyAndZoomTo` that allows both the `zoomTo` and `flyTo` events to be fired as a single animation.

## Checklist

I have not updated any documentation just yet, as I wanted to confirm that the maintainers of this package agree with the implementation decisions. For example, the leaflet `flyTo` event just allows an extra parameter if you'd also want to handle zoom ([source](https://leafletjs.com/reference.html#map-flyto)). We could do the same thing for this package, but to prevent a breaking change the `zoomLevel` would have to become the 3rd parameter of the `flyTo` function, after `animationDuration`, which is not in line with the other events which all have the `animationDuration` as the last and optional param.

Please let me know if you agree with this PR, or if you'd like me to make any changes.