### PR TITLE
New Architecture Enabled fix for `getLastKnownLocation` iOS method and Fixing `cloneReactChildrenWithProps` in Javascript Module

### DIFF
--- a/ios/RNMBX/RNMBXLocationModuleV11.swift
+++ b/ios/RNMBX/RNMBXLocationModuleV11.swift
@@ -11,8 +11,8 @@ class RNMBXLocation: NSObject {
 
   var timestamp: Date? = nil
 
-  func toJSON() -> [String:Any?] {
-    var coords: [String:Any?] = [:]
+  func toJSON() -> [String:Any] {
+    var coords: [String:Any] = [:]
     
     if let location = location {
       coords = coords.merging([
@@ -251,11 +251,11 @@ class RNMBXLocationModule: RCTEventEmitter {
     throttler.cancel()
   }
   
-  @objc func getLastKnownLocation() -> RNMBXLocation? {
+  @objc func getLastKnownLocation() -> [String: Any]? {
     let last = RNMBXLocation()
     last.heading = _locationProvider.latestHeading
     last.location = _locationProvider.getLastObservedLocation()
-    return last
+    return last.toJSON()
   }
   
   @objc

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   findNodeHandle,
   Platform,
@@ -70,14 +70,14 @@ export function runNativeMethod<ReturnType = NativeArg>(
 }
 
 export function cloneReactChildrenWithProps(
-  children: Parameters<typeof React.Children.map>[0],
+  children: ReactNode,
   propsToAdd: { [key: string]: string } = {},
 ) {
   if (!children) {
     return null;
   }
 
-  let foundChildren = null;
+  let foundChildren: typeof children[] | null = null;
 
   if (!Array.isArray(children)) {
     foundChildren = [children];
@@ -86,9 +86,19 @@ export function cloneReactChildrenWithProps(
   }
 
   const filteredChildren = foundChildren.filter((child) => !!child); // filter out falsy children, since some can be null
-  return React.Children.map(filteredChildren, (child) =>
-    React.cloneElement(child, propsToAdd),
-  );
+  return React.Children.map(filteredChildren, (child) => {
+    if (!React.isValidElement(child)) {
+      return child;
+    }
+
+    if (child.type === React.Fragment) {
+      // If the child is a Fragment, return it without adding props
+      return child;
+    }
+
+    // Otherwise, clone and add props
+    return React.cloneElement(child, propsToAdd);
+  });
 }
 
 export function resolveImagePath(imageRef: ImageSourcePropType): string {


### PR DESCRIPTION
Fixing the cloneReactChildrenWithProps method to handle those cases where the children property contains a child which is a React.Fragment, for which no prop can be added.

`getLastKnownLocation` for when New Architecture is enabled now returns an optional `[String:Any]?` value, which is compliant with Objective-C, in place of the `RNMBXLocation` type. This change is needed for the javascript invocation to actually work, when building the app with New Architecture enabled.

`toJSON` iOS method for builds with New Architecture enabled always returns a `[String:Any]` dictionary, hence there is no need for the dictionary value type to be `Any?`

## Description

Fixes an issue that prevented the proper retrieval of last known location when using New Architecture on iOS. In addition to that, another fix has been implemented to make sure that the `cloneReactChildrenWithProps` method handles properly those cases where the `children` property contains a child which is a `React.Fragment`, for which no prop can be added, and therefore should not be added, otherwise a crash would happen.

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [x] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [x] In V11 mode/ios
  - [x] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Component to reproduce the issue you're fixing

Since it's just a few lines change, thanks to which my app is not crashing anymore, I am omitting the test component in this description.