### PR TITLE
fix(v11): default to ignoreCameraPadding with view annotations 

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -10,7 +10,7 @@ prepare_react_native_project!
 
 $RNMapboxMapsImpl = 'mapbox'
 if ENV['RNMBX11']
-  $RNMapboxMapsVersion = '= 11.4.0'
+  $RNMapboxMapsVersion = '= 11.7.0'
 end
 
 if ENV['CI_MAP_IMPL']

--- a/ios/RNMBX/RNMBXMarkerView.swift
+++ b/ios/RNMBX/RNMBXMarkerView.swift
@@ -229,6 +229,7 @@ public class RNMBXMarkerView: UIView, RNMBXMapComponent {
     )
     #if RNMBX_11
     options.allowOverlapWithPuck = allowOverlapWithPuck
+    options.ignoreCameraPadding = true
     #endif
     return options
   }


### PR DESCRIPTION
Fixes #3663

This means v11 will default to v10 behaviour where moving markar view out of paddings area will not change visibility.