### PR TITLE
Fix getPointInView function return wrong point position on Android

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapView.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapView.kt
@@ -901,11 +901,13 @@ open class RNMBXMapView(private val mContext: Context, var mManager: RNMBXMapVie
 
     fun getPointInView(coordinate: Point, response: CommandResponse) {
         val point = mMap!!.pixelForCoordinate(coordinate)
+        val density = getDisplayDensity()
+        val pointInView = PointF((point.x / density).toFloat(), (point.y / density).toFloat())
 
         response.success {
             val array: WritableArray = WritableNativeArray()
-            array.pushDouble(point.x)
-            array.pushDouble(point.y)
+            array.pushDouble(pointInView.x.toDouble())
+            array.pushDouble(pointInView.y.toDouble())
             it.putArray("pointInView", array)
         }
     }


### PR DESCRIPTION
## Description

Fixes: getPointInView function return wrong point position on Android.

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)
