### PR TITLE
fix(ios): newarch - fix codegen config to use fabric components inste…

### DIFF
--- a/ios/RNMBX/RNMBXCameraViewManager.m
+++ b/ios/RNMBX/RNMBXCameraViewManager.m
@@ -1,3 +1,5 @@
+#if !RCT_NEW_ARCH_ENABLED
+
 #import "React/RCTBridgeModule.h"
 #import <React/RCTViewManager.h>
 #import <Foundation/Foundation.h>
@@ -22,3 +24,4 @@ RCT_EXPORT_VIEW_PROPERTY(onUserTrackingModeChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(stop, NSDictionary)
 
 @end
+#endif

--- a/ios/RNMBX/RNMBXCameraViewManager.swift
+++ b/ios/RNMBX/RNMBXCameraViewManager.swift
@@ -1,14 +1,16 @@
-import Foundation
-import MapboxMaps
+#if !RCT_NEW_ARCH_ENABLED
+  import Foundation
+  import MapboxMaps
 
-@objc(RNMBXCameraViewManager)
-class RNMBXCameraViewManager  : RCTViewManager {
+  @objc(RNMBXCameraViewManager)
+  class RNMBXCameraViewManager: RCTViewManager {
     @objc
     override static func requiresMainQueueSetup() -> Bool {
-        return false
+      return false
     }
-    
+
     override func view() -> UIView! {
-        return RNMBXCamera()
+      return RNMBXCamera()
     }
-}
+  }
+#endif

--- a/ios/RNMBX/RNMBXCircleLayerComponentView.mm
+++ b/ios/RNMBX/RNMBXCircleLayerComponentView.mm
@@ -32,7 +32,7 @@ using namespace facebook::react;
   if (self = [super initWithFrame:frame]) {
     static const auto defaultProps = std::make_shared<const RNMBXCircleLayerProps>();
     _props = defaultProps;
-      [self prepareView];
+    [self prepareView];
   }
 
   return self;

--- a/ios/RNMBX/RNMBXCircleLayerViewManager.m
+++ b/ios/RNMBX/RNMBXCircleLayerViewManager.m
@@ -1,3 +1,4 @@
+#ifndef RCT_NEW_ARCH_ENABLED
 #import <React/RCTBridgeModule.h>
 #import <React/RCTViewManager.h>
 
@@ -10,3 +11,4 @@ RCT_EXPORT_VIEW_PROPERTY(sourceLayerID, NSString)
 #include "CommonLayerProperties.H"
 
 @end
+#endif

--- a/ios/RNMBX/RNMBXCircleLayerViewManager.m
+++ b/ios/RNMBX/RNMBXCircleLayerViewManager.m
@@ -1,4 +1,4 @@
-#ifndef RCT_NEW_ARCH_ENABLED
+#if !RCT_NEW_ARCH_ENABLED
 #import <React/RCTBridgeModule.h>
 #import <React/RCTViewManager.h>
 

--- a/ios/RNMBX/RNMBXCircleLayerViewManager.swift
+++ b/ios/RNMBX/RNMBXCircleLayerViewManager.swift
@@ -1,3 +1,4 @@
+#if !RCT_NEW_ARCH_ENABLED
 @objc(RNMBXCircleLayerViewManager)
 class RNMBXCircleLayerViewManager: RCTViewManager {
     @objc
@@ -11,3 +12,4 @@ class RNMBXCircleLayerViewManager: RCTViewManager {
       return layer
     }
 }
+#endif

--- a/ios/RNMBX/RNMBXMapViewManager.m
+++ b/ios/RNMBX/RNMBXMapViewManager.m
@@ -1,3 +1,4 @@
+#if !RCT_NEW_ARCH_ENABLED
 #import <React/RCTBridgeModule.h>
 #import <React/RCTViewManager.h>
 
@@ -41,3 +42,4 @@ RCT_REMAP_VIEW_PROPERTY(onMapChange, reactOnMapChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(mapViewImpl, NSString)
 
 @end
+#endif

--- a/ios/RNMBX/RNMBXMapViewManager.swift
+++ b/ios/RNMBX/RNMBXMapViewManager.swift
@@ -1,230 +1,284 @@
 import MapboxMaps
 
 #if RNMBX_11
-extension QueriedSourceFeature {
-  var feature: Feature { return self.queriedFeature.feature }
-}
+  extension QueriedSourceFeature {
+    var feature: Feature { return self.queriedFeature.feature }
+  }
 #endif
 
-@objc(RNMBXMapViewManager)
-open class RNMBXMapViewManager: RCTViewManager {
+#if !RCT_NEW_ARCH_ENABLED
+
+  @objc(RNMBXMapViewManager)
+  open class RNMBXMapViewManager: RCTViewManager {
     @objc
     override public static func requiresMainQueueSetup() -> Bool {
-        return false
+      return false
     }
-  
+
     func defaultFrame() -> CGRect {
-        return UIScreen.main.bounds
+      return UIScreen.main.bounds
     }
-  
+
     override open func view() -> UIView! {
-        let result = RNMBXMapView(frame: self.defaultFrame(), eventDispatcher: self.bridge.eventDispatcher())
-        return result
+      let result = RNMBXMapView(
+        frame: self.defaultFrame(), eventDispatcher: self.bridge.eventDispatcher())
+      return result
     }
-}
+  }
+#else
+  @objc(RNMBXMapViewManager)
+  open class RNMBXMapViewManager: NSObject {
+
+  }
+#endif
 
 // MARK: - react methods
 
 extension RNMBXMapViewManager {
-    @objc public static func takeSnap(_ view: RNMBXMapView,
-                         writeToDisk: Bool,
-                         resolver: @escaping RCTPromiseResolveBlock) {
-        let uri = view.takeSnap(writeToDisk: writeToDisk)
-        resolver(["uri": uri.absoluteString])
+  @objc public static func takeSnap(
+    _ view: RNMBXMapView,
+    writeToDisk: Bool,
+    resolver: @escaping RCTPromiseResolveBlock
+  ) {
+    let uri = view.takeSnap(writeToDisk: writeToDisk)
+    resolver(["uri": uri.absoluteString])
+  }
+
+  @objc public static func queryTerrainElevation(
+    _ view: RNMBXMapView,
+    coordinates: [NSNumber],
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    let result = view.queryTerrainElevation(coordinates: coordinates)
+    if let result = result {
+      resolver(["data": NSNumber(value: result)])
+    } else {
+      resolver(nil)
     }
-  
-    @objc public static func queryTerrainElevation(_ view: RNMBXMapView,
-                                  coordinates: [NSNumber],
-                                  resolver: @escaping RCTPromiseResolveBlock,
-                                  rejecter: @escaping RCTPromiseRejectBlock
-    ) -> Void {
-       let result = view.queryTerrainElevation(coordinates: coordinates)
-       if let result = result {
-         resolver(["data": NSNumber(value: result)])
-       } else {
-         resolver(nil)
-       }
+  }
+
+  @objc public static func setSourceVisibility(
+    _ view: RNMBXMapView,
+    visible: Bool,
+    sourceId: String,
+    sourceLayerId: String?,
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    view.setSourceVisibility(visible, sourceId: sourceId, sourceLayerId: sourceLayerId)
+    resolver(nil)
+  }
+
+  @objc public static func getCenter(
+    _ view: RNMBXMapView, resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    view.withMapboxMap { map in
+      resolver([
+        "center": [
+          map.cameraState.center.longitude,
+          map.cameraState.center.latitude,
+        ]
+      ])
+    }
+  }
+
+  @objc public static func getCoordinateFromView(
+    _ view: RNMBXMapView,
+    atPoint point: CGPoint,
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    view.withMapboxMap { map in
+      let coordinates = map.coordinate(for: point)
+      resolver(["coordinateFromView": [coordinates.longitude, coordinates.latitude]])
     }
 
-    @objc public static func setSourceVisibility(_ view: RNMBXMapView,
-                                      visible: Bool,
-                                      sourceId: String,
-                                      sourceLayerId: String?,
-                                      resolver: @escaping RCTPromiseResolveBlock,
-                                      rejecter: @escaping RCTPromiseRejectBlock) -> Void {
-          view.setSourceVisibility(visible, sourceId: sourceId, sourceLayerId:sourceLayerId)
-          resolver(nil)
-    }
-    
-    @objc public static func getCenter(_ view: RNMBXMapView, resolver: @escaping RCTPromiseResolveBlock, rejecter: @escaping RCTPromiseRejectBlock) {
-      view.withMapboxMap { map in
-        resolver(["center": [
-            map.cameraState.center.longitude,
-            map.cameraState.center.latitude
-        ]])
-      }
-    }
+  }
 
-    @objc public static func getCoordinateFromView(
-        _ view: RNMBXMapView,
-        atPoint point: CGPoint,
-        resolver: @escaping RCTPromiseResolveBlock,
-        rejecter: @escaping RCTPromiseRejectBlock) {
-          view.withMapboxMap { map in
-            let coordinates = map.coordinate(for: point)
-            resolver(["coordinateFromView": [coordinates.longitude, coordinates.latitude]])
-          }
-            
+  @objc public static func getPointInView(
+    _ view: RNMBXMapView,
+    atCoordinate coordinate: [NSNumber],
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    view.withMapboxMap { map in
+      let coordinate = CLLocationCoordinate2DMake(
+        coordinate[1].doubleValue, coordinate[0].doubleValue)
+      let point = map.point(for: coordinate)
+      resolver(["pointInView": [(point.x), (point.y)]])
     }
+  }
 
-    @objc public static func getPointInView(
-        _ view: RNMBXMapView,
-        atCoordinate coordinate: [NSNumber],
-        resolver: @escaping RCTPromiseResolveBlock,
-        rejecter: @escaping RCTPromiseRejectBlock) {
-          view.withMapboxMap { map in
-              let coordinate = CLLocationCoordinate2DMake(coordinate[1].doubleValue, coordinate[0].doubleValue)
-              let point = map.point(for: coordinate)
-              resolver(["pointInView": [(point.x), (point.y)]])
-          }
-      }
+  @objc public static func setHandledMapChangedEvents(
+    _ view: RNMBXMapView,
+    events: [String],
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    view.handleMapChangedEvents = Set(
+      events.compactMap {
+        RNMBXEvent.EventType(rawValue: $0)
+      })
+    resolver(nil)
+  }
 
-    @objc public static func setHandledMapChangedEvents(
-        _ view: RNMBXMapView,
-        events: [String],
-        resolver: @escaping RCTPromiseResolveBlock,
-        rejecter: @escaping RCTPromiseRejectBlock) {
-          view.handleMapChangedEvents = Set(events.compactMap {
-            RNMBXEvent.EventType(rawValue: $0)
-          })
-          resolver(nil);
-      }
-
-    @objc public static func getZoom(
-        _ view: RNMBXMapView,
-        resolver: @escaping RCTPromiseResolveBlock,
-        rejecter: @escaping RCTPromiseRejectBlock) {
-          view.withMapboxMap { map in
-              resolver(["zoom": map.cameraState.zoom])
-          }
+  @objc public static func getZoom(
+    _ view: RNMBXMapView,
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    view.withMapboxMap { map in
+      resolver(["zoom": map.cameraState.zoom])
     }
+  }
 
-    @objc public static func getVisibleBounds(
-        _ view: RNMBXMapView,
-        resolver: @escaping RCTPromiseResolveBlock,
-        rejecter: @escaping RCTPromiseRejectBlock) {
-          view.withMapboxMap { map in
-            resolver(["visibleBounds": map.coordinateBounds(for: view.bounds).toArray()])
-          }
+  @objc public static func getVisibleBounds(
+    _ view: RNMBXMapView,
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    view.withMapboxMap { map in
+      resolver(["visibleBounds": map.coordinateBounds(for: view.bounds).toArray()])
     }
+  }
 
 }
 
 // MARK: - queryRenderedFeatures
 
 extension RNMBXMapViewManager {
-    @objc public static func queryRenderedFeaturesAtPoint(
-        _ view: RNMBXMapView,
-        atPoint point: [NSNumber],
-        withFilter filter: [Any]?,
-        withLayerIDs layerIDs: [String]?,
-        resolver: @escaping RCTPromiseResolveBlock,
-        rejecter: @escaping RCTPromiseRejectBlock) -> Void {
-          view.withMapboxMap { map in
-              let point = CGPoint(x: CGFloat(point[0].floatValue), y: CGFloat(point[1].floatValue))
+  @objc public static func queryRenderedFeaturesAtPoint(
+    _ view: RNMBXMapView,
+    atPoint point: [NSNumber],
+    withFilter filter: [Any]?,
+    withLayerIDs layerIDs: [String]?,
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    view.withMapboxMap { map in
+      let point = CGPoint(x: CGFloat(point[0].floatValue), y: CGFloat(point[1].floatValue))
 
-              logged("queryRenderedFeaturesAtPoint.option", rejecter: rejecter) {
-                let options = try RenderedQueryOptions(layerIds: (layerIDs ?? []).isEmpty ? nil : layerIDs, filter: filter?.asExpression())
-                
-                map.queryRenderedFeatures(with: point, options: options) { result in
-                  switch result {
-                  case .success(let features):
-                    resolver([
-                      "data": ["type": "FeatureCollection", "features": features.compactMap { queriedFeature in
-                        logged("queryRenderedFeaturesAtPoint.feature.toJSON") { try queriedFeature.feature.toJSON() }
-                      }]
-                    ])
-                  case .failure(let error):
-                    rejecter("queryRenderedFeaturesAtPoint","failed to query features", error)
+      logged("queryRenderedFeaturesAtPoint.option", rejecter: rejecter) {
+        let options = try RenderedQueryOptions(
+          layerIds: (layerIDs ?? []).isEmpty ? nil : layerIDs, filter: filter?.asExpression())
+
+        map.queryRenderedFeatures(with: point, options: options) { result in
+          switch result {
+          case .success(let features):
+            resolver([
+              "data": [
+                "type": "FeatureCollection",
+                "features": features.compactMap { queriedFeature in
+                  logged("queryRenderedFeaturesAtPoint.feature.toJSON") {
+                    try queriedFeature.feature.toJSON()
                   }
-                }
-              }
+                },
+              ]
+            ])
+          case .failure(let error):
+            rejecter("queryRenderedFeaturesAtPoint", "failed to query features", error)
           }
-      }
-
-    @objc public static func queryRenderedFeaturesInRect(
-        _ map: RNMBXMapView,
-        withBBox bbox: [NSNumber],
-        withFilter filter: [Any]?,
-        withLayerIDs layerIDs: [String]?,
-        resolver: @escaping RCTPromiseResolveBlock,
-        rejecter: @escaping RCTPromiseRejectBlock) -> Void {
-            let top = bbox.isEmpty ? 0.0 : CGFloat(bbox[0].floatValue)
-            let right = bbox.isEmpty ? 0.0 : CGFloat(bbox[1].floatValue)
-            let bottom = bbox.isEmpty ? 0.0 : CGFloat(bbox[2].floatValue)
-            let left = bbox.isEmpty ? 0.0 : CGFloat(bbox[3].floatValue)
-            let rect = bbox.isEmpty ? CGRect(x: 0.0, y: 0.0, width: map.bounds.size.width, height: map.bounds.size.height) : CGRect(x: [left,right].min()!, y: [top,bottom].min()!, width: abs(right-left), height: abs(bottom-top))
-            logged("queryRenderedFeaturesInRect.option", rejecter: rejecter) {
-              let options = try RenderedQueryOptions(layerIds: layerIDs?.isEmpty ?? true ? nil : layerIDs, filter: filter?.asExpression())
-              map.mapboxMap.queryRenderedFeatures(with: rect, options: options) { result in
-                switch result {
-                case .success(let features):
-                  resolver([
-                    "data": ["type": "FeatureCollection", "features": features.compactMap { queriedFeature in
-                      logged("queryRenderedFeaturesInRect.queriedfeature.map") { try queriedFeature.feature.toJSON() }
-                    }]
-                  ])
-                case .failure(let error):
-                  rejecter("queryRenderedFeaturesInRect","failed to query features", error)
-                }
-              }
-            }
         }
+      }
+    }
+  }
 
-    @objc public static func querySourceFeatures(
+  @objc public static func queryRenderedFeaturesInRect(
+    _ map: RNMBXMapView,
+    withBBox bbox: [NSNumber],
+    withFilter filter: [Any]?,
+    withLayerIDs layerIDs: [String]?,
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    let top = bbox.isEmpty ? 0.0 : CGFloat(bbox[0].floatValue)
+    let right = bbox.isEmpty ? 0.0 : CGFloat(bbox[1].floatValue)
+    let bottom = bbox.isEmpty ? 0.0 : CGFloat(bbox[2].floatValue)
+    let left = bbox.isEmpty ? 0.0 : CGFloat(bbox[3].floatValue)
+    let rect =
+      bbox.isEmpty
+      ? CGRect(x: 0.0, y: 0.0, width: map.bounds.size.width, height: map.bounds.size.height)
+      : CGRect(
+        x: [left, right].min()!, y: [top, bottom].min()!, width: abs(right - left),
+        height: abs(bottom - top))
+    logged("queryRenderedFeaturesInRect.option", rejecter: rejecter) {
+      let options = try RenderedQueryOptions(
+        layerIds: layerIDs?.isEmpty ?? true ? nil : layerIDs, filter: filter?.asExpression())
+      map.mapboxMap.queryRenderedFeatures(with: rect, options: options) { result in
+        switch result {
+        case .success(let features):
+          resolver([
+            "data": [
+              "type": "FeatureCollection",
+              "features": features.compactMap { queriedFeature in
+                logged("queryRenderedFeaturesInRect.queriedfeature.map") {
+                  try queriedFeature.feature.toJSON()
+                }
+              },
+            ]
+          ])
+        case .failure(let error):
+          rejecter("queryRenderedFeaturesInRect", "failed to query features", error)
+        }
+      }
+    }
+  }
+
+  @objc public static func querySourceFeatures(
     _ map: RNMBXMapView,
     withSourceId sourceId: String,
     withFilter filter: [Any]?,
     withSourceLayerIds sourceLayerIds: [String]?,
     resolver: @escaping RCTPromiseResolveBlock,
-    rejecter: @escaping RCTPromiseRejectBlock) -> Void {
-      let sourceLayerIds = sourceLayerIds?.isEmpty ?? true ? nil : sourceLayerIds
-      logged("querySourceFeatures.option", rejecter: rejecter) {
-        let options = SourceQueryOptions(sourceLayerIds: sourceLayerIds, filter: filter ?? Exp(arguments: []))
-        map.mapboxMap.querySourceFeatures(for: sourceId, options: options) { result in
-          switch result {
-          case .success(let features):
-            resolver([
-              "data": ["type": "FeatureCollection", "features": features.compactMap { queriedFeature in
-                logged("querySourceFeatures.queriedfeature.map") { try queriedFeature.feature.toJSON() }
-              }] as [String : Any]
-            ])
-          case .failure(let error):
-            rejecter("querySourceFeatures", "failed to query source features: \(error.localizedDescription)", error)
-          }
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    let sourceLayerIds = sourceLayerIds?.isEmpty ?? true ? nil : sourceLayerIds
+    logged("querySourceFeatures.option", rejecter: rejecter) {
+      let options = SourceQueryOptions(
+        sourceLayerIds: sourceLayerIds, filter: filter ?? Exp(arguments: []))
+      map.mapboxMap.querySourceFeatures(for: sourceId, options: options) { result in
+        switch result {
+        case .success(let features):
+          resolver([
+            "data": [
+              "type": "FeatureCollection",
+              "features": features.compactMap { queriedFeature in
+                logged("querySourceFeatures.queriedfeature.map") {
+                  try queriedFeature.feature.toJSON()
+                }
+              },
+            ] as [String: Any]
+          ])
+        case .failure(let error):
+          rejecter(
+            "querySourceFeatures",
+            "failed to query source features: \(error.localizedDescription)", error)
         }
       }
     }
+  }
 
-    static func clearData(_ view: RNMBXMapView, completion: @escaping (Error?) -> Void) {
-      #if RNMBX_11
+  static func clearData(_ view: RNMBXMapView, completion: @escaping (Error?) -> Void) {
+    #if RNMBX_11
       MapboxMap.clearData(completion: completion)
-      #else
+    #else
       view.mapboxMap.clearData(completion: completion)
-      #endif
+    #endif
+  }
+
+  @objc public static func clearData(
+    _ mapView: RNMBXMapView,
+    resolver: @escaping RCTPromiseResolveBlock,
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    self.clearData(mapView) { error in
+      if let error = error {
+        rejecter("clearData", "failed to clearData: \(error.localizedDescription)", error)
+      } else {
+        resolver(nil)
+      }
     }
-  
-    @objc public static func clearData(
-        _ mapView: RNMBXMapView,
-        resolver:@escaping RCTPromiseResolveBlock,
-        rejecter:@escaping RCTPromiseRejectBlock
-    ) {
-        self.clearData(mapView) { error in
-          if let error = error {
-            rejecter("clearData","failed to clearData: \(error.localizedDescription)", error)
-          } else {
-            resolver(nil)
-          }
-        }
-    }
+  }
 }

--- a/ios/RNMBX/RNMBXShapeSourceViewManager.m
+++ b/ios/RNMBX/RNMBXShapeSourceViewManager.m
@@ -1,3 +1,4 @@
+#if !RCT_NEW_ARCH_ENABLED
 #import <React/RCTBridgeModule.h>
 #import <React/RCTViewManager.h>
 
@@ -24,3 +25,4 @@ RCT_EXPORT_VIEW_PROPERTY(hitbox, NSDictionary)
 RCT_REMAP_VIEW_PROPERTY(onMapboxShapeSourcePress, onPress, RCTBubblingEventBlock)
 
 @end
+#endif

--- a/ios/RNMBX/RNMBXShapeSourceViewManager.swift
+++ b/ios/RNMBX/RNMBXShapeSourceViewManager.swift
@@ -1,14 +1,19 @@
-@objc(RNMBXShapeSourceViewManager)
-public class RNMBXShapeSourceViewManager: RCTViewManager {
-  @objc
-  override public static func requiresMainQueueSetup() -> Bool {
-    return false
-  }
+#if !RCT_NEW_ARCH_ENABLED
+  @objc(RNMBXShapeSourceViewManager)
+  public class RNMBXShapeSourceViewManager: RCTViewManager {
+    @objc
+    override public static func requiresMainQueueSetup() -> Bool {
+      return false
+    }
 
-  @objc override public func view() -> UIView {
-    return RNMBXShapeSource()
+    @objc override public func view() -> UIView {
+      return RNMBXShapeSource()
+    }
   }
-}
+#else
+  @objc(RNMBXShapeSourceViewManager)
+  public class RNMBXShapeSourceViewManager: NSObject {}
+#endif
 // MARK: - react methods
 
 extension RNMBXShapeSourceViewManager {
@@ -16,61 +21,61 @@ extension RNMBXShapeSourceViewManager {
     shapeSource: RNMBXShapeSource,
     featureJSON: String,
     resolver: @escaping RCTPromiseResolveBlock,
-    rejecter: @escaping RCTPromiseRejectBlock) -> Void
-  {
-      shapeSource.getClusterExpansionZoom(featureJSON) { result in
-        switch result {
-        case .success(let zoom):
-          resolver([
-            "data": NSNumber(value: zoom)
-          ])
-        case .failure(let error):
-          rejecter(error.localizedDescription, "Error.getClusterExpansionZoom", error)
-        }
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    shapeSource.getClusterExpansionZoom(featureJSON) { result in
+      switch result {
+      case .success(let zoom):
+        resolver([
+          "data": NSNumber(value: zoom)
+        ])
+      case .failure(let error):
+        rejecter(error.localizedDescription, "Error.getClusterExpansionZoom", error)
       }
+    }
   }
-  
+
   @objc public static func getClusterLeaves(
     shapeSource: RNMBXShapeSource,
     featureJSON: String,
     number: uint,
     offset: uint,
     resolver: @escaping RCTPromiseResolveBlock,
-    rejecter: @escaping RCTPromiseRejectBlock) -> Void
-  {
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
     shapeSource.getClusterLeaves(featureJSON, number: number, offset: offset) { result in
-        switch result {
-        case .success(let features):
-          logged("getClusterLeaves", rejecter: rejecter) {
-            let featuresJSON : Any = try features.features.toJSON()
-            resolver([
-              "data": ["type":"FeatureCollection", "features": featuresJSON]
-            ])
-          }
-        case .failure(let error):
-          rejecter(error.localizedDescription, "Error.getClusterLeaves", error)
+      switch result {
+      case .success(let features):
+        logged("getClusterLeaves", rejecter: rejecter) {
+          let featuresJSON: Any = try features.features.toJSON()
+          resolver([
+            "data": ["type": "FeatureCollection", "features": featuresJSON]
+          ])
         }
+      case .failure(let error):
+        rejecter(error.localizedDescription, "Error.getClusterLeaves", error)
+      }
     }
   }
-  
+
   @objc public static func getClusterChildren(
     shapeSource: RNMBXShapeSource,
     featureJSON: String,
     resolver: @escaping RCTPromiseResolveBlock,
-    rejecter: @escaping RCTPromiseRejectBlock) -> Void {
-      shapeSource.getClusterChildren(featureJSON) { result in
-        switch result {
-        case .success(let features):
-          logged("getClusterChildren", rejecter: rejecter) {
-            let featuresJSON : Any = try features.features.toJSON()
-            resolver([
-              "data": ["type":"FeatureCollection", "features": featuresJSON]
-            ])
-          }
-        case .failure(let error):
-          rejecter(error.localizedDescription, "Error.getClusterChildren", error)
+    rejecter: @escaping RCTPromiseRejectBlock
+  ) {
+    shapeSource.getClusterChildren(featureJSON) { result in
+      switch result {
+      case .success(let features):
+        logged("getClusterChildren", rejecter: rejecter) {
+          let featuresJSON: Any = try features.features.toJSON()
+          resolver([
+            "data": ["type": "FeatureCollection", "features": featuresJSON]
+          ])
         }
+      case .failure(let error):
+        rejecter(error.localizedDescription, "Error.getClusterChildren", error)
       }
     }
+  }
 }
-

--- a/package.json
+++ b/package.json
@@ -137,6 +137,136 @@
     "jsSrcsDir": "src/specs",
     "android": {
       "javaPackageName": "com.rnmapbox.rnmbx"
+    },
+    "ios": {
+      "components": {
+        "RNMBXAtmosphere": {
+          "className": "RNMBXAtmosphereComponentView"
+        },
+        "RNMBXBackgroundLayer": {
+          "className": "RNMBXBackgroundLayerComponentView"
+        },
+        "RNMBXCallout": {
+          "className": "RNMBXCalloutComponentView"
+        },
+        "RNMBXCamera": {
+          "className": "RNMBXCameraComponentView"
+        },
+        "RNMBXCircleLayer": {
+          "className": "RNMBXCircleLayerComponentView"
+        },
+        "RNMBXCustomLocationProvider": {
+          "className": "RNMBXCustomLocationProviderComponentView"
+        },
+        "RNMBXFillExtrusionLayer": {
+          "className": "RNMBXFillExtrusionLayerComponentView"
+        },
+        "RNMBXFillLayer": {
+          "className": "RNMBXFillLayerComponentView"
+        },
+        "RNMBXHeatmapLayer": {
+          "className": "RNMBXHeatmapLayerComponentView"
+        },
+        "RNMBXImage": {
+          "className": "RNMBXImageComponentView"
+        },
+        "RNMBXImageSource": {
+          "className": "RNMBXImageSourceComponentView"
+        },
+        "RNMBXImages": {
+          "className": "RNMBXImagesComponentView"
+        },
+        "RNMBXLight": {
+          "className": "RNMBXLightComponentView"
+        },
+        "RNMBXLineLayer": {
+          "className": "RNMBXLineLayerComponentView"
+        },
+        "RNMBXMapView": {
+          "className": "RNMBXMapViewComponentView"
+        },
+        "RNMBXMarkerViewContent": {
+          "className": "RNMBXMarkerViewContentComponentView"
+        },
+        "RNMBXMarkerView": {
+          "className": "RNMBXMarkerViewComponentView"
+        },
+        "RNMBXModelLayer": {
+          "className": "RNMBXModelLayerComponentView"
+        },
+        "RNMBXModels": {
+          "className": "RNMBXModelsComponentView"
+        },
+        "RNMBXNativeUserLocation": {
+          "className": "RNMBXNativeUserLocationComponentView"
+        },
+        "RNMBXPointAnnotation": {
+          "className": "RNMBXPointAnnotationComponentView"
+        },
+        "RNMBXRasterDemSource": {
+          "className": "RNMBXRasterDemSourceComponentView"
+        },
+        "RNMBXRasterLayer": {
+          "className": "RNMBXRasterLayerComponentView"
+        },
+        "RNMBXRasterSource": {
+          "className": "RNMBXRasterSourceComponentView"
+        },
+        "RNMBXShapeSource": {
+          "className": "RNMBXShapeSourceComponentView"
+        },
+        "RNMBXSkyLayer": {
+          "className": "RNMBXSkyLayerComponentView"
+        },
+        "RNMBXStyleImport": {
+          "className": "RNMBXStyleImportComponentView"
+        },
+        "RNMBXSymbolLayer": {
+          "className": "RNMBXSymbolLayerComponentView"
+        },
+        "RNMBXTerrain": {
+          "className": "RNMBXTerrainComponentView"
+        },
+        "RNMBXVectorSource": {
+          "className": "RNMBXVectorSourceComponentView"
+        },
+        "RNMBXViewport": {
+          "className": "RNMBXViewportComponentView"
+        }
+      },
+      "componentsProvider": {
+        "RNMBXAtmosphere": "RNMBXAtmosphereComponentView",
+        "RNMBXBackgroundLayer": "RNMBXBackgroundLayerComponentView",
+        "RNMBXCallout": "RNMBXCalloutComponentView",
+        "RNMBXCamera": "RNMBXCameraComponentView",
+        "RNMBXCircleLayer": "RNMBXCircleLayerComponentView",
+        "RNMBXCustomLocationProvider": "RNMBXCustomLocationProviderComponentView",
+        "RNMBXFillExtrusionLayer": "RNMBXFillExtrusionLayerComponentView",
+        "RNMBXFillLayer": "RNMBXFillLayerComponentView",
+        "RNMBXHeatmapLayer": "RNMBXHeatmapLayerComponentView",
+        "RNMBXImage": "RNMBXImageComponentView",
+        "RNMBXImageSource": "RNMBXImageSourceComponentView",
+        "RNMBXImages": "RNMBXImagesComponentView",
+        "RNMBXLight": "RNMBXLightComponentView",
+        "RNMBXLineLayer": "RNMBXLineLayerComponentView",
+        "RNMBXMapView": "RNMBXMapViewComponentView",
+        "RNMBXMarkerViewContent": "RNMBXMarkerViewContentComponentView",
+        "RNMBXMarkerView": "RNMBXMarkerViewComponentView",
+        "RNMBXModelLayer": "RNMBXModelLayerComponentView",
+        "RNMBXModels": "RNMBXModelsComponentView",
+        "RNMBXNativeUserLocation": "RNMBXNativeUserLocationComponentView",
+        "RNMBXPointAnnotation": "RNMBXPointAnnotationComponentView",
+        "RNMBXRasterDemSource": "RNMBXRasterDemSourceComponentView",
+        "RNMBXRasterLayer": "RNMBXRasterLayerComponentView",
+        "RNMBXRasterSource": "RNMBXRasterSourceComponentView",
+        "RNMBXShapeSource": "RNMBXShapeSourceComponentView",
+        "RNMBXSkyLayer": "RNMBXSkyLayerComponentView",
+        "RNMBXStyleImport": "RNMBXStyleImportComponentView",
+        "RNMBXSymbolLayer": "RNMBXSymbolLayerComponentView",
+        "RNMBXTerrain": "RNMBXTerrainComponentView",
+        "RNMBXVectorSource": "RNMBXVectorSourceComponentView",
+        "RNMBXViewport": "RNMBXViewportComponentView"
+      }
     }
   },
   "lint-staged": {

--- a/scripts/autogenHelpers/generateIOSComponents.mjs
+++ b/scripts/autogenHelpers/generateIOSComponents.mjs
@@ -1,0 +1,100 @@
+import fs from 'fs';
+import path from 'path';
+import * as url from 'url';
+
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+
+/**
+ * Scans the src/specs directory for NativeComponent files and extracts
+ * the component name from the codegenNativeComponent calls
+ */
+function extractNativeComponentsFromSpecs() {
+  const specsDir = path.join(__dirname, '..', '..', 'src', 'specs');
+  const nativeComponentFiles = fs
+    .readdirSync(specsDir)
+    .filter(file => file.endsWith('NativeComponent.ts'));
+
+  const components = {};
+
+  for (const file of nativeComponentFiles) {
+    const filePath = path.join(specsDir, file);
+    const content = fs.readFileSync(filePath, 'utf8');
+
+    // Extract the component name from codegenNativeComponent('ComponentName')
+    const match = content.match(/codegenNativeComponent<[^>]*>\(\s*['"`]([^'"`]+)['"`]/);
+
+    if (match) {
+      const [, componentName] = match; // e.g., 'RNMBXMapView'
+      const nativeComponentName = file.replace('.ts', ''); // e.g., 'RNMBXMapViewNativeComponent'
+      const className = `${componentName}ComponentView`; // e.g., 'RNMBXMapViewComponentView'
+
+      components[componentName] = {
+        className: className,
+        nativeComponentName: nativeComponentName,
+        file: file
+      };
+    }
+  }
+
+  return components;
+}
+
+/**
+ * Generates the iOS components configuration for package.json codegenConfig
+ */
+function generateIOSComponentsConfig() {
+  const components = extractNativeComponentsFromSpecs();
+
+  const iosConfig = {
+    components: {},
+    componentsProvider: {}
+  };
+
+  for (const [componentName, info] of Object.entries(components)) {
+    iosConfig.components[componentName] = {
+      className: info.className
+    };
+    iosConfig.componentsProvider[componentName] = info.className;
+  }
+
+  return iosConfig;
+}
+
+/**
+ * Updates the package.json file with the generated iOS components configuration
+ */
+function updatePackageJsonWithIOSComponents() {
+  const packageJsonPath = path.join(__dirname, '..', '..', 'package.json');
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+  const iosConfig = generateIOSComponentsConfig();
+
+  // Ensure codegenConfig exists
+  if (!packageJson.codegenConfig) {
+    packageJson.codegenConfig = {
+      name: 'rnmapbox_maps_specs',
+      type: 'all',
+      jsSrcsDir: 'src/specs',
+      android: {
+        javaPackageName: 'com.rnmapbox.rnmbx'
+      }
+    };
+  }
+
+  // Ensure ios config exists
+  if (!packageJson.codegenConfig.ios) {
+    packageJson.codegenConfig.ios = {};
+  }
+
+  // Update iOS components
+  packageJson.codegenConfig.ios.components = iosConfig.components;
+  packageJson.codegenConfig.ios.componentsProvider = iosConfig.componentsProvider;
+
+  // Write back to package.json with proper formatting
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
+
+  console.log(`Updated package.json with ${Object.keys(iosConfig.components).length} iOS components`);
+  return Object.keys(iosConfig.components);
+}
+
+export { extractNativeComponentsFromSpecs, generateIOSComponentsConfig, updatePackageJsonWithIOSComponents };

--- a/scripts/autogenerate.mjs
+++ b/scripts/autogenerate.mjs
@@ -12,6 +12,7 @@ import {
   generateCodegenJavaOldArch,
   javaOldArchDir,
 } from './codegen-old-arch.js';
+import { updatePackageJsonWithIOSComponents } from './autogenHelpers/generateIOSComponents.mjs';
 
 // process style spec json into json
 
@@ -86,6 +87,12 @@ async function generate() {
   const markdownBuilder = new MarkdownBuilder();
   await docBuilder.generate(docsJsonPath);
   await markdownBuilder.generate(docsJsonPath, docsRoot);
+
+  // autogenerate iOS components configuration
+  const updatedComponents = updatePackageJsonWithIOSComponents();
+  if (updatedComponents.length > 0) {
+    outputPaths.push('package.json');
+  }
 
   // rn new arch codegen
   await generateCodegenJavaOldArch();


### PR DESCRIPTION
…ad of legacy in new arch

See:
https://github.com/facebook/react-native-website/pull/4388/files#diff-7fbb6ff2e58f8bd50d2763e551c63e1816adb6d593f40d489785b575b0e82718R76
https://github.com/software-mansion/react-native-gesture-handler/commit/7826f5072510edb309557720c6d08f567fdae066
https://github.com/software-mansion/react-native-svg/pull/2572
## Description

Fixes #<issue-number>

<!-- OR, if you're implementing a new feature: -->

Added `your feature` that allows ...

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here  -->
```jsx

```
