### PR TITLE
Bugfix/unmount memory leak

### DIFF
--- a/docs/examples.json
+++ b/docs/examples.json
@@ -262,6 +262,16 @@
       },
       {
         "metadata": {
+          "title": "Map (un-)mount",
+          "tags": [],
+          "docs": "\nShowing and hiding the the map should not lead to increased memory consumption, use this example to check it on the profiler.\n"
+        },
+        "fullPath": "example/src/examples/Map/MapUnMount.tsx",
+        "relPath": "Map/MapUnMount.tsx",
+        "name": "MapUnMount"
+      },
+      {
+        "metadata": {
           "title": "Offline Example",
           "tags": [
             "offlineManager#createPack",

--- a/example/src/examples/Map/MapUnMount.tsx
+++ b/example/src/examples/Map/MapUnMount.tsx
@@ -1,0 +1,51 @@
+import React, { useState, useEffect } from 'react';
+import Mapbox from '@rnmapbox/maps';
+import { Button } from '@rneui/base';
+
+import sheet from '../../styles/sheet';
+import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
+
+const MapUnMount = () => {
+  const [isMounted, setIsMounted] = useState(true);
+
+  useEffect(() => {
+    Mapbox.locationManager.start();
+
+    return (): void => {
+      Mapbox.locationManager.stop();
+    };
+  }, []);
+
+  return (
+    <>
+      <Button
+        onPress={() => setIsMounted((mounted) => !mounted)}
+        title={isMounted ? 'unmount MapView' : 'mount MapView'}
+      />
+      {isMounted ? (
+        <Mapbox.MapView
+          styleURL={Mapbox.StyleURL.Dark}
+          style={sheet.matchParent}
+          testID={'show-map'}
+        >
+          <Mapbox.Camera followZoomLevel={12} followUserLocation />
+
+          <Mapbox.UserLocation />
+        </Mapbox.MapView>
+      ) : null}
+    </>
+  );
+};
+
+export default MapUnMount;
+
+/* end-example-doc */
+
+const metadata: ExampleWithMetadata['metadata'] = {
+  title: 'Map (un-)mount',
+  tags: [],
+  docs: `
+Showing and hiding the the map should not lead to increased memory consumption, use this example to check it on the profiler.
+`,
+};
+MapUnMount.metadata = metadata;

--- a/example/src/examples/Map/ShowMap.tsx
+++ b/example/src/examples/Map/ShowMap.tsx
@@ -15,11 +15,9 @@ const ShowMap = () => {
         data: (Mapbox.StyleURL as any)[key], // bad any, because enums
       };
     })
-    .sort(onSortOptions)
-    .concat({ data: 'mount', label: '(un)mount' });
+    .sort(onSortOptions);
 
   const [styleURL, setStyleURL] = useState({ styleURL: _mapOptions[0].data });
-  const [isMounted, setIsMounted] = useState(true);
 
   useEffect(() => {
     Mapbox.locationManager.start();
@@ -44,26 +42,17 @@ const ShowMap = () => {
         selectedIndex={_mapOptions.findIndex(
           (i) => i.data === styleURL.styleURL,
         )}
-        onPress={(index) => {
-          const { data } = _mapOptions[index];
-          if (data === 'mount') {
-            setIsMounted((m) => !m);
-            return;
-          }
-          onMapChange(index, data);
-        }}
+        onPress={(index) => onMapChange(index, _mapOptions[index].data)}
       />
-      {isMounted ? (
-        <Mapbox.MapView
-          styleURL={styleURL.styleURL}
-          style={sheet.matchParent}
-          testID={'show-map'}
-        >
-          <Mapbox.Camera followZoomLevel={12} followUserLocation />
+      <Mapbox.MapView
+        styleURL={styleURL.styleURL}
+        style={sheet.matchParent}
+        testID={'show-map'}
+      >
+        <Mapbox.Camera followZoomLevel={12} followUserLocation />
 
-          <Mapbox.UserLocation onPress={onUserMarkerPress} />
-        </Mapbox.MapView>
-      ) : null}
+        <Mapbox.UserLocation onPress={onUserMarkerPress} />
+      </Mapbox.MapView>
     </>
   );
 };

--- a/example/src/examples/Map/ShowMap.tsx
+++ b/example/src/examples/Map/ShowMap.tsx
@@ -15,9 +15,11 @@ const ShowMap = () => {
         data: (Mapbox.StyleURL as any)[key], // bad any, because enums
       };
     })
-    .sort(onSortOptions);
+    .sort(onSortOptions)
+    .concat({ data: 'mount', label: '(un)mount' });
 
   const [styleURL, setStyleURL] = useState({ styleURL: _mapOptions[0].data });
+  const [isMounted, setIsMounted] = useState(true);
 
   useEffect(() => {
     Mapbox.locationManager.start();
@@ -42,17 +44,26 @@ const ShowMap = () => {
         selectedIndex={_mapOptions.findIndex(
           (i) => i.data === styleURL.styleURL,
         )}
-        onPress={(index) => onMapChange(index, _mapOptions[index].data)}
+        onPress={(index) => {
+          const { data } = _mapOptions[index];
+          if (data === 'mount') {
+            setIsMounted((m) => !m);
+            return;
+          }
+          onMapChange(index, data);
+        }}
       />
-      <Mapbox.MapView
-        styleURL={styleURL.styleURL}
-        style={sheet.matchParent}
-        testID={'show-map'}
-      >
-        <Mapbox.Camera followZoomLevel={12} followUserLocation />
+      {isMounted ? (
+        <Mapbox.MapView
+          styleURL={styleURL.styleURL}
+          style={sheet.matchParent}
+          testID={'show-map'}
+        >
+          <Mapbox.Camera followZoomLevel={12} followUserLocation />
 
-        <Mapbox.UserLocation onPress={onUserMarkerPress} />
-      </Mapbox.MapView>
+          <Mapbox.UserLocation onPress={onUserMarkerPress} />
+        </Mapbox.MapView>
+      ) : null}
     </>
   );
 };

--- a/example/src/examples/Map/index.js
+++ b/example/src/examples/Map/index.js
@@ -6,6 +6,7 @@ export { default as PointInMapView } from './PointInMapView';
 export { default as ShowAndHideLayer } from './ShowAndHideLayer';
 export { default as ShowClick } from './ShowClick';
 export { default as ShowMap } from './ShowMap';
+export { default as MapUnMount } from './MapUnMount';
 export { default as ShowMapLocalStyle } from './ShowMapLocalStyle';
 export { default as ShowRegionDidChange } from './ShowRegionDidChange';
 export { default as SourceLayerVisibility } from './SourceLayerVisibility';

--- a/ios/RNMBX/RNMBXMapView.swift
+++ b/ios/RNMBX/RNMBXMapView.swift
@@ -154,7 +154,23 @@ class RNMBXCameraChanged : RNMBXEvent, RCTEvent {
 }
 
 @objc(RNMBXMapView)
-open class RNMBXMapView: UIView {
+open class RNMBXMapView: UIView, RCTInvalidating {
+  
+  public func invalidate() {
+    self.removeAllFeaturesFromMap(reason: .ViewRemoval)
+
+#if RNMBX_11
+    cancelables.forEach { $0.cancel() }
+    cancelables.removeAll()
+#endif
+    
+    _mapView.gestures.delegate = nil
+    _mapView.removeFromSuperview()
+    _mapView = nil
+    
+    self.removeFromSuperview()
+  }
+  
   var imageManager: ImageManager = ImageManager()
 
   var tapDelegate: IgnoreRNMBXMakerViewGestureDelegate? = nil


### PR DESCRIPTION
## Description

Fixes an issue that memory would not be freed up when the MapView was unmounted on iOS.

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [x] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [x] I have tested the new bugfix on `/example` app.
  - [x] In V11 mode/ios
  - [x] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video
without this memory consumption increases whenever a new MapView is mounted
![Bildschirmfoto 2024-11-29 um 13 01 16](https://github.com/user-attachments/assets/2122c4e3-ec74-4330-aae8-bf89199a0800)

with this fix memory is freed up when a MapView is unmounted
![Bildschirmfoto 2024-12-01 um 15 31 35](https://github.com/user-attachments/assets/bd93d0e8-67a4-49fe-8eae-9c227d55ebad)

## Component to reproduce the issue you're fixing
I've updated the ShowMap.tsx and added an (un)mount button there. Whenever you press this button and a MapView is mounted memory usage increases but never decreases when unmounting unless this fix is in place.