### PR TITLE
fix: events in bridgeless mode

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXRasterSourceManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXRasterSourceManager.kt
@@ -5,6 +5,8 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNMBXRasterSourceManagerInterface
+import com.rnmapbox.rnmbx.events.constants.EventKeys
+import com.rnmapbox.rnmbx.events.constants.eventMapOf
 import javax.annotation.Nonnull
 
 class RNMBXRasterSourceManager(reactApplicationContext: ReactApplicationContext) :
@@ -26,7 +28,10 @@ class RNMBXRasterSourceManager(reactApplicationContext: ReactApplicationContext)
     }
 
     override fun customEvents(): Map<String, String>? {
-        return null
+        return eventMapOf(
+            EventKeys.RASTER_SOURCE_LAYER_CLICK to "onMapboxRasterSourcePress",
+            EventKeys.MAP_ANDROID_CALLBACK to "onAndroidCallback"
+        )
     }
 
     companion object {

--- a/android/src/main/java/com/rnmapbox/rnmbx/events/constants/EventKeys.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/events/constants/EventKeys.kt
@@ -4,35 +4,37 @@ private fun ns(name: String): String {
     val namespace = "rct.mapbox"
     return String.format("%s.%s", namespace, name)
 }
+
 enum class EventKeys(val value: String) {
     // map events
-    MAP_CLICK(ns("map.press")),
-    MAP_LONG_CLICK(ns("map.longpress")),
-    MAP_ONCHANGE(ns("map.change")),
-    MAP_ON_LOCATION_CHANGE(ns("map.location.change")),
-    MAP_ANDROID_CALLBACK(ns("map.androidcallback")),
-    MAP_USER_TRACKING_MODE_CHANGE(ns("map.usertrackingmodechange")),
+    MAP_CLICK("topPress"),
+    MAP_LONG_CLICK("topLongPress"),
+    MAP_ONCHANGE("topMapChange"),
+    MAP_ON_LOCATION_CHANGE("topLocationChange"),
+    MAP_ANDROID_CALLBACK("topAndroidCallback"),
+    MAP_USER_TRACKING_MODE_CHANGE("topUserTrackingModeChange"),
 
     // point annotation events
-    POINT_ANNOTATION_SELECTED(ns("pointannotation.selected")),
-    POINT_ANNOTATION_DESELECTED(ns("pointannotation.deselected")),
-    POINT_ANNOTATION_DRAG_START(ns("pointannotation.dragstart")),
-    POINT_ANNOTATION_DRAG(ns("pointannotation.drag")),
-    POINT_ANNOTATION_DRAG_END(ns("pointannotation.dragend")),
+    POINT_ANNOTATION_SELECTED("topMapboxPointAnnotationSelected"),
+    POINT_ANNOTATION_DESELECTED("topMapboxPointAnnotationDeselected"),
+    POINT_ANNOTATION_DRAG_START("topMapboxPointAnnotationDragStart"),
+    POINT_ANNOTATION_DRAG("topMapboxPointAnnotationDrag"),
+    POINT_ANNOTATION_DRAG_END("topMapboxPointAnnotationDragEnd"),
 
     // source events
-    SHAPE_SOURCE_LAYER_CLICK(ns("shapesource.layer.pressed")),
-    VECTOR_SOURCE_LAYER_CLICK(ns("vectorsource.layer.pressed")),
-    RASTER_SOURCE_LAYER_CLICK(ns("rastersource.layer.pressed")),
+    SHAPE_SOURCE_LAYER_CLICK("topMapboxShapeSourcePress"),
+    VECTOR_SOURCE_LAYER_CLICK("topMapboxVectorSourcePress"),
+    RASTER_SOURCE_LAYER_CLICK("topMapboxRasterSourcePress"),
 
     // images event
-    IMAGES_MISSING(ns("images.missing")),
+    IMAGES_MISSING("topImageMissing"),
 
     // location events
+    // TODO: not sure about this one since it is not registered anywhere
     USER_LOCATION_UPDATE(ns("user.location.update")),
 
     // viewport events
-    VIEWPORT_STATUS_CHANGE(ns("viewport.statuschange"))
+    VIEWPORT_STATUS_CHANGE("topStatusChanged")
 }
 
 fun eventMapOf(vararg values: Pair<EventKeys, String>): Map<String, String> {

--- a/example/android/app/src/main/java/com/rnmapboxglexample/MainApplication.kt
+++ b/example/android/app/src/main/java/com/rnmapboxglexample/MainApplication.kt
@@ -29,7 +29,7 @@ class MainApplication : Application(), ReactApplication {
     SoLoader.init(this, false)
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
       // If you opted-in for the New Architecture, we load the native entry point for this app.
-      load(bridgelessEnabled=false)
+      load()
     }
   }
 }


### PR DESCRIPTION
## PR concerning New Architecture support in the library :tada:

We at [Software Mansion](https://swmansion.com/) have been working on [improving support](https://blog.swmansion.com/sunrising-new-architecture-in-the-new-expensify-app-729d237a02f5) for the new architecture for quite a while now. If you need help with anything related to New Architecture, like:
- [migrating your library](https://x.com/swmansion/status/1717512089323864275)
- [migrating your app](https://github.com/Expensify/App/pull/13767)
- [investigating issues](https://github.com/facebook/react-native/pulls?q=sort%3Aupdated-desc+is%3Apr+author%3Aj-piasecki+is%3Aopen)
- [improving performance](https://x.com/BBloniarz_/status/1808138585528303977)

or you just want to ask any questions, hit us up on [projects@swmansion.com](mailto:projects@swmansion.com)

---

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes events on bridgeless mode on Android in new arch. The naming convention is more strict there and events have to follow the convention of `on<Event>` to `top<Event>` naming.

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [x] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [x] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

Just run the example app on new arch now, I removed the `bridgelessEnabled=false` flag since `bridgeless` mode is the default and recommended option.
