### PR TITLE
fix: v11 Raster DEM source id

### DIFF
--- a/ios/RNMBX/RNMBXRasterDemSource.swift
+++ b/ios/RNMBX/RNMBXRasterDemSource.swift
@@ -30,8 +30,8 @@ public class RNMBXRasterDemSource : RNMBXSource {
 
   override func makeSource() -> Source
   {
-    #if RNMBX_11 // RNMBX_11_TODO
-    var result = SourceType(id: "raster-dem-source-id-todo")
+    #if RNMBX_11
+    var result = SourceType(id: self.id)
     #else
     var result = SourceType()
     #endif


### PR DESCRIPTION
## Description
Fixes the DEM raster source layer in Mapbox V11 from being used

Fixes #3567 

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [x] I have tested the new feature on `/example` app.
  - [x] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)
