### PR TITLE
chore: up default mapbox ios to 10.19 and android to 10.18.4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 def defaultMapboxMapsImpl = "mapbox"
-def defaultMapboxMapsVersion = "10.18.0"
+def defaultMapboxMapsVersion = "10.18.4"
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
@@ -163,7 +163,7 @@ dependencies {
         } else {
             msg = '@rnmapbox/maps: RNMapboxMapsImpl has invalid value - only mapbox supported - see https://github.com/rnmapbox/maps/wiki/Deprecated-RNMapboxImpl-Maplibre#android'
             logger.error(msg)
-            throw new GradleException(msg) 
+            throw new GradleException(msg)
         }
     }
 

--- a/rnmapbox-maps.podspec
+++ b/rnmapbox-maps.podspec
@@ -20,7 +20,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 ## Warning: these lines are scanned by autogenerate.js
-rnMapboxMapsDefaultMapboxVersion = '~> 10.18.2'
+rnMapboxMapsDefaultMapboxVersion = '~> 10.19.0'
 
 rnMapboxMapsDefaultImpl = 'mapbox'
 


### PR DESCRIPTION
## Description

upgrade default mapbox ios to 10.19 and android to 10.18.4

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

