### PR TITLE
Fix[iOS]: get visit bounds

### DIFF
--- a/ios/RNMBX/RNMBXMapViewManager.swift
+++ b/ios/RNMBX/RNMBXMapViewManager.swift
@@ -111,8 +111,11 @@ extension RNMBXMapViewManager {
 
     @objc public static func getVisibleBounds(
         _ view: RNMBXMapView,
-        resolver: @escaping RCTPromiseResolveBlock) {
-            resolver(["visibleBounds":  view.mapboxMap.coordinateBounds(for: view.bounds).toArray()])
+        resolver: @escaping RCTPromiseResolveBlock,
+        rejecter: @escaping RCTPromiseRejectBlock) {
+          view.withMapboxMap { map in
+            resolver(["visibleBounds": map.coordinateBounds(for: view.bounds).toArray()])
+          }
     }
 
 }

--- a/ios/RNMBX/RNMBXMapViewModule.mm
+++ b/ios/RNMBX/RNMBXMapViewModule.mm
@@ -87,7 +87,7 @@ RCT_EXPORT_METHOD(getPointInView:(nonnull NSNumber*)viewRef atCoordinate:(NSArra
 
 RCT_EXPORT_METHOD(getVisibleBounds:(nonnull NSNumber*)viewRef resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     [self withMapView:viewRef block:^(RNMBXMapView *view) {
-        [RNMBXMapViewManager getVisibleBounds:view resolver:resolve];
+        [RNMBXMapViewManager getVisibleBounds:view resolver:resolve rejecter:reject];
     } reject:reject methodName:@"getVisibleBounds"];
 }
 


### PR DESCRIPTION

## Description
Fixes runtime exception in getVisibleBounds (iOS only)

<img width="1365" alt="Screenshot 2024-10-22 at 22 11 13" src="https://github.com/user-attachments/assets/d524cd75-d6a3-48b3-acff-37d2c1077f4b">

<!-- OR, if you're implementing a new feature: -->

Added `your feature` that allows ...

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [x] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here  -->
```jsx

```
