### PR TITLE
fix: use older lifecycle APIs for RN 0.76 compatibility [Android]

### DIFF
--- a/android/src/main/lifecycle-compat/v26/com/rnmapbox/rnmbx/components/mapview/LifecycleCompat.kt
+++ b/android/src/main/lifecycle-compat/v26/com/rnmapbox/rnmbx/components/mapview/LifecycleCompat.kt
@@ -5,7 +5,7 @@ import android.view.View
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
-import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.lifecycle.ViewTreeLifecycleOwner
 
 /**
  * Lifecycle compatibility for Lifecycle 2.6+ which uses 'lifecycle' property
@@ -34,12 +34,12 @@ class RNMBXLifeCycle {
                     }
                 }
 
-                // Lifecycle 2.6+ uses property syntax
-                override val lifecycle: Lifecycle
-                    get() = lifecycleRegistry
+                override fun getLifecycle(): Lifecycle {
+                    return lifecycleRegistry
+                }
 
             }
-            view.setViewTreeLifecycleOwner(lifecycleOwner)
+            ViewTreeLifecycleOwner.set(view, lifecycleOwner)
         }
         lifecycleOwner?.handleLifecycleEvent(Lifecycle.Event.ON_START)
     }


### PR DESCRIPTION
- Replace setViewTreeLifecycleOwner with ViewTreeLifecycleOwner.set()
- Use getLifecycle() method instead of lifecycle property


## Description

Fixes #3909


## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)



```
