### PR TITLE
fix(ios): support 'url' prop for ShapeSource on iOS

### DIFF
--- a/ios/RNMBX/RNMBXShapeSourceComponentView.mm
+++ b/ios/RNMBX/RNMBXShapeSourceComponentView.mm
@@ -96,6 +96,7 @@ using namespace facebook::react;
 
   RNMBX_OPTIONAL_PROP_NSString(id)
   RNMBX_OPTIONAL_PROP_BOOL(existing)
+  RNMBX_OPTIONAL_PROP_NSString(url)
   RNMBX_OPTIONAL_PROP_NSString(shape)
   RNMBX_OPTIONAL_PROP_NSNumber(cluster)
   RNMBX_OPTIONAL_PROP_NSNumber(clusterRadius)


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description
support '**url**' prop for ShapeSource on iOS

Fixes #3863

<!-- OR, if you're implementing a new feature: -->

Added `your feature` that allows ...

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [X] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

Minimal fix, tested in own app (Android / iOS)