### PR TITLE
fix(android): Add long click listener support for point annotations

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXPointAnnotationCoordinator.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXPointAnnotationCoordinator.kt
@@ -6,11 +6,11 @@ import com.mapbox.maps.plugin.annotation.AnnotationConfig
 import com.mapbox.maps.plugin.annotation.annotations
 import com.mapbox.maps.plugin.annotation.generated.OnPointAnnotationClickListener
 import com.mapbox.maps.plugin.annotation.generated.OnPointAnnotationDragListener
+import com.mapbox.maps.plugin.annotation.generated.OnPointAnnotationLongClickListener
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotation
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationManager
 import com.mapbox.maps.plugin.annotation.generated.PointAnnotationOptions
 import com.mapbox.maps.plugin.annotation.generated.createPointAnnotationManager
-import com.rnmapbox.rnmbx.components.annotation.RNMBXPointAnnotation
 import com.rnmapbox.rnmbx.utils.Logger
 
 class RNMBXPointAnnotationCoordinator(val mapView: MapView) {
@@ -26,6 +26,10 @@ class RNMBXPointAnnotationCoordinator(val mapView: MapView) {
     init {
         manager = mapView.annotations.createPointAnnotationManager(AnnotationConfig(layerId = "RNMBX-mapview-annotations"))
         manager.addClickListener(OnPointAnnotationClickListener { pointAnnotation ->
+            onAnnotationClick(pointAnnotation)
+            false
+        })
+        manager.addLongClickListener(OnPointAnnotationLongClickListener { pointAnnotation ->
             onAnnotationClick(pointAnnotation)
             false
         })


### PR DESCRIPTION
## Description

Fixes #3715 

<!-- OR, if you're implementing a new feature: -->

The issue appeared after a change in the Mapbox Android library in version [v10.18.4](https://github.com/mapbox/mapbox-maps-android/releases/tag/v10.18.4), specifically in this [commit](https://github.com/mapbox/mapbox-maps-android/commit/97d04fa880a75292652defad5e16131b51422eb6). After I added OnPointAnnotationLongClickListener to RNMBXPointAnnotationCoordinator, everything started working fine. I’m not sure why this change fixes the issue, so I’ve marked the PR as a draft.

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [X] I've read `CONTRIBUTING.md`
- [X] I updated the doc/other generated code with running `yarn generate` in the root folder
- [] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)