### PR TITLE
fix nobridge obj-c type unsupported

### DIFF
--- a/ios/RNMBX/RNMBXLocationModule.swift
+++ b/ios/RNMBX/RNMBXLocationModule.swift
@@ -11,7 +11,7 @@ class RNMBXLocation: NSObject {
 
   var timestamp: Date? = nil
 
-  func toJSON() -> [String:Any] {
+  func toJSON() -> NSDictionary {
     return [
       "coords": [
         "longitude": location.coordinate.longitude,
@@ -512,8 +512,22 @@ class RNMBXLocationModule: RCTEventEmitter, LocationProviderRNMBXDelegate {
     }
   }
   
-  @objc func getLastKnownLocation() -> RNMBXLocation? {
-    return RNMBXLocation()
+  @objc func getLastKnownLocation() -> NSDictionary? {
+    let result = RNMBXLocation()
+    if let locationProvider = locationProvider as? LocationProviderRNMBX {
+      if let location = locationProvider.lastKnownLocation {
+        result.location = location
+        result.timestamp = location.timestamp
+      }
+      if let heading = locationProvider.lastKnownHeading {
+        result.heading = heading
+        if result.timestamp == nil ||
+            heading.timestamp.compare(result.timestamp!) == .orderedAscending {
+          result.timestamp = heading.timestamp
+        }
+      }
+    }
+    return result.toJSON()
   }
   
   @objc func setMinDisplacement(_ minDisplacement: CLLocationDistance) {


### PR DESCRIPTION
## Description

Fix `[Bug]: (NOBRIDGE) WARN locationManager Error: [Error: RNMBXLocationModule.getLastKnownLocation()Objective C type was unsupported.` as in non bridge mode we cannot pass custom objc types but only objc primiitives including a dict

Fixes #3707

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here  -->
```jsx

```
