### PR TITLE
chore: remove assets from the published package bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "src",
     "lib",
     "plugin",
-    "assets",
     "app.plugin.js",
     "index.d.ts",
     "rnmapbox-maps.podspec",


### PR DESCRIPTION
## Description

While working on adding a new metadata information to the React Native Directory, and analysing the results, I have spotted that `@rnmapbox/maps` published package includes README assets files, which increase significantly the final bundle size, see:
* https://www.npmjs.com/package/@rnmapbox/maps?activeTab=code

To avoid that, I have updated the `files` array in `package.json`, and removed `assets` directory form the list. 

It should be safe to ignore those resources, since npm will replace relative links in README file with direct GitHub URLs while rendering them, so for example:
* `./assets/intro-examples.png` becomes `https://github.com/rnmapbox/maps/blob/HEAD/assets/intro-examples.png`

## Test plan

I have run the `npm pack --dry-run` command before and after the changes, and make sure that assets file are no longer a part of the final bundle. 

Results are as follows, before the change:

```
npm notice filename: rnmapbox-maps-10.1.44-rc.0.tgz
npm notice package size: 3.4 MB
npm notice unpacked size: 6.2 MB
npm notice shasum: 2488fc0c651e0b3e0b0010c881122dc2c313a76a
npm notice integrity: sha512-GZsl4PBuIma8G[...]J3SmDO0Oumk8w==
npm notice total files: 1386
```

After excluding assets files:

```
npm notice filename: rnmapbox-maps-10.1.44-rc.0.tgz
npm notice package size: 563.9 kB
npm notice unpacked size: 3.4 MB
npm notice shasum: 75812996f2d0843e73b113307b5cdf81ac240081
npm notice integrity: sha512-VdG0NnzOKldOT[...]5HGzw4ADoibCQ==
npm notice total files: 1374
```
