### PR TITLE
Remove unused com.facebook.react.uimanager.MeasureSpecAssertions import

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewContent.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewContent.kt
@@ -2,7 +2,6 @@ package com.rnmapbox.rnmbx.components.annotation
 
 import android.content.Context
 import android.view.View.MeasureSpec
-import com.facebook.react.uimanager.MeasureSpecAssertions
 import com.facebook.react.views.view.ReactViewGroup
 
 class RNMBXMarkerViewContent(context: Context): ReactViewGroup(context) {


### PR DESCRIPTION
## Description

I'm currently looking into reducing visibility to the public API surface of React Native. I've noticed you are one of the few repos using `com.facebook.react.uimanager.MeasureSpecAssertions`; this import is currently unused in this codebase hence I'd like to remove it to reduce breaking changes across the ecosystem.

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] In V11 mode/android
- [x] In New Architecture mode/android

## Screenshot OR Video

N/A

## Component to reproduce the issue you're fixing

N/A
