### PR TITLE
fix(docs): correct typo poitn → point in MarkerView.tsx

### DIFF
--- a/docs/examples.json
+++ b/docs/examples.json
@@ -619,7 +619,7 @@
             "PointAnnotation",
             "MarkerView"
           ],
-          "docs": "\nShows marker view and poitn annotations\n"
+          "docs": "\nShows marker view and point annotations\n"
         },
         "fullPath": "example/src/examples/Annotations/MarkerView.tsx",
         "relPath": "Annotations/MarkerView.tsx",

--- a/example/src/examples/Annotations/MarkerView.tsx
+++ b/example/src/examples/Annotations/MarkerView.tsx
@@ -103,7 +103,7 @@ const metadata = {
   title: 'Marker View',
   tags: ['PointAnnotation', 'MarkerView'],
   docs: `
-Shows marker view and poitn annotations
+Shows marker view and point annotations
 `,
 };
 ShowMarkerView.metadata = metadata;


### PR DESCRIPTION
## Description

Fixed a small typo in MarkerView example documentation:  
`poitn` → `point` in the description text.

## Checklist

- [ x] I've read `CONTRIBUTING.md`
- [x ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

N/A – text-only documentation fix.

## Component to reproduce the issue you're fixing

```jsx
/* end-example-doc */

/** @type ExampleWithMetadata['metadata'] */
const metadata = {
  title: 'Marker View',
  tags: ['PointAnnotation', 'MarkerView'],
  docs: `
Shows marker view and point annotations
`,
};
ShowMarkerView.metadata = metadata;```
