### PR TITLE
feat: add symbolZOffset to symbol layer

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/RNMBXStyleFactory.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/RNMBXStyleFactory.kt
@@ -194,6 +194,8 @@ object RNMBXStyleFactory {
                 setSymbolAvoidEdges(layer, styleValue)
               "symbolSortKey" ->
                 setSymbolSortKey(layer, styleValue)
+              "symbolZOffset" ->
+                setSymbolZOffset(layer, styleValue)
               "symbolZOrder" ->
                 setSymbolZOrder(layer, styleValue)
               "iconAllowOverlap" ->
@@ -1555,6 +1557,24 @@ object RNMBXStyleFactory {
             layer.symbolSortKey(value)
           } else {
             Logger.e("RNMBXSymbol", "value for symbolSortKey is null")
+          }
+      }
+    }
+
+    fun setSymbolZOffset(layer: SymbolLayer, styleValue: RNMBXStyleValue ) {
+      if (styleValue.isExpression()) {
+        val expression = styleValue.getExpression()
+        if (expression != null) {
+          layer.symbolZOffset(expression)
+        } else {
+          Logger.e("RNMBXSymbol", "Expression for symbolZOffset is null")
+        }
+      } else {
+          val value = styleValue.getDouble(VALUE_KEY)
+          if (value != null) {
+            layer.symbolZOffset(value)
+          } else {
+            Logger.e("RNMBXSymbol", "value for symbolZOffset is null")
           }
       }
     }

--- a/docs/SymbolLayer.md
+++ b/docs/SymbolLayer.md
@@ -150,6 +150,7 @@ This is now deprecated, use Image component instead.
 * <a href="#symbolplacement">symbolPlacement</a><br/>
 * <a href="#symbolspacing">symbolSpacing</a><br/>
 * <a href="#symbolavoidedges">symbolAvoidEdges</a><br/>
+* <a href="#symbolzoffset">symbolZOffset</a><br/>
 * <a href="#symbolsortkey">symbolSortKey</a><br/>
 * <a href="#symbolzorder">symbolZOrder</a><br/>
 * <a href="#iconallowoverlap">iconAllowOverlap</a><br/>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -5905,6 +5905,29 @@
         }
       },
       {
+        "name": "symbolZOffset",
+        "type": "number",
+        "values": [],
+        "units": "meters",
+        "default": 0,
+        "description": "Specifies an uniform elevation from the ground, in meters.",
+        "requires": [],
+        "disabledBy": [],
+        "allowedFunctionTypes": [],
+        "expression": {
+          "interpolated": true,
+          "parameters": [ 
+            "zoom",
+            "feature"
+          ]
+        },
+        "mbx": {
+          "fullName": "paint-symbol-symbol-z-offset",
+          "name": "symbol-z-offset",
+          "namespace": "paint"
+        }
+      },
+      {
         "name": "symbolZOrder",
         "type": "enum",
         "values": [

--- a/ios/RNMBX/RNMBXStyle.swift
+++ b/ios/RNMBX/RNMBXStyle.swift
@@ -177,6 +177,8 @@ func symbolLayer(layer: inout SymbolLayer, reactStyle:Dictionary<String, Any>, o
       self.setSymbolAvoidEdges(&layer, styleValue:styleValue);
     } else if (prop == "symbolSortKey") {
       self.setSymbolSortKey(&layer, styleValue:styleValue);
+    } else if (prop == "symbolZOffset") {
+      self.setSymbolZOffset(&layer, styleValue:styleValue);
     } else if (prop == "symbolZOrder") {
       self.setSymbolZOrder(&layer, styleValue:styleValue);
     } else if (prop == "iconAllowOverlap") {
@@ -1281,6 +1283,15 @@ func setSymbolSortKey(_ layer: inout SymbolLayer, styleValue: RNMBXStyleValue)
       
         
           layer.symbolSortKey = styleValue.mglStyleValueNumber();
+        
+      
+}
+
+func setSymbolZOffset(_ layer: inout SymbolLayer, styleValue: RNMBXStyleValue)
+{
+      
+        
+          layer.symbolZOffset = styleValue.mglStyleValueNumber();
         
       
 }

--- a/src/utils/MapboxStyles.d.ts
+++ b/src/utils/MapboxStyles.d.ts
@@ -690,6 +690,10 @@ export interface SymbolLayerStyleProps {
    */
   symbolSortKey?: Value<number, ['zoom', 'feature']>;
   /**
+   * Specifies an uniform elevation from the ground, in meters.
+   */
+  symbolZOffset?: Value<number, ['zoom', 'feature']>;
+  /**
    * Determines whether overlapping symbols in the same layer are rendered in the order that they appear in the data source or by their yPosition relative to the viewport. To control the order and prioritization of symbols otherwise, use `symbolSortKey`.
    */
   symbolZOrder?: Value<

--- a/src/utils/styleMap.ts
+++ b/src/utils/styleMap.ts
@@ -72,6 +72,7 @@ const styleMap = {
   symbolSpacing: StyleTypes.Constant,
   symbolAvoidEdges: StyleTypes.Constant,
   symbolSortKey: StyleTypes.Constant,
+  symbolZOffset: StyleTypes.Constant,
   symbolZOrder: StyleTypes.Enum,
   iconAllowOverlap: StyleTypes.Constant,
   iconIgnorePlacement: StyleTypes.Constant,

--- a/style-spec/v8.json
+++ b/style-spec/v8.json
@@ -1848,6 +1848,33 @@
       },
       "property-type": "data-driven"
     },
+    "symbol-z-offset": {
+      "type": "number",
+      "default": 0,
+      "minimum": 0,
+      "units": "meters",
+      "doc": "Specifies an uniform elevation from the ground, in meters.",
+      "sdk-support": {
+        "basic functionality": {
+          "js": "3.7.0",
+          "android": "11.7.0",
+          "ios": "11.7.0"
+        },
+        "data-driven styling": {
+          "js": "3.7.0",
+          "android": "11.7.0",
+          "ios": "11.7.0"
+        }
+      },
+      "expression": {
+        "interpolated": true,
+        "parameters": [
+          "zoom",
+          "feature"
+        ]
+      },
+      "property-type": "data-driven"
+    },
     "symbol-z-order": {
       "type": "enum",
       "values": {


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Add support for [`symbol-z-offset`](https://docs.mapbox.com/style-spec/reference/layers/#paint-symbol-symbol-z-offset)

I've filled the values in `v8.json` based on other values I saw there. I don't exactly know what each field should be (especially in `expression` and `property-type`), so I'm not 100% certain that these are correct. 

Also, at some point `yarn generate` added the values at the right places, but for some reason it doesn't anymore for me at the moment and removes everything except for the entry in `v8.json`. I'm probably doing something wrong here, but I've restored what was initially added by `yarn generate`.

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [x] I have tested the new feature on `/example` app.
  - Actually not in the `/example` app as I couldn't get it to build, but it does work in our own application FWIW (with both V11 and New Architecture enabled).
  - [x] In V11 mode/ios
  - [x] In New Architecture mode/ios
  - [x] In V11 mode/android
  - [x] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

https://github.com/user-attachments/assets/0bf4f925-ffd5-44ad-a89e-156d76dc5f38


https://github.com/user-attachments/assets/d3815d83-e705-43b7-a38b-ee3a3e3584fc

