### PR TITLE
fix: Fix npm publish error by updating Node.js version in workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,20 +9,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Read .nvmrc
-        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
         id: nvm
       - name: Setup node ${{ steps.nvm.outputs.NVMRC }}
-        uses: actions/setup-node@v3.5.1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
-          registry-url: https://registry.npmjs.org/
-      - name: Setup Node
-        uses: actions/setup-node@v3.5.1
-        with:
-          node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies and build 🔧
-        run: npm install --force
+        run: yarn install --frozen-lockfile
       - name: Publish package on NPM 📦
         run: npm publish ${{ github.event.release.prerelease && '--tag next' || ''}}
         env:


### PR DESCRIPTION
The publish workflow was using Node.js 14.x which is incompatible with react-native-builder-bob's arktype dependency. This causes the ERR_REQUIRE_ESM error during npm publish.

Changes:
- Remove duplicate Node.js setup that was overriding the .nvmrc version
- Update to actions/setup-node@v4 for better compatibility
- Use yarn install instead of npm install for better module handling
- Fix deprecated set-output syntax to use GITHUB_OUTPUT

This fixes the "Error [ERR_REQUIRE_ESM]: Must use import to load ES Module" error that was preventing successful npm publishes.

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes #<issue-number>

<!-- OR, if you're implementing a new feature: -->

Added `your feature` that allows ...

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here  -->
```jsx

```
