### PR TITLE
fix(android): ignore camera padding for marker view

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerView.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerView.kt
@@ -186,7 +186,7 @@ class RNMBXMarkerView(context: Context?, private val mManager: RNMBXMarkerViewMa
             allowOverlapWithPuck(mAllowOverlapWithPuck)
             offsets(offset.dx, offset.dy)
             selected(mIsSelected)
-
+            ignoreCameraPadding(true)
         }
         return options
     }

--- a/android/src/main/mapbox-v11-compat/v10/com/rnmapbox/rnmbx/v11compat/Annotation.kt
+++ b/android/src/main/mapbox-v11-compat/v10/com/rnmapbox/rnmbx/v11compat/Annotation.kt
@@ -21,7 +21,11 @@ fun ViewAnnotationOptions.Builder.height(value: Double): ViewAnnotationOptions.B
   return this.height(value.toInt())
 }
 
-fun com.mapbox.maps.ViewAnnotationOptions.Builder.allowOverlapWithPuck(value: Boolean): ViewAnnotationOptions.Builder {
+fun ViewAnnotationOptions.Builder.allowOverlapWithPuck(value: Boolean): ViewAnnotationOptions.Builder {
+  return this;
+}
+
+fun ViewAnnotationOptions.Builder.ignoreCameraPadding(value: Boolean): ViewAnnotationOptions.Builder {
   return this;
 }
 


### PR DESCRIPTION
## Description

Fixes #3887 

## Checklist

- [X] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

See demo GIFs in #3887. Android now behaves the same as iOS (_marker views don't disappear anymore_).

## Component to reproduce the issue you're fixing

See demo code in #3887.