### PR TITLE
feat: Support to set style value of specific layer

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/NativeMapViewModule.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/NativeMapViewModule.kt
@@ -69,6 +69,20 @@ class NativeMapViewModule(context: ReactApplicationContext, val viewTagResolver:
         }
     }
 
+    override fun setStyleLayerProperty(
+        viewRef: ViewRefTag?,
+        layerId: String,
+        propertyName: String,
+        propertyValue: String,
+        promise: Promise
+    ) {
+        withMapViewOnUIThread(viewRef, promise) {
+            it.setStyleLayerProperty(layerId, propertyName, propertyValue)
+
+            promise.resolve(null)
+        }
+    }
+
     override fun getCenter(viewRef: ViewRefTag?, promise: Promise) {
         withMapViewOnUIThread(viewRef, promise) {
             it.getCenter(createCommandResponse(promise))

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapView.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapView.kt
@@ -1076,6 +1076,41 @@ open class RNMBXMapView(private val mContext: Context, var mManager: RNMBXMapVie
             }
         }
     }
+
+    fun setStyleLayerProperty(
+        layerId: String, 
+        propertyName: String, 
+        propertyValue: String
+    ): Boolean {
+        if (mMap == null) {
+            Logger.e("MapView", "setStyleLayerProperty, map is null")
+            return false
+        }
+
+        val style = mMap.getStyle()
+        if (style == null) {
+            Logger.e("MapView", "setStyleLayerProperty, style is null")
+            return false
+        }
+
+        try {
+            val result = style.setStyleLayerProperty(
+                layerId,
+                propertyName,
+                Value.valueOf(propertyValue)
+            )
+
+            if (result.isError) {
+                Logger.e("MapView", "setStyleLayerProperty error: ${result.error}")
+                return false
+            }
+
+            return true
+        } catch (e: Exception) {
+            Logger.e("MapView", "setStyleLayerProperty exception: ${e.message}")
+            return false
+        }
+    }
     // endregion
 
     companion object {

--- a/android/src/main/old-arch/com/rnmapbox/rnmbx/NativeMapViewModuleSpec.java
+++ b/android/src/main/old-arch/com/rnmapbox/rnmbx/NativeMapViewModuleSpec.java
@@ -49,6 +49,10 @@ public abstract class NativeMapViewModuleSpec extends ReactContextBaseJavaModule
 
   @ReactMethod
   @DoNotStrip
+  public abstract void setStyleLayerProperty(@Nullable Double viewRef, String layerId, String propertyName, String propertyValue, Promise promise);
+
+  @ReactMethod
+  @DoNotStrip
   public abstract void getCenter(@Nullable Double viewRef, Promise promise);
 
   @ReactMethod

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -730,4 +730,22 @@ await this._map.setSourceVisibility(false, 'composite', 'building')
 ```
 
 
+### setStyleLayerProperty(layerId, propertyName, propertyValue)
+
+Sets the value of a property for a specific layer referencing the specified `layerId`
+
+#### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+| `layerId` | `string` | `Yes` | layerId |
+| `propertyName` | `string` | `Yes` | propertyName |
+| `propertyValue` | `string` | `Yes` | propertyValue |
+
+
+
+```javascript
+await this._map.setStyleLayerProperty('my-layer', 'visibility', 'none')
+```
+
+
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3726,6 +3726,42 @@
         "examples": [
           "\nawait this._map.setSourceVisibility(false, 'composite', 'building')\n\n"
         ]
+      },
+      {
+        "name": "setStyleLayerProperty",
+        "docblock": "Sets the value of a property for a specific layer referencing the specified `layerId`\n\n@example\nawait this._map.setStyleLayerProperty('my-layer', 'visibility', 'none')\n\n@param {String} layerId - layerId\n@param {String} propertyName - propertyName\n@param {String} propertyValue - propertyValue",
+        "modifiers": [],
+        "params": [
+          {
+            "name": "layerId",
+            "description": "layerId",
+            "type": {
+              "name": "string"
+            },
+            "optional": false
+          },
+          {
+            "name": "propertyName",
+            "description": "propertyName",
+            "type": {
+              "name": "string"
+            },
+            "optional": false
+          },
+          {
+            "name": "propertyValue",
+            "description": "propertyValue",
+            "type": {
+              "name": "string"
+            },
+            "optional": false
+          }
+        ],
+        "returns": null,
+        "description": "Sets the value of a property for a specific layer referencing the specified `layerId`",
+        "examples": [
+          "\nawait this._map.setStyleLayerProperty('my-layer', 'visibility', 'none')\n\n"
+        ]
       }
     ],
     "props": [

--- a/ios/RNMBX/RNMBXMapView.swift
+++ b/ios/RNMBX/RNMBXMapView.swift
@@ -1514,6 +1514,18 @@ extension RNMBXMapView {
   }
 }
 
+extension RNMBXMapView {
+    func setStyleLayerProperty(layerId: String, propertyName: String, propertyValue: Any) -> Void {
+        let style = self.mapboxMap.style
+        
+        do {
+            try style.setLayerProperty(for: layerId, property: propertyName, value: propertyValue)
+        } catch {
+            Logger.log(level: .error, message: "Cannot set property \(propertyName) on layer: \(layerId)")
+        }
+    }
+}
+
 class RNMBXPointAnnotationManager : AnnotationInteractionDelegate {
   weak var selected : RNMBXPointAnnotation? = nil
   private var draggedAnnotation: PointAnnotation?

--- a/ios/RNMBX/RNMBXMapViewManager.swift
+++ b/ios/RNMBX/RNMBXMapViewManager.swift
@@ -55,6 +55,16 @@ extension RNMBXMapViewManager {
           view.setSourceVisibility(visible, sourceId: sourceId, sourceLayerId:sourceLayerId)
           resolver(nil)
     }
+
+    @objc public static func setStyleLayerProperty(_ view: RNMBXMapView,
+                                      layerId: String,
+                                      propertyName: String,
+                                      propertyValue: String,
+                                      resolver: @escaping RCTPromiseResolveBlock,
+                                      rejecter: @escaping RCTPromiseRejectBlock) -> Void {
+          view.setStyleLayerProperty(layerId: layerId, propertyName: propertyName, propertyValue: propertyValue)
+          resolver(nil)
+    }
     
     @objc public static func getCenter(_ view: RNMBXMapView, resolver: @escaping RCTPromiseResolveBlock, rejecter: @escaping RCTPromiseRejectBlock) {
       view.withMapboxMap { map in

--- a/ios/RNMBX/RNMBXMapViewModule.mm
+++ b/ios/RNMBX/RNMBXMapViewModule.mm
@@ -133,6 +133,17 @@ RCT_EXPORT_METHOD(setSourceVisibility:(nonnull NSNumber*)viewRef visible:(BOOL)v
     } reject:reject methodName:@"setSourceVisibility"];
 }
 
+RCT_EXPORT_METHOD(setStyleLayerProperty:(nonnull NSNumber*)viewRef
+               layerId:(NSString *)layerId
+               propertyName:(NSString *)propertyName
+               propertyValue:(id)propertyValue
+               resolve:(RCTPromiseResolveBlock)resolve
+               reject:(RCTPromiseRejectBlock)reject) {
+    [self withMapView:viewRef block:^(RNMBXMapView *view) {
+        [RNMBXMapViewManager setStyleLayerProperty:view layerId:layerId propertyName:propertyName propertyValue:propertyValue resolver:resolve rejecter:reject];
+    } reject:reject methodName:@"setStyleLayerProperty"];
+}
+
 RCT_EXPORT_METHOD(querySourceFeatures:(nonnull NSNumber*)viewRef sourceId:(NSString*)sourceId withFilter:(NSArray<id>*)withFilter withSourceLayerIDs:(NSArray<NSString*>*)withSourceLayerIDs resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
     [self withMapView:viewRef block:^(RNMBXMapView *view) {
         [RNMBXMapViewManager querySourceFeatures:view withSourceId:sourceId withFilter:withFilter withSourceLayerIds:withSourceLayerIDs resolver:resolve rejecter:reject];

--- a/setup-jest.js
+++ b/setup-jest.js
@@ -152,6 +152,7 @@ NativeModules.RNMBXMapViewModule = {
   takeSnap: jest.fn(),
   queryTerrainElevation: jest.fn(),
   setSourceVisibility: jest.fn(),
+  setStyleLayerProperty: jest.fn(),
   getCenter: jest.fn(),
   getCoordinateFromView: jest.fn(),
   getPointInView: jest.fn(),

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -922,6 +922,28 @@ class MapView extends NativeBridgeComponent(
     ]);
   }
 
+  /**
+   * Sets the value of a property for a specific layer referencing the specified `layerId`
+   *
+   * @example
+   * await this._map.setStyleLayerProperty('my-layer', 'visibility', 'none')
+   *
+   * @param {String} layerId - layerId
+   * @param {String} propertyName - propertyName
+   * @param {String} propertyValue - propertyValue
+   */
+  setStyleLayerProperty(
+    layerId: string,
+    propertyName: string,
+    propertyValue: string,
+  ) {
+    this._runNative<void>('setStyleLayerProperty', [
+      layerId,
+      propertyName,
+      propertyValue,
+    ]);
+  }
+
   _decodePayload<T>(payload: T | string): T {
     if (typeof payload === 'string') {
       return JSON.parse(payload);

--- a/src/specs/NativeMapViewModule.ts
+++ b/src/specs/NativeMapViewModule.ts
@@ -15,6 +15,12 @@ export interface Spec extends TurboModule {
     sourceId: string,
     sourceLayerId: string,
   ) => Promise<Object>;
+  setStyleLayerProperty: (
+    viewRef: Int32 | null, 
+    layerId: string, 
+    propertyName: string, 
+    propertyValue: string,
+  ) => Promise<Object>;
   getCenter: (viewRef: Int32 | null) => Promise<Object>;
   getCoordinateFromView: (
     viewRef: Int32 | null,


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes #<issue-number>

Added `setStyleLayerProperty support` that allows setting the value of a property for a specific layer referencing the specified `layerId`

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [x] I have tested the new feature on `/example` app.
  - [x] In V11 mode/ios
  - [x] In New Architecture mode/ios
  - [x] In V11 mode/android
  - [x] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)
