### PR TITLE
fix(android,v11): fix takeSnap

### DIFF
--- a/android/src/main/mapbox-v11-compat/v11/com/rnmapbox/rnmbx/v11compat/Image.kt
+++ b/android/src/main/mapbox-v11-compat/v11/com/rnmapbox/rnmbx/v11compat/Image.kt
@@ -26,7 +26,16 @@ fun ByteArray.toImageData() : DataRef {
 }
 
 fun DataRef.toByteArray(): ByteArray {
-    return this.buffer.array()
+    if (this.buffer.hasArray()) {
+        return this.buffer.array()
+    } else {
+        val buffer = this.buffer
+        val bytes = ByteArray(buffer.remaining())
+        val oldPos = buffer.position()
+        buffer.get(bytes)
+        buffer.position(oldPos)
+        return bytes
+    }
 }
 /*
 fun Drawable.toImageHolder(drawableId: Int) : ImageHolder {


### PR DESCRIPTION
## Description

Fixes #3830
Take snap on android was crashing on v11

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

```jsx
import React from 'react';
import { snapshotManager } from '@rnmapbox/maps';
import { useEffect, useState } from 'react';
import { View, Image } from 'react-native';

const MapboxBugTestComponent = () => {
  const [snapshotURI, setSnapshotURI] = useState();

  useEffect(() => {
    (async () => {
      const uri = await snapshotManager.takeSnap({
        centerCoordinate: [-74.12641, 40.797968],
      });
      console.log('uri', uri);
      setSnapshotURI(uri);
    })();
  }, []);

  return (
    <View
      style={{
        flex: 1,
        backgroundColor: 'blue',
        justifyContent: 'center',
        alignItems: 'center',
      }}
    >
      {snapshotURI ? (
        <View style={{ width: 300, height: 300 }}>
          <Image
            source={{ uri: snapshotURI }}
            style={{ width: '100%', height: '100%', resizeMode: 'contain' }}
          />
        </View>
      ) : null}
    </View>
  );
};

export default MapboxBugTestComponent;
```
