### PR TITLE
feat: make Mapbox SDK authentication optional

### DIFF
--- a/.github/workflows/android-actions.yml
+++ b/.github/workflows/android-actions.yml
@@ -26,11 +26,7 @@ on:
     secrets:
       MAPBOX_ACCESS_TOKEN:
         required: true
-      MAPBOX_DOWNLOAD_TOKEN:
-        required: false
       ENV_MAPBOX_ACCESS_TOKEN:
-        required: false
-      ENV_MAPBOX_DOWNLOAD_TOKEN:
         required: false
 
 jobs:
@@ -60,19 +56,7 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
 
-      # Mapbox download token is no longer required as per Mapbox's removal of authentication requirement
-      # See: https://github.com/mapbox/mapbox-maps-flutter/issues/775
-      # Only set if token is provided for backward compatibility
-      - run: |
-          mkdir -p ~/.gradle/
-          if [ -n "$MAPBOX_DOWNLOAD_TOKEN" ]; then
-            echo MAPBOX_DOWNLOADS_TOKEN=$MAPBOX_DOWNLOAD_TOKEN > ~/.gradle/gradle.properties
-          fi
-        working-directory: example
-        env:
-          MAPBOX_DOWNLOAD_TOKEN: ${{ secrets.MAPBOX_DOWNLOAD_TOKEN || secrets.ENV_MAPBOX_DOWNLOAD_TOKEN }}
-        if: "${{ secrets.MAPBOX_DOWNLOAD_TOKEN || secrets.ENV_MAPBOX_DOWNLOAD_TOKEN }}"
-
+      
       - run: echo $MAPBOX_ACCESS_TOKEN > ./accesstoken
         working-directory: example
         env:

--- a/.github/workflows/android-actions.yml
+++ b/.github/workflows/android-actions.yml
@@ -27,7 +27,7 @@ on:
       MAPBOX_ACCESS_TOKEN:
         required: true
       MAPBOX_DOWNLOAD_TOKEN:
-        required: true
+        required: false
       ENV_MAPBOX_ACCESS_TOKEN:
         required: false
       ENV_MAPBOX_DOWNLOAD_TOKEN:
@@ -60,12 +60,18 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
 
+      # Mapbox download token is no longer required as per Mapbox's removal of authentication requirement
+      # See: https://github.com/mapbox/mapbox-maps-flutter/issues/775
+      # Only set if token is provided for backward compatibility
       - run: |
           mkdir -p ~/.gradle/
-          echo MAPBOX_DOWNLOADS_TOKEN=$MAPBOX_DOWNLOAD_TOKEN > ~/.gradle/gradle.properties
+          if [ -n "$MAPBOX_DOWNLOAD_TOKEN" ]; then
+            echo MAPBOX_DOWNLOADS_TOKEN=$MAPBOX_DOWNLOAD_TOKEN > ~/.gradle/gradle.properties
+          fi
         working-directory: example
         env:
           MAPBOX_DOWNLOAD_TOKEN: ${{ secrets.MAPBOX_DOWNLOAD_TOKEN || secrets.ENV_MAPBOX_DOWNLOAD_TOKEN }}
+        if: "${{ secrets.MAPBOX_DOWNLOAD_TOKEN || secrets.ENV_MAPBOX_DOWNLOAD_TOKEN }}"
 
       - run: echo $MAPBOX_ACCESS_TOKEN > ./accesstoken
         working-directory: example

--- a/.github/workflows/ci-for-forked-repos.yml
+++ b/.github/workflows/ci-for-forked-repos.yml
@@ -12,6 +12,5 @@ jobs:
       env_name: CI with Mapbox Tokens
       ref: ${{ github.event.pull_request.head.sha }}
     secrets:
-      ENV_MAPBOX_ACCESS_TOKEN: ${{ secrets.ENV_MAPBOX_ACCESS_TOKEN }}
-      ENV_MAPBOX_DOWNLOAD_TOKEN: ${{ secrets.ENV_MAPBOX_DOWNLOAD_TOKEN }}
+      MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
 

--- a/.github/workflows/ci-requiring-tokens.yml
+++ b/.github/workflows/ci-requiring-tokens.yml
@@ -16,14 +16,10 @@ on:
     secrets:
       MAPBOX_ACCESS_TOKEN:
         required: false
-      MAPBOX_DOWNLOAD_TOKEN:
-        required: false
       ENV_MAPBOX_ACCESS_TOKEN:
         required: false
-      ENV_MAPBOX_DOWNLOAD_TOKEN:
-        required: false
 
-concurrency: 
+concurrency:
   group: ${{ github.head_ref || github.run_id }}-ci-with-tokens
   cancel-in-progress: true
 
@@ -38,9 +34,7 @@ jobs:
       MAP_IMPL: mapbox
     secrets:
       MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-      MAPBOX_DOWNLOAD_TOKEN: ${{ secrets.MAPBOX_DOWNLOAD_TOKEN }}
       ENV_MAPBOX_ACCESS_TOKEN: ${{ secrets.ENV_MAPBOX_ACCESS_TOKEN }}
-      ENV_MAPBOX_DOWNLOAD_TOKEN: ${{ secrets.ENV_MAPBOX_DOWNLOAD_TOKEN }}
 
   call_android_workflow_fabric:
     name: "Android/Mapbox/Fabric"
@@ -53,9 +47,7 @@ jobs:
       NEW_ARCH: true
     secrets:
       MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-      MAPBOX_DOWNLOAD_TOKEN: ${{ secrets.MAPBOX_DOWNLOAD_TOKEN }}
       ENV_MAPBOX_ACCESS_TOKEN: ${{ secrets.ENV_MAPBOX_ACCESS_TOKEN }}
-      ENV_MAPBOX_DOWNLOAD_TOKEN: ${{ secrets.ENV_MAPBOX_DOWNLOAD_TOKEN }}
 
 
   call_android_workflow_11:
@@ -68,9 +60,7 @@ jobs:
       MAP_IMPL: mapbox11
     secrets:
       MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-      MAPBOX_DOWNLOAD_TOKEN: ${{ secrets.MAPBOX_DOWNLOAD_TOKEN }}
       ENV_MAPBOX_ACCESS_TOKEN: ${{ secrets.ENV_MAPBOX_ACCESS_TOKEN }}
-      ENV_MAPBOX_DOWNLOAD_TOKEN: ${{ secrets.ENV_MAPBOX_DOWNLOAD_TOKEN }}
 
   call_ios_workflow:
     name: "iOS/Mapbox"
@@ -82,9 +72,7 @@ jobs:
       MAP_IMPL: mapbox
     secrets:
       MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-      MAPBOX_DOWNLOAD_TOKEN: ${{ secrets.MAPBOX_DOWNLOAD_TOKEN }}
       ENV_MAPBOX_ACCESS_TOKEN: ${{ secrets.ENV_MAPBOX_ACCESS_TOKEN }}
-      ENV_MAPBOX_DOWNLOAD_TOKEN: ${{ secrets.ENV_MAPBOX_DOWNLOAD_TOKEN }}
 
   call_ios_workflow_fabric:
     name: "iOS/Mapbox/Fabric"
@@ -97,9 +85,7 @@ jobs:
       NEW_ARCH: true
     secrets:
       MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-      MAPBOX_DOWNLOAD_TOKEN: ${{ secrets.MAPBOX_DOWNLOAD_TOKEN }}
       ENV_MAPBOX_ACCESS_TOKEN: ${{ secrets.ENV_MAPBOX_ACCESS_TOKEN }}
-      ENV_MAPBOX_DOWNLOAD_TOKEN: ${{ secrets.ENV_MAPBOX_DOWNLOAD_TOKEN }}
 
   call_ios_workflow_11:
     name: "iOS/Mapbox11"
@@ -111,10 +97,8 @@ jobs:
       MAP_IMPL: mapbox11
     secrets:
       MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-      MAPBOX_DOWNLOAD_TOKEN: ${{ secrets.MAPBOX_DOWNLOAD_TOKEN }}
       ENV_MAPBOX_ACCESS_TOKEN: ${{ secrets.ENV_MAPBOX_ACCESS_TOKEN }}
-      ENV_MAPBOX_DOWNLOAD_TOKEN: ${{ secrets.ENV_MAPBOX_DOWNLOAD_TOKEN }}
-  
+
   call_web_workflow:
     name: "Web/Mapbox"
     uses: ./.github/workflows/web-actions.yml
@@ -124,6 +108,4 @@ jobs:
       NVMRC: ${{ inputs.NVMRC }}
     secrets:
       MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-      MAPBOX_DOWNLOAD_TOKEN: ${{ secrets.MAPBOX_DOWNLOAD_TOKEN }}
       ENV_MAPBOX_ACCESS_TOKEN: ${{ secrets.ENV_MAPBOX_ACCESS_TOKEN }}
-      ENV_MAPBOX_DOWNLOAD_TOKEN: ${{ secrets.ENV_MAPBOX_DOWNLOAD_TOKEN }}

--- a/.github/workflows/ios-actions.yml
+++ b/.github/workflows/ios-actions.yml
@@ -27,7 +27,7 @@ on:
       MAPBOX_ACCESS_TOKEN:
         required: true
       MAPBOX_DOWNLOAD_TOKEN:
-        required: true
+        required: false
       ENV_MAPBOX_ACCESS_TOKEN:
         required: false
       ENV_MAPBOX_DOWNLOAD_TOKEN:
@@ -60,15 +60,9 @@ jobs:
         env:
           MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN || secrets.ENV_MAPBOX_ACCESS_TOKEN }}
 
-      - name: Setup .netrc with MAPBOX_DOWNLOAD_TOKEN
-        run: |
-          echo 'machine api.mapbox.com' >> ~/.netrc
-          echo 'login mapbox' >> ~/.netrc
-          echo "password $MAPBOX_DOWNLOAD_TOKEN" >> ~/.netrc
-          chmod 0600 ~/.netrc
-        if: "${{ env.MAPBOX_DOWNLOAD_TOKEN != '' }}"
-        env:
-          MAPBOX_DOWNLOAD_TOKEN: ${{ secrets.MAPBOX_DOWNLOAD_TOKEN || secrets.ENV_MAPBOX_DOWNLOAD_TOKEN }}
+        # Mapbox download token is no longer required as per Mapbox's removal of authentication requirement
+      # See: https://github.com/mapbox/mapbox-maps-flutter/issues/775
+      # .netrc setup is no longer needed for iOS builds
 
       - name: Setup node ${{ inputs.NVMRC }}
         uses: actions/setup-node@v3.5.1

--- a/.github/workflows/ios-actions.yml
+++ b/.github/workflows/ios-actions.yml
@@ -26,11 +26,7 @@ on:
     secrets:
       MAPBOX_ACCESS_TOKEN:
         required: true
-      MAPBOX_DOWNLOAD_TOKEN:
-        required: false
       ENV_MAPBOX_ACCESS_TOKEN:
-        required: false
-      ENV_MAPBOX_DOWNLOAD_TOKEN:
         required: false
 
 jobs:
@@ -60,10 +56,7 @@ jobs:
         env:
           MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN || secrets.ENV_MAPBOX_ACCESS_TOKEN }}
 
-        # Mapbox download token is no longer required as per Mapbox's removal of authentication requirement
-      # See: https://github.com/mapbox/mapbox-maps-flutter/issues/775
-      # .netrc setup is no longer needed for iOS builds
-
+        
       - name: Setup node ${{ inputs.NVMRC }}
         uses: actions/setup-node@v3.5.1
         with:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -77,7 +77,6 @@ jobs:
     if: needs.has_mapbox_token.outputs.has-mapbox-token == 'true'
     secrets:
       MAPBOX_ACCESS_TOKEN: ${{ secrets.MAPBOX_ACCESS_TOKEN }}
-      MAPBOX_DOWNLOAD_TOKEN: ${{ secrets.MAPBOX_DOWNLOAD_TOKEN }}
 
   publish:
     if: startsWith(github.ref, 'refs/tags/') && (github.event_name == 'push')

--- a/.github/workflows/web-actions.yml
+++ b/.github/workflows/web-actions.yml
@@ -9,18 +9,14 @@ on:
         type: string
       ref:
         required: false
-        type: string 
+        type: string
       NVMRC:
         required: true
         type: string
     secrets:
       MAPBOX_ACCESS_TOKEN:
         required: true
-      MAPBOX_DOWNLOAD_TOKEN:
-        required: true
       ENV_MAPBOX_ACCESS_TOKEN:
-        required: false
-      ENV_MAPBOX_DOWNLOAD_TOKEN:
         required: false
 
 jobs:
@@ -32,7 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         if: ${{ inputs.ref == '' }}
-      
+
       - name: Checkout fork
         uses: actions/checkout@v4
         if: ${{ inputs.ref != '' }}

--- a/android/install.md
+++ b/android/install.md
@@ -20,15 +20,20 @@ allprojects {
         // ...other repos
         maven {
             url 'https://api.mapbox.com/downloads/v2/releases/maven'
-            authentication {
-                basic(BasicAuthentication)
-            }
-            credentials {
-                // Do not change the username below.
-                // This should always be `mapbox` (not your username).
-                username = 'mapbox'
-                // Use the secret token you stored in gradle.properties as the password
-                password = project.properties['MAPBOX_DOWNLOADS_TOKEN'] ?: ""
+            // Authentication is no longer required as per Mapbox's removal of download token requirement
+            // See: https://github.com/mapbox/mapbox-maps-flutter/issues/775
+            // Keeping this as optional for backward compatibility
+            if (project.properties['MAPBOX_DOWNLOADS_TOKEN']) {
+                authentication {
+                    basic(BasicAuthentication)
+                }
+                credentials {
+                    // Do not change the username below.
+                    // This should always be `mapbox` (not your username).
+                    username = 'mapbox'
+                    // Use the secret token you stored in gradle.properties as the password
+                    password = project.properties['MAPBOX_DOWNLOADS_TOKEN']
+                }
             }
         }
         // ...even more repos?

--- a/android/install.md
+++ b/android/install.md
@@ -2,13 +2,10 @@
 
 ## Supported mapbox libraries
 
-We're only supporting mapbox 10.16* and 11.*. The default is 10.16*. 
+We're only supporting mapbox 10.16* and 11.*. The default is 10.16*.
 Next release will be 11.* only so we recommend updatign to 11.*
 
 ### Adding mapbox maven repo
-
-You will need to authorize your download of the Maps SDK via a secret access token with the `DOWNLOADS:READ` scope.  
-This [guide](https://docs.mapbox.com/android/maps/guides/install/#configure-credentials) explains how to `Configure credentials` and `Configure your secret token`.
 
 Then under section `allprojects/repositories` add your data:
 
@@ -20,26 +17,13 @@ allprojects {
         // ...other repos
         maven {
             url 'https://api.mapbox.com/downloads/v2/releases/maven'
-            // Authentication is no longer required as per Mapbox's removal of download token requirement
-            // See: https://github.com/mapbox/mapbox-maps-flutter/issues/775
-            // Keeping this as optional for backward compatibility
-            if (project.properties['MAPBOX_DOWNLOADS_TOKEN']) {
-                authentication {
-                    basic(BasicAuthentication)
-                }
-                credentials {
-                    // Do not change the username below.
-                    // This should always be `mapbox` (not your username).
-                    username = 'mapbox'
-                    // Use the secret token you stored in gradle.properties as the password
-                    password = project.properties['MAPBOX_DOWNLOADS_TOKEN']
-                }
-            }
         }
         // ...even more repos?
     }
 }
 ```
+
+*Note:* mapbox lifted auth requirement from downloads so MAPBOX_DOWNLOADS_TOKEN is no longer needed
 
 ### Using non default mapbox version
 

--- a/example/README.md
+++ b/example/README.md
@@ -57,8 +57,7 @@ cd example
 * Android: Set up your Mapbox developer keys as described in https://github.com/rnmapbox/maps/blob/main/android/install.md#adding-mapbox-maven-repo (no need to change build.gradle, just set up gradle.properties)
 
 * iOS:
-  1. Set up your Mapbox developer keys as described in [https://github.com/rnmapbox/maps/blob/main/ios/install.md#adding-mapbox-maven-repo](https://github.com/rnmapbox/maps/blob/main/ios/install.md#mapbox-maps-sdk-v10) (add your cerdentials to .netrc as described)
-  2. Install pod dependencies
+  1. Install pod dependencies
     ```
     cd ios
     pod install

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -54,15 +54,20 @@ allprojects {
 
         maven {
             url 'https://api.mapbox.com/downloads/v2/releases/maven'
-            authentication {
-                basic(BasicAuthentication)
-            }
-            credentials {
-                // Do not change the username below.
-                // This should always be `mapbox` (not your username).
-                username = 'mapbox'
-                // Use the secret token you stored in gradle.properties as the password
-                password = project.properties['MAPBOX_DOWNLOADS_TOKEN'] ?: ""
+            // Authentication is no longer required as per Mapbox's removal of download token requirement
+            // See: https://github.com/mapbox/mapbox-maps-flutter/issues/775
+            // Keeping this as optional for backward compatibility
+            if (project.properties['MAPBOX_DOWNLOADS_TOKEN']) {
+                authentication {
+                    basic(BasicAuthentication)
+                }
+                credentials {
+                    // Do not change the username below.
+                    // This should always be `mapbox` (not your username).
+                    username = 'mapbox'
+                    // Use the secret token you stored in gradle.properties as the password
+                    password = project.properties['MAPBOX_DOWNLOADS_TOKEN']
+                }
             }
         }
     }

--- a/plugin/build/withMapbox.js
+++ b/plugin/build/withMapbox.js
@@ -211,12 +211,16 @@ allprojects {
   repositories {
     maven {
       url 'https://api.mapbox.com/downloads/v2/releases/maven'
-      authentication { basic(BasicAuthentication) }
-      credentials {
-        username = 'mapbox'
-        password = project.properties['MAPBOX_DOWNLOADS_TOKEN'] ?: System.getenv('RNMAPBOX_MAPS_DOWNLOAD_TOKEN') ?: {
-          throw new GradleException('❌ RNMapbox Maps Error: Mapbox download token is required.\\nSet RNMAPBOX_MAPS_DOWNLOAD_TOKEN environment variable:\\n  export RNMAPBOX_MAPS_DOWNLOAD_TOKEN="sk.ey...qg"\\n  npx expo prebuild\\n\\nOr use deprecated config:\\n  RNMapboxMapsDownloadToken in app.json plugin config')
-        }()
+      // Authentication is no longer required as per Mapbox's removal of download token requirement
+      // See: https://github.com/mapbox/mapbox-maps-flutter/issues/775
+      // Keeping this as optional for backward compatibility
+      def token = project.properties['MAPBOX_DOWNLOADS_TOKEN'] ?: System.getenv('RNMAPBOX_MAPS_DOWNLOAD_TOKEN')
+      if (token) {
+        authentication { basic(BasicAuthentication) }
+        credentials {
+          username = 'mapbox'
+          password = token
+        }
       }
     }
   }

--- a/plugin/src/withMapbox.ts
+++ b/plugin/src/withMapbox.ts
@@ -331,12 +331,16 @@ allprojects {
   repositories {
     maven {
       url 'https://api.mapbox.com/downloads/v2/releases/maven'
-      authentication { basic(BasicAuthentication) }
-      credentials {
-        username = 'mapbox'
-        password = project.properties['MAPBOX_DOWNLOADS_TOKEN'] ?: System.getenv('RNMAPBOX_MAPS_DOWNLOAD_TOKEN') ?: {
-          throw new GradleException('❌ RNMapbox Maps Error: Mapbox download token is required.\\nSet RNMAPBOX_MAPS_DOWNLOAD_TOKEN environment variable:\\n  export RNMAPBOX_MAPS_DOWNLOAD_TOKEN="sk.ey...qg"\\n  npx expo prebuild\\n\\nOr use deprecated config:\\n  RNMapboxMapsDownloadToken in app.json plugin config')
-        }()
+      // Authentication is no longer required as per Mapbox's removal of download token requirement
+      // See: https://github.com/mapbox/mapbox-maps-flutter/issues/775
+      // Keeping this as optional for backward compatibility
+      def token = project.properties['MAPBOX_DOWNLOADS_TOKEN'] ?: System.getenv('RNMAPBOX_MAPS_DOWNLOAD_TOKEN')
+      if (token) {
+        authentication { basic(BasicAuthentication) }
+        credentials {
+          username = 'mapbox'
+          password = token
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
• Remove mandatory authentication requirement for Mapbox SDK downloads
• Align with Mapbox's removal of download token requirements
• Make authentication optional for backward compatibility

## Changes
- **Android**: Make MAPBOX_DOWNLOADS_TOKEN optional in build.gradle and CI workflows
- **iOS**: Remove .netrc setup from CI workflows 
- **Expo Plugin**: Update withMapbox.ts to make authentication optional
- **Documentation**: Update installation docs to reflect optional authentication

## Technical Details
- Modified `example/android/build.gradle` to conditionally set authentication only if token is provided
- Updated CI workflows to make MAPBOX_DOWNLOAD_TOKEN optional (required: false)
- Removed .netrc setup step from iOS CI workflow
- Updated both source and built Expo plugin files
- Modified Android installation documentation

## Test plan
- [x] Android build works without authentication tokens
- [x] CI workflows updated to handle optional tokens
- [x] Backward compatibility maintained for existing setups
- [x] Documentation updated to reflect changes

References:
- Mapbox authentication removal: https://github.com/mapbox/mapbox-maps-flutter/issues/775

🤖 Generated with [Claude Code](https://claude.com/claude-code)