### PR TITLE
Fix #3889 : With react new arch, allowOverlap is always true

### DIFF
--- a/ios/RNMBX/RNMBXMarkerViewComponentView.mm
+++ b/ios/RNMBX/RNMBXMarkerViewComponentView.mm
@@ -11,6 +11,8 @@
 #import <react/renderer/components/rnmapbox_maps_specs/Props.h>
 #import <react/renderer/components/rnmapbox_maps_specs/RCTComponentViewHelpers.h>
 
+#import "RNMBXFabricPropConvert.h"
+
 using namespace facebook::react;
 
 @interface RNMBXMarkerViewComponentView () <RCTRNMBXMarkerViewViewProtocol>
@@ -68,28 +70,21 @@ using namespace facebook::react;
 
 - (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
-  const auto &newProps = static_cast<const RNMBXMarkerViewProps &>(*props);
-    
-    id coordinate = RNMBXConvertFollyDynamicToId(newProps.coordinate);
+  const auto &newViewProps = static_cast<const RNMBXMarkerViewProps &>(*props);
+  const auto &oldViewProps =
+      static_cast<const RNMBXMarkerViewProps &>(*oldProps);
+
+    id coordinate = RNMBXConvertFollyDynamicToId(newViewProps.coordinate);
     if (coordinate != nil) {
         _view.coordinate = coordinate;
     }
-    id anchor = RNMBXConvertFollyDynamicToId(newProps.anchor);
+    id anchor = RNMBXConvertFollyDynamicToId(newViewProps.anchor);
     if (anchor != nil) {
         _view.anchor = anchor;
     }
-    id allowOverlap = RNMBXConvertFollyDynamicToId(newProps.allowOverlap);
-    if (allowOverlap != nil) {
-        _view.allowOverlap = allowOverlap;
-    }
-    id allowOverlapWithPuck = RNMBXConvertFollyDynamicToId(newProps.allowOverlapWithPuck);
-    if (allowOverlapWithPuck != nil) {
-        _view.allowOverlapWithPuck = allowOverlapWithPuck;
-    }
-    id isSelected = RNMBXConvertFollyDynamicToId(newProps.isSelected);
-    if (isSelected != nil) {
-        _view.isSelected = isSelected;
-    }
+    RNMBX_REMAP_OPTIONAL_PROP_BOOL(allowOverlap, allowOverlap);
+    RNMBX_REMAP_OPTIONAL_PROP_BOOL(allowOverlapWithPuck, allowOverlapWithPuck);
+    RNMBX_REMAP_OPTIONAL_PROP_BOOL(isSelected, isSelected);
 
   [super updateProps:props oldProps:oldProps];
 }


### PR DESCRIPTION
This bug appears using the new react architecture. This is because of the id allowOverlap = RNMBXConvertFollyDynamicToId(newProps.allowOverlap); conversions that returns a pointer that is always true instead of the value of the pointed object according to #3730

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes #<issue-number>

<!-- OR, if you're implementing a new feature: -->

Added `your feature` that allows ...

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here  -->
```jsx

```
