### PR TITLE
fix: register map change events after map fully loads

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -560,10 +560,6 @@ class MapView extends NativeBridgeComponent(
     );
   }
 
-  componentDidMount() {
-    this._setHandledMapChangedEvents(this.props);
-  }
-
   componentWillUnmount() {
     this._onDebouncedRegionWillChange.clear();
     this._onDebouncedRegionDidChange.clear();
@@ -1073,6 +1069,10 @@ class MapView extends NativeBridgeComponent(
     const func = this.props[propName] as (payload: object) => void;
     if (func && isFunction(func)) {
       func(payload);
+    }
+
+    if (propName === 'onDidFinishLoadingMap') {
+      this._setHandledMapChangedEvents(this.props);
     }
   }
 


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes #3836 
Events are registered too early in the component lifecycle before the native map is fully ready. These events should be registered after the map is fully loaded.

<!-- OR, if you're implementing a new feature: -->

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [x] I have tested the new feature on `/example` app.
  - [x] In V11 mode/ios
  - [x] In New Architecture mode/ios
  - [x] In V11 mode/android
  - [x] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)