### PR TITLE
fix(ios): memory leak cause by style prop changes

### DIFF
--- a/ios/RNMBX/RNMBXMapViewComponentView.mm
+++ b/ios/RNMBX/RNMBXMapViewComponentView.mm
@@ -224,6 +224,7 @@ using namespace facebook::react;
 - (void)prepareForRecycle
 {
     [super prepareForRecycle];
+    _lastStyleURL = nil;
     [self prepareView];
 }
 


### PR DESCRIPTION
Sorry @mfazekas I caused a memory leak with the previous update for `styleURL` when mounting/unmounting map instances. Hopefully this fix is ok.

- [x] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [x] I have tested the new feature on `/example` app.
  - [x] In V11 mode/ios
  - [x] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)
