### PR TITLE
feat(android): Add support for 16KB page size via NDK27 variant

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -167,7 +167,19 @@ dependencies {
     // Mapbox SDK
     customizableDependencies('RNMapboxMapsLibs') {
         if (safeExtGet("RNMapboxMapsImpl", defaultMapboxMapsImpl) == "mapbox") {
-            implementation "com.mapbox.maps:android:${safeExtGet("RNMapboxMapsVersion", defaultMapboxMapsVersion)}"
+            def targetSdk = safeExtGet("targetSdkVersion", 28)
+            def mapboxVersion = safeExtGet("RNMapboxMapsVersion", defaultMapboxMapsVersion)
+            
+            // Use NDK27 variant for Android 15+ (API 35+) to support 16KB page size
+            // Required by Google Play for apps targeting Android 15+ by November 1, 2025
+            // See: https://github.com/rnmapbox/maps/issues/3896
+            // Mapbox Docs: https://docs.mapbox.com/android/maps/guides/#ndk-27
+            if (targetSdk >= 35) {
+                implementation "com.mapbox.maps:android-ndk27:${mapboxVersion}"
+            } else {
+                implementation "com.mapbox.maps:android:${mapboxVersion}"
+            }
+            
             implementation 'com.mapbox.mapboxsdk:mapbox-sdk-turf:6.11.0'
             implementation 'androidx.asynclayoutinflater:asynclayoutinflater:1.0.0'
         } else {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -8,10 +8,10 @@ buildscript {
             RNMapboxMapsImpl = "mapbox"
             kotlinVersion = '1.6.21'
         } else if (System.getenv('CI_MAP_IMPL').equals('mapbox11')) {
-            RNMapboxMapsVersion = '11.4.1'
+            RNMapboxMapsVersion = '11.14.1'
             RNMapboxMapsImpl = "mapbox"
         } else if (project.hasProperty('RNMBX11') && project.getProperty('RNMBX11').toBoolean()) {
-            RNMapboxMapsVersion = '11.4.1'
+            RNMapboxMapsVersion = '11.14.1'
         }
 
         // Mapbox deps


### PR DESCRIPTION
## Summary
- Automatically use Mapbox Maps NDK27 variant when `targetSdkVersion >= 35`
- Fallback to regular variant for lower SDK versions
- Adds comprehensive documentation with links to relevant resources

## Context
Google requires native libraries to support 16KB page size for Android 15+ apps by November 1, 2025. The Mapbox Maps SDK provides an NDK27 variant specifically for this purpose.

## Implementation
The change conditionally selects the appropriate Mapbox SDK variant based on the target SDK version:
- SDK 35+ → `com.mapbox.maps:android-ndk27`
- SDK <35 → `com.mapbox.maps:android` (default)

## Test Plan
- [x] Verified NDK27 variant is used when `targetSdkVersion = 35`
- [x] Verified regular variant is used when `targetSdkVersion = 34`
- [x] Verified regular variant is used with default SDK (28)
- [ ] Test on actual device with Android 15
- [ ] Verify app submission to Google Play Console

Fixes #3896

🤖 Generated with [Claude Code](https://claude.ai/code)