### PR TITLE
fix: yarn install for doc and publish, by using dummy token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,13 +11,15 @@ jobs:
       - name: Read .nvmrc
         run: echo "NVMRC=$(cat .nvmrc)" >> $GITHUB_OUTPUT
         id: nvm
+      - name: Create dummy accesstoken file
+        run: echo 'dummytoken' > ./accesstoken
       - name: Setup node ${{ steps.nvm.outputs.NVMRC }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies and build 🔧
-        run: yarn install --frozen-lockfile
+        run: yarn install --immutable
       - name: Publish package on NPM 📦
         run: npm publish ${{ github.event.release.prerelease && '--tag next' || ''}}
         env:

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -35,6 +35,8 @@ jobs:
       - uses: oven-sh/setup-bun@v1
         with:
           bun-version: latest
+      - name: Create dummy accesstoken file
+        run: echo 'dummytoken' > ./accesstoken
       - name: Install dependencies
         run: yarn install
       - name: Generate component docs into maps-docs repo


### PR DESCRIPTION
Fixes broken CI on publish and doc publish. 

<img width="1212" height="680" alt="image" src="https://github.com/user-attachments/assets/417f5ca8-603c-4f99-a90c-5c7b0c9acc4e" />


## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here  -->
```jsx

```
