### PR TITLE
feat: Add bounds to raster source

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXRasterSource.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXRasterSource.kt
@@ -34,4 +34,8 @@ class RNMBXRasterSource(context: Context?) : RNMBXTileSource<RasterSource?>(cont
     companion object {
         const val DEFAULT_TILE_SIZE = 512
     }
+
+    fun setSourceBounds(value: Array<Double>) {
+        bounds = value
+    }
 }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXRasterSourceManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXRasterSourceManager.kt
@@ -8,9 +8,7 @@ import com.facebook.react.viewmanagers.RNMBXRasterSourceManagerInterface
 import com.rnmapbox.rnmbx.events.constants.EventKeys
 import com.rnmapbox.rnmbx.events.constants.eventMapOf
 import javax.annotation.Nonnull
-import com.facebook.react.bridge.ReadableArray
-import com.rnmapbox.rnmbx.components.styles.RNMBXStyleImportManager
-import com.rnmapbox.rnmbx.components.styles.RNMBXStyleImportManager.Companion
+import com.facebook.react.bridge.ReadableType
 import com.rnmapbox.rnmbx.utils.Logger
 
 class RNMBXRasterSourceManager(reactApplicationContext: ReactApplicationContext) :
@@ -49,25 +47,21 @@ class RNMBXRasterSourceManager(reactApplicationContext: ReactApplicationContext)
 
     @ReactProp(name = "sourceBounds")
     override fun setSourceBounds(source: RNMBXRasterSource, value: Dynamic) {
-        if (value.type.name == "Array") {
-            val readableArray: ReadableArray = value.asArray()
-
-            if (readableArray.size() == 4) {
-                val bboxArray = Array(4) { i -> readableArray.getDouble(i) }
-
-                if(this.validateBbox(bboxArray)){
-                    source.setSourceBounds(bboxArray)
-                 } else {
-                    Logger.e(RNMBXRasterSourceManager.REACT_CLASS, "source bounds contain invalid bbox")
-                }
-
-                return
-            }
+        if (value.type != ReadableType.Array || value.asArray().size() != 4) {
+           Logger.e(REACT_CLASS, "source bounds must be an array with left, bottom, top, and right values")
+           return
         }
-        Logger.e(RNMBXRasterSourceManager.REACT_CLASS, "source bounds must be an array with left, bottom, top, and right values")
+        val bboxArray = Array(4) { i -> value.asArray().getDouble(i) }
+
+        if(!this.validateBbox(bboxArray)){
+            Logger.e(REACT_CLASS, "source bounds contain invalid bbox")
+            return
+        }
+
+        source.setSourceBounds(bboxArray)
     }
 
-    fun validateBbox(bbox: Array<Double>): Boolean {
+    private fun validateBbox(bbox: Array<Double>): Boolean {
         if (bbox.size != 4) return false
 
         val (swLng, swLat, neLng, neLat) = bbox

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXTileSource.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXTileSource.kt
@@ -13,6 +13,7 @@ abstract class RNMBXTileSource<T : Source?>(context: Context?) : RNMBXSource<T>(
     var attribution: String? = null
     var minZoomLevel: Int? = null
     var maxZoomLevel: Int? = null
+    var bounds: Array<Double>? = null
     var tMS = false
     fun buildTileset(): TileSet {
         val tileUrlTemplates =
@@ -34,6 +35,10 @@ abstract class RNMBXTileSource<T : Source?>(context: Context?) : RNMBXSource<T>(
         val attribution = this.attribution
         if (attribution != null) {
             builder.attribution(attribution)
+        }
+        if(bounds != null) {
+             val boundsArray = bounds!!.clone()
+             builder.bounds(Arrays.asList(*boundsArray))
         }
         return builder.build()
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXTileSource.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXTileSource.kt
@@ -36,9 +36,8 @@ abstract class RNMBXTileSource<T : Source?>(context: Context?) : RNMBXSource<T>(
         if (attribution != null) {
             builder.attribution(attribution)
         }
-        if(bounds != null) {
-             val boundsArray = bounds!!.clone()
-             builder.bounds(Arrays.asList(*boundsArray))
+        bounds?.let {
+           builder.bounds(it.toList())
         }
         return builder.build()
     }

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXRasterSourceManagerDelegate.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXRasterSourceManagerDelegate.java
@@ -49,6 +49,9 @@ public class RNMBXRasterSourceManagerDelegate<T extends View, U extends BaseView
       case "attribution":
         mViewManager.setAttribution(view, new DynamicFromObject(value));
         break;
+      case "sourceBounds":
+        mViewManager.setSourceBounds(view, new DynamicFromObject(value));
+        break;
       default:
         super.setProperty(view, propName, value);
     }

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXRasterSourceManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXRasterSourceManagerInterface.java
@@ -22,4 +22,5 @@ public interface RNMBXRasterSourceManagerInterface<T extends View> {
   void setTileSize(T view, Dynamic value);
   void setTms(T view, Dynamic value);
   void setAttribution(T view, Dynamic value);
+  void setSourceBounds(T view, Dynamic value);
 }

--- a/docs/RasterSource.md
+++ b/docs/RasterSource.md
@@ -113,6 +113,17 @@ FIX ME NO DESCRIPTION
 
 
   
+### sourceBounds
+
+```tsx
+Array
+```
+An array containing the longitude and latitude of the southwest and northeast corners of
+the source's bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`.
+When this property is included in a source, no tiles outside of the given bounds are requested by Mapbox GL.
+
+
+  
 
 
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -5052,6 +5052,13 @@
         "type": "React.ReactElement \\| React.ReactElement[]",
         "default": "none",
         "description": "FIX ME NO DESCRIPTION"
+      },
+      {
+        "name": "sourceBounds",
+        "required": false,
+        "type": "Array",
+        "default": "none",
+        "description": "An array containing the longitude and latitude of the southwest and northeast corners of\nthe source's bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`.\nWhen this property is included in a source, no tiles outside of the given bounds are requested by Mapbox GL."
       }
     ],
     "fileNameWithExt": "RasterSource.tsx",

--- a/example/src/examples/FillRasterLayer/RasterSource.js
+++ b/example/src/examples/FillRasterLayer/RasterSource.js
@@ -23,6 +23,10 @@ export default function RasterSourceExample() {
       <RasterSource
         id="stamen-watercolor"
         tileSize={256}
+        sourceBounds={[
+          -74.01010105570786, 40.7096750598196, -74.00028742807824,
+          40.71670107507063,
+        ]}
         tileUrlTemplates={['https://tile.openstreetmap.org/{z}/{x}/{y}.png']}
       />
       <RasterLayer

--- a/ios/RNMBX/RNMBXRasterSource.swift
+++ b/ios/RNMBX/RNMBXRasterSource.swift
@@ -5,16 +5,18 @@ public class RNMBXRasterSource : RNMBXSource {
   typealias SourceType = RasterSource
 
   @objc public var url: String? = nil
-  
+
   @objc public var tileUrlTemplates: [String]? = nil
-  
+
   @objc public var minZoomLevel: NSNumber?
   @objc public var maxZoomLevel: NSNumber?
   @objc public var tileSize: NSNumber?
-  
+
   @objc public var tms: Bool = false
-  
+
   @objc public var attribution: String?
+
+  @objc public var sourceBounds: [NSNumber]? = nil
 
   override func makeSource() -> Source
   {
@@ -28,27 +30,31 @@ public class RNMBXRasterSource : RNMBXSource {
     } else {
       result.tiles = tileUrlTemplates
     }
-    
+
     if let tileSize = tileSize {
       result.tileSize = tileSize.doubleValue
     }
-    
+
     if let minZoomLevel = minZoomLevel {
       result.minzoom = minZoomLevel.doubleValue
     }
-    
+
     if let maxZoomLevel = maxZoomLevel {
       result.maxzoom = maxZoomLevel.doubleValue
     }
-    
+
     if tms {
       result.scheme = .tms
     }
-    
+
     if let attribution = attribution {
       result.attribution = attribution
     }
-    
+
+    if let bounds = sourceBounds {
+      result.bounds = bounds.map { $0.doubleValue }
+    }
+
     return result
   }
 

--- a/ios/RNMBX/RNMBXRasterSourceComponentView.mm
+++ b/ios/RNMBX/RNMBXRasterSourceComponentView.mm
@@ -76,7 +76,7 @@ using namespace facebook::react;
 
 - (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
-  const auto &newProps = static_cast<const RNMBXRasterSourceProps &>(*props);    
+  const auto &newProps = static_cast<const RNMBXRasterSourceProps &>(*props);
     id idx = RNMBXConvertFollyDynamicToId(newProps.id);
     if (idx != nil) {
         _view.id = idx;
@@ -113,7 +113,11 @@ using namespace facebook::react;
     if (attribution != nil) {
         _view.attribution = attribution;
     }
-    
+    id sourceBounds = RNMBXConvertFollyDynamicToId(newProps.sourceBounds);
+    if (sourceBounds != nil) {
+       _view.sourceBounds = sourceBounds;
+    }
+
   [super updateProps:props oldProps:oldProps];
 }
 

--- a/ios/RNMBX/RNMBXRasterSourceViewManager.m
+++ b/ios/RNMBX/RNMBXRasterSourceViewManager.m
@@ -14,6 +14,6 @@ RCT_EXPORT_VIEW_PROPERTY(maxZoomLevel, NSNumber)
 
 RCT_EXPORT_VIEW_PROPERTY(tms, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(attribution, NSString)
-
+RCT_EXPORT_VIEW_PROPERTY(sourceBounds, NSArray)
 
 @end

--- a/src/components/RasterSource.tsx
+++ b/src/components/RasterSource.tsx
@@ -67,6 +67,12 @@ type Props = BaseProps & {
   attribution?: string;
 
   children?: React.ReactElement | React.ReactElement[];
+  /**
+   * An array containing the longitude and latitude of the southwest and northeast corners of
+   * the source's bounding box in the following order: `[sw.lng, sw.lat, ne.lng, ne.lat]`.
+   * When this property is included in a source, no tiles outside of the given bounds are requested by Mapbox GL.
+   */
+  sourceBounds?: number[];
 };
 
 type NativeProps = Props;

--- a/src/specs/RNMBXRasterSourceNativeComponent.ts
+++ b/src/specs/RNMBXRasterSourceNativeComponent.ts
@@ -14,6 +14,7 @@ export interface NativeProps extends ViewProps {
   tileSize: UnsafeMixed<Double>;
   tms: UnsafeMixed<boolean>;
   attribution: UnsafeMixed<string>;
+  sourceBounds: UnsafeMixed<Array<number>>;
 }
 
 export default codegenNativeComponent<NativeProps>(


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description


<!-- OR, if you're implementing a new feature: -->

Added `bounds support for RasterSource` . Now, you can limit the bounds within which raster tiles will render.

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [X] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [x] I have tested the new feature on `/example` app.
  - [x] In V11 mode/ios
  - [x] In New Architecture mode/ios
  - [x] In V11 mode/android
  - [x] In New Architecture mode/android
- [X] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video
![Screenshot_1730212439](https://github.com/user-attachments/assets/da698d61-7305-43e1-8715-94c40649a499)
![Simulator Screenshot - iPhone SE (3rd generation) - 2024-10-29 at 15 34 47](https://github.com/user-attachments/assets/57338869-b302-4df3-9aec-7865632538f7)

<!-- If it's a visual PR, we appreciate a screenshot or video -->

