### PR TITLE
chore(ci): fix detox build

### DIFF
--- a/.github/workflows/ios-actions.yml
+++ b/.github/workflows/ios-actions.yml
@@ -125,6 +125,25 @@ jobs:
           brew install applesimutils
           brew install xcbeautify
 
+      - name: Setup xcodesorg/made/xcodes
+        run: |
+          brew install xcodes
+          brew install aria2
+
+      - name: Check and Download iOS Runtime
+        id: check-runtime
+        run: |
+          echo "Runtimes before download"
+          available_runtimes="$(xcrun simctl list runtimes)"
+          echo "$available_runtimes"
+
+          if echo "$available_runtimes" | grep -q "^iOS 18.4"; then
+            echo "iOS 18.4 runtime is already installed"
+          else
+            echo "iOS 18.4 runtime is not installed"
+            sudo xcodes runtimes install "iOS 18.4"
+          fi
+
       - name: Build for detox
         run: |
           xcodebuild -version

--- a/.github/workflows/ios-actions.yml
+++ b/.github/workflows/ios-actions.yml
@@ -122,7 +122,9 @@ jobs:
           brew install xcbeautify
 
       - name: Build for detox
-        run: set -o pipefail && NSUnbufferedIO=YES  yarn detox build --configuration ios.debug.ci 2>&1
+        run: |
+          xcodebuild -version
+          set -o pipefail && NSUnbufferedIO=YES  yarn detox build --configuration ios.debug.ci 2>&1
 
       - name: Test with detox
         if: inputs.NEW_ARCH != 1

--- a/.github/workflows/ios-actions.yml
+++ b/.github/workflows/ios-actions.yml
@@ -77,7 +77,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 16.2
+          xcode-version: 16.3
 
       - name: Cache node_modules
         uses: actions/cache@v3
@@ -142,7 +142,7 @@ jobs:
           else
             echo "iOS 18.2 runtime is not installed - installing..."
             sudo xcodes list
-            sudo xcodes select 16.2
+            sudo xcodes select 16.3
             sudo xcodes runtimes install "iOS 18.2"
             xcrun simctl list runtimes
             xcrun simctl create "iPhone 13 mini" "iPhone 13 mini" "com.apple.CoreSimulator.SimRuntime.iOS-18-2"

--- a/.github/workflows/ios-actions.yml
+++ b/.github/workflows/ios-actions.yml
@@ -75,10 +75,6 @@ jobs:
         with:
           node-version: ${{ inputs.NVMRC }}
 
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: 16.3
-
       - name: Cache node_modules
         uses: actions/cache@v3
         id: yarn-cache

--- a/.github/workflows/ios-actions.yml
+++ b/.github/workflows/ios-actions.yml
@@ -137,11 +137,15 @@ jobs:
           available_runtimes="$(xcrun simctl list runtimes)"
           echo "$available_runtimes"
 
-          if echo "$available_runtimes" | grep -q "^iOS 18.4"; then
-            echo "iOS 18.4 runtime is already installed"
+          if echo "$available_runtimes" | grep -q "^iOS 18.2"; then
+            echo "iOS 18.2 runtime is already installed"
           else
-            echo "iOS 18.4 runtime is not installed"
-            sudo xcodes runtimes install "iOS 18.4"
+            echo "iOS 18.2 runtime is not installed - installing..."
+            sudo xcodes list
+            sudo xcodes select 16.2
+            sudo xcodes runtimes install "iOS 18.2"
+            xcrun simctl list runtimes
+            xcrun simctl create "iPhone 13 mini" "iPhone 13 mini" "com.apple.CoreSimulator.SimRuntime.iOS-18-2"
           fi
 
       - name: Build for detox

--- a/.github/workflows/ios-actions.yml
+++ b/.github/workflows/ios-actions.yml
@@ -75,6 +75,10 @@ jobs:
         with:
           node-version: ${{ inputs.NVMRC }}
 
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: 16.2
+
       - name: Cache node_modules
         uses: actions/cache@v3
         id: yarn-cache

--- a/.github/workflows/ios-actions.yml
+++ b/.github/workflows/ios-actions.yml
@@ -137,15 +137,15 @@ jobs:
           available_runtimes="$(xcrun simctl list runtimes)"
           echo "$available_runtimes"
 
-          if echo "$available_runtimes" | grep -q "^iOS 18.2"; then
-            echo "iOS 18.2 runtime is already installed"
+          if echo "$available_runtimes" | grep -q "^iOS 18.4"; then
+            echo "iOS 18.4 runtime is already installed"
           else
-            echo "iOS 18.2 runtime is not installed - installing..."
+            echo "iOS 18.4 runtime is not installed - installing..."
             sudo xcodes list
             sudo xcodes select 16.3
-            sudo xcodes runtimes install "iOS 18.2"
+            sudo xcodes runtimes install "iOS 18.4"
             xcrun simctl list runtimes
-            xcrun simctl create "iPhone 13 mini" "iPhone 13 mini" "com.apple.CoreSimulator.SimRuntime.iOS-18-2"
+            xcrun simctl create "iPhone SE (3rd generation)" "iPhone SE (3rd generation)" "com.apple.CoreSimulator.SimRuntime.iOS-18-4"
           fi
 
       - name: Build for detox

--- a/.github/workflows/ios-actions.yml
+++ b/.github/workflows/ios-actions.yml
@@ -125,29 +125,6 @@ jobs:
           brew install applesimutils
           brew install xcbeautify
 
-      - name: Setup xcodesorg/made/xcodes
-        run: |
-          brew install xcodes
-          brew install aria2
-
-      - name: Check and Download iOS Runtime
-        id: check-runtime
-        run: |
-          echo "Runtimes before download"
-          available_runtimes="$(xcrun simctl list runtimes)"
-          echo "$available_runtimes"
-
-          if echo "$available_runtimes" | grep -q "^iOS 18.4"; then
-            echo "iOS 18.4 runtime is already installed"
-          else
-            echo "iOS 18.4 runtime is not installed - installing..."
-            sudo xcodes list
-            sudo xcodes select 16.3
-            sudo xcodes runtimes install "iOS 18.4"
-            xcrun simctl list runtimes
-            xcrun simctl create "iPhone SE (3rd generation)" "iPhone SE (3rd generation)" "com.apple.CoreSimulator.SimRuntime.iOS-18-4"
-          fi
-
       - name: Build for detox
         run: |
           xcodebuild -version

--- a/example/.detoxrc.js
+++ b/example/.detoxrc.js
@@ -18,7 +18,7 @@ module.exports = {
     },
     "ios.debug.ci": {
       type: "ios.app",
-      build: "FORCE_BUNDLING=1 xcodebuild -quiet -workspace ios/RNMapboxGLExample.xcworkspace -configuration Debug -scheme RNMapboxGLExample DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=1 GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS DEBUG_RCT_BUNDLE=1' -sdk iphonesimulator -derivedDataPath ios/build -destination 'platform=iOS Simulator,OS=18.4,arch=arm64,name=iPhone SE (3rd generation)'",
+      build: "FORCE_BUNDLING=1 xcodebuild -quiet -workspace ios/RNMapboxGLExample.xcworkspace -configuration Debug -scheme RNMapboxGLExample DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=1 GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS DEBUG_RCT_BUNDLE=1' -sdk iphonesimulator -derivedDataPath ios/build -destination 'platform=iOS Simulator,OS=18.4,name=iPhone SE (3rd generation)'",
       binaryPath: "ios/build/Build/Products/Debug-iphonesimulator/RNMapboxGLExample.app"
     },
   },

--- a/example/.detoxrc.js
+++ b/example/.detoxrc.js
@@ -18,7 +18,7 @@ module.exports = {
     },
     "ios.debug.ci": {
       type: "ios.app",
-      build: "FORCE_BUNDLING=1 xcodebuild -quiet -workspace ios/RNMapboxGLExample.xcworkspace -configuration Debug -scheme RNMapboxGLExample DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=1 GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS DEBUG_RCT_BUNDLE=1' -sdk iphonesimulator -derivedDataPath ios/build -destination 'platform=iOS Simulator,OS=18.4,name=iPhone SE (3rd generation)'",
+      build: "FORCE_BUNDLING=1 xcodebuild -quiet -workspace ios/RNMapboxGLExample.xcworkspace -configuration Debug -scheme RNMapboxGLExample DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=1 GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS DEBUG_RCT_BUNDLE=1' -sdk iphonesimulator -derivedDataPath ios/build -destination 'platform=iOS Simulator,OS=18.6,arch=arm64,name=iPhone SE (3rd generation)'",
       binaryPath: "ios/build/Build/Products/Debug-iphonesimulator/RNMapboxGLExample.app"
     },
   },

--- a/example/.detoxrc.js
+++ b/example/.detoxrc.js
@@ -18,7 +18,7 @@ module.exports = {
     },
     "ios.debug.ci": {
       type: "ios.app",
-      build: "FORCE_BUNDLING=1 xcodebuild -quiet -workspace ios/RNMapboxGLExample.xcworkspace -configuration Debug -scheme RNMapboxGLExample DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=1 GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS DEBUG_RCT_BUNDLE=1' -sdk iphonesimulator -derivedDataPath ios/build -destination 'platform=iOS Simulator,OS=18.2,name=iPhone 13 mini'",
+      build: "FORCE_BUNDLING=1 xcodebuild -quiet -workspace ios/RNMapboxGLExample.xcworkspace -configuration Debug -scheme RNMapboxGLExample DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=1 GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS DEBUG_RCT_BUNDLE=1' -sdk iphonesimulator -derivedDataPath ios/build -destination 'platform=iOS Simulator,OS=18.4,name=iPhone SE (3rd generation)'",
       binaryPath: "ios/build/Build/Products/Debug-iphonesimulator/RNMapboxGLExample.app"
     },
   },

--- a/example/.detoxrc.js
+++ b/example/.detoxrc.js
@@ -18,7 +18,7 @@ module.exports = {
     },
     "ios.debug.ci": {
       type: "ios.app",
-      build: "FORCE_BUNDLING=1 xcodebuild -quiet -workspace ios/RNMapboxGLExample.xcworkspace -configuration Debug -scheme RNMapboxGLExample DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=1 GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS DEBUG_RCT_BUNDLE=1' -sdk iphonesimulator -derivedDataPath ios/build -destination 'platform=iOS Simulator,OS=18.6,name=iPhone SE (3rd generation)'",
+      build: "FORCE_BUNDLING=1 xcodebuild -quiet -workspace ios/RNMapboxGLExample.xcworkspace -configuration Debug -scheme RNMapboxGLExample DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=1 GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS DEBUG_RCT_BUNDLE=1' -sdk iphonesimulator -derivedDataPath ios/build -destination 'platform=iOS Simulator,OS=18.6,arch=arm64,name=iPhone SE (3rd generation)'",
       binaryPath: "ios/build/Build/Products/Debug-iphonesimulator/RNMapboxGLExample.app"
     },
   },

--- a/example/.detoxrc.js
+++ b/example/.detoxrc.js
@@ -18,7 +18,7 @@ module.exports = {
     },
     "ios.debug.ci": {
       type: "ios.app",
-      build: "FORCE_BUNDLING=1 xcodebuild -quiet -workspace ios/RNMapboxGLExample.xcworkspace -configuration Debug -scheme RNMapboxGLExample DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=1 GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS DEBUG_RCT_BUNDLE=1' -sdk iphonesimulator -derivedDataPath ios/build -destination 'platform=iOS Simulator,OS=18.6,arch=arm64,name=iPhone SE (3rd generation)'",
+      build: "FORCE_BUNDLING=1 xcodebuild -quiet -workspace ios/RNMapboxGLExample.xcworkspace -configuration Debug -scheme RNMapboxGLExample DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=1 GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS DEBUG_RCT_BUNDLE=1' -sdk iphonesimulator -derivedDataPath ios/build -destination 'platform=iOS Simulator,OS=18.4,arch=arm64,name=iPhone SE (3rd generation)'",
       binaryPath: "ios/build/Build/Products/Debug-iphonesimulator/RNMapboxGLExample.app"
     },
   },
@@ -34,7 +34,7 @@ module.exports = {
       type: "ios.simulator",
       device: {
         type: "iPhone SE (3rd generation)",
-        os: "17.2"
+        os: "18.2"
       }
     },
   },

--- a/example/.detoxrc.js
+++ b/example/.detoxrc.js
@@ -18,7 +18,7 @@ module.exports = {
     },
     "ios.debug.ci": {
       type: "ios.app",
-      build: "FORCE_BUNDLING=1 xcodebuild -quiet -workspace ios/RNMapboxGLExample.xcworkspace -configuration Debug -scheme RNMapboxGLExample DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=1 GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS DEBUG_RCT_BUNDLE=1' -sdk iphonesimulator -derivedDataPath ios/build -destination 'platform=iOS Simulator,OS=18.4,name=iPhone SE (3rd generation)'",
+      build: "FORCE_BUNDLING=1 xcodebuild -quiet -workspace ios/RNMapboxGLExample.xcworkspace -configuration Debug -scheme RNMapboxGLExample DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=1 GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS DEBUG_RCT_BUNDLE=1' -sdk iphonesimulator -derivedDataPath ios/build -destination 'platform=iOS Simulator,name=iPhone 13 mini'",
       binaryPath: "ios/build/Build/Products/Debug-iphonesimulator/RNMapboxGLExample.app"
     },
   },

--- a/example/.detoxrc.js
+++ b/example/.detoxrc.js
@@ -18,7 +18,7 @@ module.exports = {
     },
     "ios.debug.ci": {
       type: "ios.app",
-      build: "FORCE_BUNDLING=1 xcodebuild -quiet -workspace ios/RNMapboxGLExample.xcworkspace -configuration Debug -scheme RNMapboxGLExample DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=1 GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS DEBUG_RCT_BUNDLE=1' -sdk iphonesimulator -derivedDataPath ios/build -destination 'platform=iOS Simulator,name=iPhone 13 mini'",
+      build: "FORCE_BUNDLING=1 xcodebuild -quiet -workspace ios/RNMapboxGLExample.xcworkspace -configuration Debug -scheme RNMapboxGLExample DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=1 GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS DEBUG_RCT_BUNDLE=1' -sdk iphonesimulator -derivedDataPath ios/build -destination 'platform=iOS Simulator,OS=18.4,name=iPhone 13 mini'",
       binaryPath: "ios/build/Build/Products/Debug-iphonesimulator/RNMapboxGLExample.app"
     },
   },

--- a/example/.detoxrc.js
+++ b/example/.detoxrc.js
@@ -18,7 +18,7 @@ module.exports = {
     },
     "ios.debug.ci": {
       type: "ios.app",
-      build: "FORCE_BUNDLING=1 xcodebuild -quiet -workspace ios/RNMapboxGLExample.xcworkspace -configuration Debug -scheme RNMapboxGLExample DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=1 GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS DEBUG_RCT_BUNDLE=1' -sdk iphonesimulator -derivedDataPath ios/build -destination 'platform=iOS Simulator,OS=18.4,name=iPhone 13 mini'",
+      build: "FORCE_BUNDLING=1 xcodebuild -quiet -workspace ios/RNMapboxGLExample.xcworkspace -configuration Debug -scheme RNMapboxGLExample DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=1 GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS DEBUG_RCT_BUNDLE=1' -sdk iphonesimulator -derivedDataPath ios/build -destination 'platform=iOS Simulator,OS=18.2,name=iPhone 13 mini'",
       binaryPath: "ios/build/Build/Products/Debug-iphonesimulator/RNMapboxGLExample.app"
     },
   },

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -82,34 +82,20 @@ target 'RNMapboxGLExample' do
     end
   end
 
-  if !ENV['CI']
-    post_install do |installer|
-      # See https://github.com/rnmapbox/maps/pull/2878
-      installer.pods_project.targets.each do |target|
-        target.build_configurations.each do |config|
-          config.build_settings["ONLY_ACTIVE_ARCH"] = "NO"
-        end
+  post_install do |installer|
+    # See https://github.com/rnmapbox/maps/pull/2878
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings["ONLY_ACTIVE_ARCH"] = "NO"
       end
-      react_native_post_install(
-        installer,
-        # Set `mac_catalyst_enabled` to `true` in order to apply patches
-        # necessary for Mac Catalyst builds
-        :mac_catalyst_enabled => false,
-        # :ccache_enabled => true
-      )
-      $RNMapboxMaps.post_install(installer)
     end
-  else
-    # CI configuration
-    post_install do |installer|
-      # https://github.com/facebook/react-native/blob/main/packages/react-native/scripts/react_native_pods.rb#L197-L202
-      react_native_post_install(
-        installer,
-        config[:reactNativePath],
-        :mac_catalyst_enabled => false
-      )
-      disable_optimizations_in_release(installer)
-      $RNMapboxMaps.post_install(installer)
-    end
+    react_native_post_install(
+      installer,
+      # Set `mac_catalyst_enabled` to `true` in order to apply patches
+      # necessary for Mac Catalyst builds
+      :mac_catalyst_enabled => false,
+      # :ccache_enabled => true
+    )
+    $RNMapboxMaps.post_install(installer)
   end
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2250,13 +2250,13 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - rnmapbox-maps (10.1.41):
+  - rnmapbox-maps (10.1.42-rc.0):
     - MapboxMaps (~> 10.19.0)
     - React
     - React-Core
-    - rnmapbox-maps/DynamicLibrary (= 10.1.41)
+    - rnmapbox-maps/DynamicLibrary (= 10.1.42-rc.0)
     - Turf
-  - rnmapbox-maps/DynamicLibrary (10.1.41):
+  - rnmapbox-maps/DynamicLibrary (10.1.42-rc.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2636,79 +2636,79 @@ SPEC CHECKSUMS:
   MapboxCoreMaps: 35685edba03e44468aed57c3dfd7f8795edafda8
   MapboxMaps: f87023cf0d72b180b40ea0b6fb4b2d7db6b73b71
   MapboxMobileEvents: d044b9edbe0ec7df60f6c2c9634fe9a7f449266b
-  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
+  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: 300c5eb91114d4339b0bb39505d0f4824d7299b7
   RCTRequired: e0446b01093475b7082fbeee5d1ef4ad1fe20ac4
   RCTTypeSafety: cb974efcdc6695deedf7bf1eb942f2a0603a063f
   React: e7a4655b09d0e17e54be188cc34c2f3e2087318a
   React-callinvoker: 62192daaa2f30c3321fc531e4f776f7b09cf892b
-  React-Core: b23cdaaa9d76389d958c06af3c57aa6ad611c542
-  React-CoreModules: 8e0f562e5695991e455abbebe1e968af71d52553
-  React-cxxreact: 6ccbe0cc2c652b29409b14b23cfb3cd74e084691
+  React-Core: c400b068fdb6172177f3b3fae00c10d1077244d7
+  React-CoreModules: 8e911a5a504b45824374eec240a78de7a6db8ca2
+  React-cxxreact: 06a91f55ac5f842219d6ca47e0f77187a5b5f4ac
   React-debug: 1834225a63b420b16e9b8b01ba5870aee96d0610
-  React-defaultsnativemodule: dd88d445d542d58ab61a8a29a7c1d2272dfed577
-  React-domnativemodule: fc3c24f4d3bb92770727ea48b4133dab77ded7f7
-  React-Fabric: 00fe76339e568da0d0497cc72daeeb01e463871a
-  React-FabricComponents: 7bb179ee55db68f88c007800b0ac62c930115a85
-  React-FabricImage: 21e01118011dd1e4ff3cdab20dbf57839cff52ee
-  React-featureflags: 6e67f2e252bc8ebb1d538c2ae8c14df432fe5fc0
-  React-featureflagsnativemodule: eff5216a5cde5df5d09243d15db1bc401474deef
-  React-graphics: 8539372da8754118a565251ed08a88fc70f69340
-  React-hermes: cc8c77acee1406c258622cd8abbee9049f6b5761
-  React-idlecallbacksnativemodule: 7349675d1ccbec876c29b0e206ac08c762baaa36
-  React-ImageManager: 4089d8ad52c86a8ae1d7591282fff1665ff5518b
-  React-jserrorhandler: 89a7a5fa8d04791e729119d1db03bf0ee85a9e29
-  React-jsi: ea5c640ea63c127080f158dac7f4f393d13d415c
-  React-jsiexecutor: cf7920f82e46fe9a484c15c9f31e67d7179aa826
-  React-jsinspector: 69e974b6313dbbb635ba503f2f4f2c389b30edbf
-  React-jsinspectorcdp: 231ddd5b7164c37589dcde3b8b6960136c891d6d
-  React-jsinspectornetwork: ff74911f79cf0a407a7f0ad0eeb0be64687ed815
-  React-jsinspectortracing: df2aa2d944bb3fa280d9c920b9a06664bca8a7e8
-  React-jsitooling: 77849c27e374a028ed8106e434a35267f6c6600b
-  React-jsitracing: 0dc6978e5b38c6e5e01e6aed484e4aec3f5f581b
-  React-logger: 7cfc7b1ae1f8e5fe5097f9c746137cc3a8fad4ce
-  React-Mapbuffer: 7018c5b7da5b13ed22fe55dae51d50187a00b2d7
-  React-microtasksnativemodule: 8ff9cb220a8efa625b5885996bd69e69db9edf02
-  react-native-safe-area-context: bd8e149c82b5a20cfd55e9775d82f1b5954b7e6d
-  React-NativeModulesApple: 37c08c3c54db55854de816b0df0f3683832be35a
+  React-defaultsnativemodule: 260aa990a9617c58df46c00321f396ad6ea7cc7f
+  React-domnativemodule: 9b3456a614c325da986867f27ca0eb34cb86828c
+  React-Fabric: fc7bcbac28989e6025ca6ae0988bff61bb78e5d3
+  React-FabricComponents: ae4a9c82bedf7c95bace1b215caf8685bcb32e23
+  React-FabricImage: c9cd4786180c150bb2a3841d65d360fd52be9ef8
+  React-featureflags: 534cd678e05848fbfc8c7288d4b14bcd8894b696
+  React-featureflagsnativemodule: bf7419f4d81226a3c4dd792445a03a6d703ce9a4
+  React-graphics: 18296c3559d54a42baaf7f2ae9c137a2e0fe9d51
+  React-hermes: b6e33fcd21aa7523dc76e62acd7a547e68c28a5b
+  React-idlecallbacksnativemodule: da8696a714ab16adb56bbfc9e0dfb4de7a713340
+  React-ImageManager: 052ccce122e4fd4e09c5d4f30e56381704dac439
+  React-jserrorhandler: 4c037384a32f57332abfa64181aeea915f9e0f0d
+  React-jsi: 3fde19aaf675c0607a0824c4d6002a4943820fd9
+  React-jsiexecutor: 4f898228240cf261a02568e985dfa7e1d7ad1dfb
+  React-jsinspector: 4ad0cdfa25a45d1362e2ddd06c78727d7964b34f
+  React-jsinspectorcdp: a649cc98a448e0fd8d54ac2a9e3e53177a1d8bd3
+  React-jsinspectornetwork: 2d701b6b152be202342f8269223046ec664c7d47
+  React-jsinspectortracing: cd898b3d7ea89f3e0ae10020fe3504bb4b327dd8
+  React-jsitooling: feca163583c69ba642cebb6b8ccd2f5e6732fed8
+  React-jsitracing: 1965307a468987b20d2a020f8fe782efa591ded7
+  React-logger: ea80169d826e0cd112fa4d68f58b2b3b968f1ecb
+  React-Mapbuffer: a5d550d1add940ed2bc65b20dc1413407bf1a63f
+  React-microtasksnativemodule: 5d00fefc19f0bc9a6432e5533683d6fc9c3da4e1
+  react-native-safe-area-context: 47c1782a327ca2affa9bec5a2f95534cbabb620a
+  React-NativeModulesApple: b22e6abb44d78270dfdfc7d85efe29e35e0333a7
   React-oscompat: 56d6de59f9ae95cd006a1c40be2cde83bc06a4e1
-  React-perflogger: 4008bd05a8b6c157b06608c0ea0b8bd5d9c5e6c9
-  React-performancetimeline: 9321ba7605abcfb3a2b497fd7cbaf5cfd8c7cf67
+  React-perflogger: 0633844e495d8b34798c9bf0cb32ce315f1d5c9f
+  React-performancetimeline: a04dae9154c32eda1891fcfa51cb2680a0421b3e
   React-RCTActionSheet: 49138012280ec3bbb35193d8d09adb8bc61c982e
-  React-RCTAnimation: ebfe7c62016d4c17b56b2cab3a221908ae46288d
-  React-RCTAppDelegate: 0108657ba9a19f6a1cd62dcd19c2c0485b3fc251
-  React-RCTBlob: 6cc309d1623f3c2679125a04a7425685b7219e6b
-  React-RCTFabric: 0a9ff5c9d1e1d7fc026bda6671180cbf56861c15
-  React-RCTFBReactNativeSpec: ff3e37e2456afc04211334e86d07bf20488df0ae
-  React-RCTImage: bb98a59aeed953a48be3f917b9b745b213b340ab
-  React-RCTLinking: d6e9795d4d75d154c1dd821fd0746cc3e05d6670
-  React-RCTNetwork: 5c8a7a2dd26728323189362f149e788548ac72bc
-  React-RCTRuntime: 96808e8fdce300a26c82d8c24174e33ba5210a7c
-  React-RCTSettings: b6a02d545ce10dd936b39914b32674db6e865307
-  React-RCTText: c7d9232da0e9b5082a99a617483d9164a9cd46e9
-  React-RCTVibration: fe636c985c1bf25e4a5b5b4d9315a3b882468a72
+  React-RCTAnimation: c7ed4a9d5a4e43c9b10f68bb43cd238c4a2e7e89
+  React-RCTAppDelegate: ea2ab6f4aef1489f72025b7128d8ab645b40eafb
+  React-RCTBlob: c052799460b245e1fffe3d1dddea36fa88e998a0
+  React-RCTFabric: e7acf005f8ed58d09f755b980ff83703b3af9fcf
+  React-RCTFBReactNativeSpec: ffb22c3ee3d359ae9245ca94af203845da9371ec
+  React-RCTImage: 59fc2571f4f109a77139924f5babee8f9cd639c9
+  React-RCTLinking: a045cb58c08188dce6c6f4621de105114b1b16ce
+  React-RCTNetwork: fc7115a2f5e15ae0aa05e9a9be726817feefb482
+  React-RCTRuntime: a7bca9be4f571586b2a9d4b57cf605421ffb6335
+  React-RCTSettings: 30d7dd7eae66290467a1e72bf42d927fa78c3884
+  React-RCTText: 755d59284e66c7d33bb4f0ccc428fe69110c3e74
+  React-RCTVibration: ffe019e588815df226f6f8ccdc65979f8b2bc440
   React-rendererconsistency: d20fcb77173861cc7d8356239823e3b36966fc31
-  React-renderercss: 56461d1e18db6a325048fdd04a51d68bd7ddb5a8
-  React-rendererdebug: fcd44d3eb8a02d74beee778bb142e724016c7375
+  React-renderercss: 63c720c32aaabd4788ac4136a071d49a052d8002
+  React-rendererdebug: a25ddddc73cabf50d814d8dfbc60d257b3d854c4
   React-rncore: bafb76fc01b78757a9592e92dbc227f9260bf0ac
-  React-RuntimeApple: 01e3ad08793efaa54cf85276457fa4a1f103d5b4
-  React-RuntimeCore: 5c4bec5bf402a99b134e55972f2f4e676c70b9ab
+  React-RuntimeApple: 45f8ef1b220a91b4fa4a79820b81990bffd95aa5
+  React-RuntimeCore: a0e095493b22ee3f6c639df4258cc5185674f0b8
   React-runtimeexecutor: b35de9cb7f5d19c66ea9b067235f95b947697ba5
-  React-RuntimeHermes: ba549a5834a6592d243b9a605530ecd7b6f5e79c
-  React-runtimescheduler: 9a9914d58caec7976aaae381cd2d997408f2260f
+  React-RuntimeHermes: 5b8126fffd1531475861dc0294a10b5f9793271a
+  React-runtimescheduler: 44fa97351d105afd0ffaecc4ed11cadad562deb6
   React-timing: 4f97958cc918f0af9444f93e4a7083415e6f5daf
-  React-utils: f491e2726eb8ced8af13893e1f77317f0fa9a954
-  ReactAppDependencyProvider: 8df342c127fd0c1e30e8b9f71ff814c22414a7c0
-  ReactCodegen: 439c427ccc115d71d16cc84256e5fbdc7fcef57a
-  ReactCommon: 592ef441605638b95e533653259254b4bd35ff4f
-  RNCAsyncStorage: 1f04c8d56558e533277beda29187f571cf7eecb2
-  rnmapbox-maps: f657dc1a89f6c821be7f86356db65c2e271a35d8
-  RNScreens: c63849403489bd068ea160f276fbc8416f19f2f7
-  RNVectorIcons: ef9b4b0b786053ebdd63ee2972f48de9633ba166
+  React-utils: 3c4b0b7788e4dc132d1bf918bc0615e2b21f36b3
+  ReactAppDependencyProvider: 6c9197c1f6643633012ab646d2bfedd1b0d25989
+  ReactCodegen: 9ea66ee246511816b72e9d6e380f884b7b3b99d7
+  ReactCommon: 7aca047f2f453a7d7f0adeccb63810d61829235a
+  RNCAsyncStorage: 767abb068db6ad28b5f59a129fbc9fab18b377e2
+  rnmapbox-maps: d6df11bbecca71ad07824334d8cf31b0f39d0a09
+  RNScreens: 75074e642b69b086813a943bdf63da7085fb2166
+  RNVectorIcons: 417c003b0ce7ac7748aa548720fd7127d1d74ded
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Turf: aa2ede4298009639d10db36aba1a7ebaad072a5e
   Yoga: 1c52fbd270869e556504def7e94fffbf67f53f7b
 
 PODFILE CHECKSUM: 94f2f531fc1800235b243c8fe6a7f76b8756da58
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/example/package.json
+++ b/example/package.json
@@ -66,7 +66,7 @@
     "@types/react-test-renderer": "^19.0.0",
     "babel-jest": "^29.6.3",
     "babel-plugin-module-resolver": "^5.0.0",
-    "detox": "^20.12.1",
+    "detox": "^20.40.2",
     "eslint": "^8.19.0",
     "glob-to-regexp": "^0.4.0",
     "jest": "^29.7.0",

--- a/rnmapbox-maps.podspec
+++ b/rnmapbox-maps.podspec
@@ -24,7 +24,16 @@ rnMapboxMapsDefaultMapboxVersion = '~> 10.19.0'
 
 rnMapboxMapsDefaultImpl = 'mapbox'
 
-new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+$RNMapboxMaps = Object.new
+def $RNMapboxMaps.compute_new_arch_enabled
+  if defined?(NewArchitectureHelper) && NewArchitectureHelper.respond_to?(:new_arch_enabled)
+    NewArchitectureHelper.new_arch_enabled
+  else
+    ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+  end
+end
+
+new_arch_enabled = $RNMapboxMaps.compute_new_arch_enabled
 
 # DEPRECATIONS
 
@@ -81,9 +90,6 @@ end
 if $MapboxImplVersion =~ /(~>|>=|=|>)?\S*11\./
   $RNMapboxMapsUseV11 = true
 end
-
-
-$RNMapboxMaps = Object.new
 
 def $RNMapboxMaps._check_no_mapbox_spm(project)
   pkg_class = Xcodeproj::Project::Object::XCRemoteSwiftPackageReference


### PR DESCRIPTION
## Description

Detox builds are broken on iOS. Try to fix them to make ci run on main again

```
<unknown>:0: error: module map file '/Users/runner/work/maps/maps/example/ios/build/Build/Products/Debug-iphonesimulator/rnmapbox-maps/rnmapbox_maps.modulemap' not found
```

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

