### PR TITLE
fix: react-native 0.77 compilation for android old-arch

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -157,7 +157,7 @@ android {
                 // Add lifecycle compatibility source sets
                 // Priority order:
                 // 1. User-defined override (RNMapboxMapsLifecycleCompat)
-                // 2. React Native version detection (0.78+ uses new API)
+                // 2. React Native version detection (0.77+ uses new API)
                 // 3. Conservative default (v25 for better compatibility)
                 
                 def lifecycleCompat = safeExtGet("RNMapboxMapsLifecycleCompat", null)
@@ -183,8 +183,8 @@ android {
                             def majorVersion = versionParts[0].toInteger()
                             def minorVersion = versionParts[1].toInteger()
                             
-                            // React Native < 0.78 needs the old lifecycle API
-                            if (majorVersion == 0 && minorVersion < 78) {
+                            // React Native < 0.77 needs the old lifecycle API
+                            if (majorVersion == 0 && minorVersion < 77) {
                                 logger.info("@rnmapbox/maps: Detected React Native ${rnVersion} - using v25 lifecycle compatibility (old API)")
                                 java.srcDirs += 'src/main/lifecycle-compat/v25'
                             } else {

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXAtmosphereManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXAtmosphereManagerInterface.java
@@ -11,8 +11,6 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXAtmosphereManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXAtmosphereManagerInterface<T extends View> {
   void setReactStyle(T view, Dynamic value);
 }

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXBackgroundLayerManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXBackgroundLayerManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXBackgroundLayerManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXBackgroundLayerManagerInterface<T extends View> {
   void setId(T view, Dynamic value);
   void setSourceID(T view, Dynamic value);
   void setExisting(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXCalloutManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXCalloutManagerInterface.java
@@ -10,8 +10,6 @@
 package com.facebook.react.viewmanagers;
 
 import android.view.View;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXCalloutManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXCalloutManagerInterface<T extends View> {
   // No props
 }

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXCameraManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXCameraManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXCameraManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXCameraManagerInterface<T extends View> {
   void setMaxBounds(T view, Dynamic value);
   void setAnimationDuration(T view, Dynamic value);
   void setAnimationMode(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXCircleLayerManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXCircleLayerManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXCircleLayerManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXCircleLayerManagerInterface<T extends View> {
   void setSourceID(T view, Dynamic value);
   void setExisting(T view, Dynamic value);
   void setFilter(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXCustomLocationProviderManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXCustomLocationProviderManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXCustomLocationProviderManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXCustomLocationProviderManagerInterface<T extends View> {
   void setCoordinate(T view, Dynamic value);
   void setHeading(T view, Dynamic value);
 }

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXFillExtrusionLayerManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXFillExtrusionLayerManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXFillExtrusionLayerManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXFillExtrusionLayerManagerInterface<T extends View> {
   void setId(T view, Dynamic value);
   void setSourceID(T view, Dynamic value);
   void setExisting(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXFillLayerManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXFillLayerManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXFillLayerManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXFillLayerManagerInterface<T extends View> {
   void setSourceID(T view, Dynamic value);
   void setExisting(T view, Dynamic value);
   void setFilter(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXHeatmapLayerManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXHeatmapLayerManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXHeatmapLayerManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXHeatmapLayerManagerInterface<T extends View> {
   void setSourceID(T view, Dynamic value);
   void setExisting(T view, Dynamic value);
   void setFilter(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXImageManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXImageManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXImageManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXImageManagerInterface<T extends View> {
   void setStretchX(T view, Dynamic value);
   void setStretchY(T view, Dynamic value);
   void setContent(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXImageSourceManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXImageSourceManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXImageSourceManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXImageSourceManagerInterface<T extends View> {
   void setId(T view, Dynamic value);
   void setExisting(T view, Dynamic value);
   void setUrl(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXImagesManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXImagesManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXImagesManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXImagesManagerInterface<T extends View> {
   void setImages(T view, Dynamic value);
   void setNativeImages(T view, Dynamic value);
   void setHasOnImageMissing(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXLightManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXLightManagerInterface.java
@@ -11,8 +11,6 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXLightManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXLightManagerInterface<T extends View> {
   void setReactStyle(T view, Dynamic value);
 }

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXLineLayerManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXLineLayerManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXLineLayerManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXLineLayerManagerInterface<T extends View> {
   void setSourceID(T view, Dynamic value);
   void setExisting(T view, Dynamic value);
   void setFilter(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXMapViewManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXMapViewManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXMapViewManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXMapViewManagerInterface<T extends View> {
   void setAttributionEnabled(T view, Dynamic value);
   void setAttributionPosition(T view, Dynamic value);
   void setLogoEnabled(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXMarkerViewContentManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXMarkerViewContentManagerInterface.java
@@ -10,8 +10,6 @@
 package com.facebook.react.viewmanagers;
 
 import android.view.View;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXMarkerViewContentManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXMarkerViewContentManagerInterface<T extends View> {
   // No props
 }

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXMarkerViewManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXMarkerViewManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXMarkerViewManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXMarkerViewManagerInterface<T extends View> {
   void setCoordinate(T view, Dynamic value);
   void setAnchor(T view, Dynamic value);
   void setAllowOverlap(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXModelLayerManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXModelLayerManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXModelLayerManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXModelLayerManagerInterface<T extends View> {
   void setSourceID(T view, Dynamic value);
   void setExisting(T view, Dynamic value);
   void setFilter(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXModelsManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXModelsManagerInterface.java
@@ -11,8 +11,6 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXModelsManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXModelsManagerInterface<T extends View> {
   void setModels(T view, Dynamic value);
 }

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXNativeUserLocationManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXNativeUserLocationManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXNativeUserLocationManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXNativeUserLocationManagerInterface<T extends View> {
   void setAndroidRenderMode(T view, Dynamic value);
   void setPuckBearing(T view, Dynamic value);
   void setPuckBearingEnabled(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXPointAnnotationManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXPointAnnotationManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXPointAnnotationManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXPointAnnotationManagerInterface<T extends View> {
   void setCoordinate(T view, Dynamic value);
   void setDraggable(T view, Dynamic value);
   void setId(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXRasterDemSourceManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXRasterDemSourceManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXRasterDemSourceManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXRasterDemSourceManagerInterface<T extends View> {
   void setId(T view, Dynamic value);
   void setExisting(T view, Dynamic value);
   void setUrl(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXRasterLayerManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXRasterLayerManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXRasterLayerManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXRasterLayerManagerInterface<T extends View> {
   void setSourceID(T view, Dynamic value);
   void setExisting(T view, Dynamic value);
   void setFilter(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXRasterSourceManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXRasterSourceManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXRasterSourceManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXRasterSourceManagerInterface<T extends View> {
   void setId(T view, Dynamic value);
   void setExisting(T view, Dynamic value);
   void setUrl(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXShapeSourceManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXShapeSourceManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXShapeSourceManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXShapeSourceManagerInterface<T extends View> {
   void setId(T view, Dynamic value);
   void setExisting(T view, Dynamic value);
   void setUrl(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXSkyLayerManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXSkyLayerManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXSkyLayerManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXSkyLayerManagerInterface<T extends View> {
   void setId(T view, Dynamic value);
   void setSourceID(T view, Dynamic value);
   void setExisting(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXStyleImportManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXStyleImportManagerInterface.java
@@ -12,9 +12,7 @@ package com.facebook.react.viewmanagers;
 import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXStyleImportManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXStyleImportManagerInterface<T extends View> {
   void setId(T view, @Nullable String value);
   void setExisting(T view, boolean value);
   void setConfig(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXSymbolLayerManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXSymbolLayerManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXSymbolLayerManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXSymbolLayerManagerInterface<T extends View> {
   void setSourceID(T view, Dynamic value);
   void setExisting(T view, Dynamic value);
   void setFilter(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXTerrainManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXTerrainManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXTerrainManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXTerrainManagerInterface<T extends View> {
   void setSourceID(T view, Dynamic value);
   void setReactStyle(T view, Dynamic value);
 }

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXVectorSourceManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXVectorSourceManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXVectorSourceManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXVectorSourceManagerInterface<T extends View> {
   void setId(T view, Dynamic value);
   void setExisting(T view, Dynamic value);
   void setUrl(T view, Dynamic value);

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXViewportManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXViewportManagerInterface.java
@@ -11,9 +11,7 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import com.facebook.react.bridge.Dynamic;
-import com.facebook.react.uimanager.ViewManagerWithGeneratedInterface;
-
-public interface RNMBXViewportManagerInterface<T extends View> extends ViewManagerWithGeneratedInterface {
+public interface RNMBXViewportManagerInterface<T extends View> {
   void setTransitionsToIdleUponUserInteraction(T view, Dynamic value);
   void setHasStatusChanged(T view, boolean value);
 }

--- a/scripts/codegen-old-arch.js
+++ b/scripts/codegen-old-arch.js
@@ -24,30 +24,45 @@ function javaOldArchDir() {
   return OLD_ARCH_DIR;
 }
 
-function fixOldArchJavaForRN72Compat(dir) {
-  // see https://github.com/rnmapbox/maps/issues/3193
+function fixOldArchJava(dir) {
   const files = fs.readdirSync(dir);
   files.forEach((file) => {
     const filePath = path.join(dir, file);
-    const fileExtension = path.extname(file);
-    if (fileExtension === '.java') {
-      let fileContent = fs.readFileSync(filePath, 'utf-8');
-      let newFileContent = fileContent.replace(
-        /extends ReactContextBaseJavaModule implements TurboModule/g,
-        'extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule',
-      );
-      if (fileContent !== newFileContent) {
-        // also insert an import line with `import com.facebook.react.bridge.ReactModuleWithSpec;`
-        newFileContent = newFileContent.replace(
-          /import com.facebook.react.bridge.ReactMethod;/,
-          'import com.facebook.react.bridge.ReactMethod;\nimport com.facebook.react.bridge.ReactModuleWithSpec;',
-        );
 
-        console.log(' => fixOldArchJava applied to:', filePath);
-        fs.writeFileSync(filePath, newFileContent, 'utf-8');
-      }
-    } else if (fs.lstatSync(filePath).isDirectory()) {
-      fixOldArchJavaForRN72Compat(filePath);
+    if (fs.lstatSync(filePath).isDirectory()) {
+      fixOldArchJava(filePath);
+      return;
+    }
+
+    if (path.extname(filePath) !== '.java') return;
+
+    let content = fs.readFileSync(filePath, 'utf-8');
+    let newContent = content;
+
+    // RN72: ensure modules implement ReactModuleWithSpec
+    // see https://github.com/rnmapbox/maps/issues/3193
+    newContent = newContent.replace(
+      /extends ReactContextBaseJavaModule implements TurboModule/g,
+      'extends ReactContextBaseJavaModule implements ReactModuleWithSpec, TurboModule',
+    );
+    // insert import if ReactMethod import exists but ReactModuleWithSpec is missing
+    if (/import com\.facebook\.react\.bridge\.ReactMethod;/.test(newContent) && !/import com\.facebook\.react\.bridge\.ReactModuleWithSpec;/.test(newContent)) {
+      newContent = newContent.replace(
+        /import com\.facebook\.react\.bridge\.ReactMethod;/,
+        'import com.facebook.react.bridge.ReactMethod;\nimport com.facebook.react.bridge.ReactModuleWithSpec;',
+      );
+    }
+
+    // RN77: for generated Interface files, remove ViewManagerWithGeneratedInterface import and extends
+    if (file.endsWith('Interface.java')) {
+      newContent = newContent
+        .replace(/import com\.facebook\.react\.uimanager\.ViewManagerWithGeneratedInterface;\s*\n?/g, '')
+        .replace(/extends\s+ViewManagerWithGeneratedInterface /g, '');
+    }
+
+    if (content !== newContent) {
+      fs.writeFileSync(filePath, newContent, 'utf-8');
+      console.log(' => fixOldArchJava applied to:', filePath);
     }
   });
 }
@@ -63,7 +78,7 @@ async function generateCodegenJavaOldArch() {
     `node ${RN_DIR}/scripts/generate-specs-cli.js --platform android --schemaPath ${GENERATED_DIR}/source/codegen/schema.json --outputDir ${GENERATED_DIR}/source/codegen --libraryName rnmapbox_maps_specs --javaPackageName com.rnmapbox.rnmbx`,
   );
 
-  fixOldArchJavaForRN72Compat(`${GENERATED_DIR}/source/codegen/java/`);
+  fixOldArchJava(`${GENERATED_DIR}/source/codegen/java/`);
   exec(`cp -rf ${GENERATED_DIR}/source/codegen/java/ ${OLD_ARCH_DIR}/`);
 }
 


### PR DESCRIPTION
## Description

We cannot compile for Android with the old-arch and React-Native 0.77
The lifecycle issue can be fixed with a workaround in build.gradle: `RNMapboxMapsLifecycleCompat= "v26"`

## Environment
react-native = 0.77.3
@rnmapbox/maps = 10.1.41
targetSdkVersion = 35
kotlinVersion = 2.0.21
RNMapboxMapsVersion = 11.13.5
newArchEnabled = false

## Compilation errors:
```shell
e: file:///mobile/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXCalloutManager.kt:9:1 Cannot access 'ViewManagerWithGeneratedInterface' which is a supertype of 'com.rnmapbox.rnmbx.components.annotation.RNMBXCalloutManager'. Check your module classpath for missing or conflicting dependencies.
e: file:///mobile/node_modules/@rnmapbox/maps/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXCalloutManager.kt:15:9 Cannot access 'ViewManagerWithGeneratedInterface' which is a supertype of 'com.rnmapbox.rnmbx.components.annotation.RNMBXCalloutManager'. Check your module classpath for missing or conflicting dependencies.
...
e: file:///mobile/node_modules/@rnmapbox/maps/android/src/main/lifecycle-compat/v25/com/rnmapbox/rnmbx/components/mapview/LifecycleCompat.kt:8:27 Unresolved reference 'ViewTreeLifecycleOwner'.
e: file:///mobile/node_modules/@rnmapbox/maps/android/src/main/lifecycle-compat/v25/com/rnmapbox/rnmbx/components/mapview/LifecycleCompat.kt:22:30 Class '<anonymous>' is not abstract and does not implement abstract member 'lifecycle'.
e: file:///mobile/node_modules/@rnmapbox/maps/android/src/main/lifecycle-compat/v25/com/rnmapbox/rnmbx/components/mapview/LifecycleCompat.kt:38:17 'getLifecycle' overrides nothing.
e: file:///mobile/node_modules/@rnmapbox/maps/android/src/main/lifecycle-compat/v25/com/rnmapbox/rnmbx/components/mapview/LifecycleCompat.kt:43:13 Unresolved reference 'ViewTreeLifecycleOwner'.
```

Fixes #3753

Inspiration from https://github.com/stripe/stripe-react-native/pull/1927

## Checklist

- [X] I've read `CONTRIBUTING.md`
- [X] I updated the doc/other generated code with running `yarn generate` in the root folder
- [X] I have tested the fix on `/example` app. (rn 0.80.2)
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In Old Arch V11 mode/android
  - [ ] In New Arch V11 mode/android
 - [X]  I have tested the fix on my app. (rn 0.77.3)
  - [X] In Old Arch V11 mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)