### PR TITLE
fix(ios): frameRate capped at 60fps

### DIFF
--- a/ios/RNMBX/RNMBXMapView.swift
+++ b/ios/RNMBX/RNMBXMapView.swift
@@ -466,7 +466,7 @@ open class RNMBXMapView: UIView, RCTInvalidating {
   func applyPreferredFramesPerSecond() {
     if let value = preferredFramesPerSecond {
       if #available(iOS 15.0, *) {
-        self.mapView.preferredFrameRateRange = CAFrameRateRange(minimum: 1, maximum: Float(value))
+        self.mapView.preferredFrameRateRange = CAFrameRateRange(minimum: Float(value), maximum: Float(value))
       } else {
         self.mapView.preferredFramesPerSecond = value
       }


### PR DESCRIPTION
## Description

Regardless of "preferredFramesPerSecond" prop passed to MapView, iOS devices with 120Hz displays still cap at 60fps, resulting in a choppy panning experience.

Android works fine, iOS does not.

This change fixes this problem. #4018 

## Checklist
- [X] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [X] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [X] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Video

Before:
https://github.com/user-attachments/assets/ff310290-fdeb-475e-9958-5f60cd31d777

After:
https://github.com/user-attachments/assets/f74cc136-b80a-4960-b3dd-6ec88ac84a57