### PR TITLE
fix: use boolValue for hasPressListener prop

### DIFF
--- a/ios/RNMBX/RNMBXVectorSourceComponentView.mm
+++ b/ios/RNMBX/RNMBXVectorSourceComponentView.mm
@@ -40,7 +40,7 @@ using namespace facebook::react;
 - (void)prepareView
 {
     _view = [[RNMBXVectorSource alloc] init];
-      
+
     // capture weak self reference to prevent retain cycle
     __weak __typeof__(self) weakSelf = self;
 
@@ -124,13 +124,13 @@ using namespace facebook::react;
     }
     id hasPressListener = RNMBXConvertFollyDynamicToId(newProps.hasPressListener);
     if (hasPressListener != nil) {
-        _view.hasPressListener = hasPressListener;
+        _view.hasPressListener = [hasPressListener boolValue];
     }
     id hitbox = RNMBXConvertFollyDynamicToId(newProps.hitbox);
     if (hitbox != nil) {
         _view.hitbox = hitbox;
     }
-    
+
   [super updateProps:props oldProps:oldProps];
 }
 


### PR DESCRIPTION
## Description

Explicitly extracts the `boolValue` from the `hasPressListener` prop on `RNMBXVectorSourceComponentView`. This fixes an issue when running in New Architecture where all `VectorSource` layers are marked as `touchable` because `hasPressListener` is always `true` when bridged to Swift.

Functionally, this manifests as a bug wherein `VectorSource` components will incorrectly "capture" taps, even when no `onPress` handler is provided, also preventing the root `MapView:onPress` handler from firing.

Similar change as https://github.com/rnmapbox/maps/pull/3850.

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [x] I have tested the new feature on `/example` app.
  - [x] In V11 mode/ios
  - [x] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)