### PR TITLE
fix(ios): support 'url' prop for ShapeSource on iOS

### DIFF
--- a/ios/RNMBX/RNMBXShapeSourceComponentView.mm
+++ b/ios/RNMBX/RNMBXShapeSourceComponentView.mm
@@ -96,6 +96,7 @@ using namespace facebook::react;
 
   RNMBX_OPTIONAL_PROP_NSString(id)
   RNMBX_OPTIONAL_PROP_BOOL(existing)
+  RNMBX_OPTIONAL_PROP_NSString(url)
   RNMBX_OPTIONAL_PROP_NSString(shape)
   RNMBX_OPTIONAL_PROP_NSNumber(cluster)
   RNMBX_OPTIONAL_PROP_NSNumber(clusterRadius)


### PR DESCRIPTION
## Description

Closes: #3866
Fixes #3863

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here  -->
```jsx

```
