### PR TITLE
fix(point annotation): selected property should select/deselect a point annotation

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXPointAnnotationManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXPointAnnotationManager.kt
@@ -78,6 +78,15 @@ class RNMBXPointAnnotationManager(reactApplicationContext: ReactApplicationConte
         annotation.setAnchor(mapValue.getDouble("x").toFloat(), mapValue.getDouble("y").toFloat())
     }
 
+    override fun setSelected(
+        annotation: RNMBXPointAnnotation,
+        value: Dynamic?
+    ) {
+       value?.let {
+           annotation.isSelected = it.asBoolean()
+       }
+    }
+
     @ReactProp(name = "draggable")
     override fun setDraggable(annotation: RNMBXPointAnnotation, draggable: Dynamic) {
         annotation.setDraggable(draggable.asBoolean())

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXPointAnnotationManagerDelegate.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXPointAnnotationManagerDelegate.java
@@ -35,6 +35,9 @@ public class RNMBXPointAnnotationManagerDelegate<T extends View, U extends BaseV
       case "anchor":
         mViewManager.setAnchor(view, new DynamicFromObject(value));
         break;
+      case "selected":
+        mViewManager.setSelected(view, new DynamicFromObject(value));
+        break;
       default:
         super.setProperty(view, propName, value);
     }

--- a/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXPointAnnotationManagerInterface.java
+++ b/android/src/main/old-arch/com/facebook/react/viewmanagers/RNMBXPointAnnotationManagerInterface.java
@@ -16,4 +16,5 @@ public interface RNMBXPointAnnotationManagerInterface<T extends View> {
   void setDraggable(T view, Dynamic value);
   void setId(T view, Dynamic value);
   void setAnchor(T view, Dynamic value);
+  void setSelected(T view, Dynamic value);
 }

--- a/ios/RNMBX/RNMBXMapView.swift
+++ b/ios/RNMBX/RNMBXMapView.swift
@@ -1522,6 +1522,19 @@ class RNMBXPointAnnotationManager : AnnotationInteractionDelegate {
     // We handle taps ourselfs
     //   onTap(annotations: annotations)
   }
+  
+  func selected(pointAnnotation: RNMBXPointAnnotation) {
+    if (selected != nil) {
+      deselectCurrentlySelected(deselectAnnotationOnTap: false)
+    }
+    selected = pointAnnotation
+  }
+  
+  func unselected(pointAnnotation: RNMBXPointAnnotation) {
+    if (selected == pointAnnotation) {
+      deselectCurrentlySelected(deselectAnnotationOnTap: false)
+    }
+  }
 
   func deselectCurrentlySelected(deselectAnnotationOnTap: Bool = false) -> Bool {
     if let selected = selected {
@@ -1754,6 +1767,7 @@ class RNMBXPointAnnotationManager : AnnotationInteractionDelegate {
   #endif
 
   func add(_ annotation: PointAnnotation, _ rnmbxPointAnnotation: RNMBXPointAnnotation) {
+    rnmbxPointAnnotation.manager = self
     manager.annotations.append(annotation)
     manager.refresh()
     #if RNMBX_11

--- a/ios/RNMBX/RNMBXPointAnnotation.swift
+++ b/ios/RNMBX/RNMBXPointAnnotation.swift
@@ -10,6 +10,8 @@ final class WeakRef<T: AnyObject> {
 }
 @objc
 public class RNMBXPointAnnotation : RNMBXInteractiveElement {
+  weak var manager:RNMBXPointAnnotationManager? = nil
+  
   static let key = "RNMBXPointAnnotation"
   static var gid = 0;
   
@@ -26,11 +28,28 @@ public class RNMBXPointAnnotation : RNMBXInteractiveElement {
   var image : UIImage? = nil
   var reactSubviews : [UIView] = []
  
-    
   @objc public var onDeselected: RCTBubblingEventBlock? = nil
   @objc public var onDrag: RCTBubblingEventBlock? = nil
   @objc public var onDragEnd: RCTBubblingEventBlock? = nil
   @objc public var onSelected: RCTBubblingEventBlock? = nil
+  
+  private var selected: Bool? = nil {
+    didSet {
+      update { annotation in
+        if let selected = selected {
+          annotation.isSelected = selected
+        }
+      }
+    }
+  }
+  
+  @objc public func setReactSelected(_ _selected: Bool) {
+    if (_selected == true && self.selected != true) {
+      manager?.selected(pointAnnotation: self)
+    } else if (_selected == false && self.selected == true) {
+      manager?.unselected(pointAnnotation: self)
+    }
+  }
   
   @objc public var coordinate : String? {
     didSet {
@@ -173,6 +192,7 @@ public class RNMBXPointAnnotation : RNMBXInteractiveElement {
   }
   
   func doSelect() {
+    self.selected = true
     let event = makeEvent(isSelect: true)
     if let onSelected = onSelected {
       onSelected(event.toJSON())
@@ -181,6 +201,7 @@ public class RNMBXPointAnnotation : RNMBXInteractiveElement {
   }
   
   func doDeselect(deselectAnnotationOnMapTap: Bool = false) {
+    self.selected = false
     let event = makeEvent(isSelect: false, deselectAnnotationOnMapTap: deselectAnnotationOnMapTap)
     if let onDeselected = onDeselected {
       onDeselected(event.toJSON())

--- a/ios/RNMBX/RNMBXPointAnnotationComponentView.mm
+++ b/ios/RNMBX/RNMBXPointAnnotationComponentView.mm
@@ -11,6 +11,8 @@
 #import <react/renderer/components/rnmapbox_maps_specs/Props.h>
 #import <react/renderer/components/rnmapbox_maps_specs/RCTComponentViewHelpers.h>
 
+#import "RNMBXFabricPropConvert.h"
+
 using namespace facebook::react;
 
 @interface RNMBXPointAnnotationComponentView () <RCTRNMBXPointAnnotationViewProtocol>
@@ -122,23 +124,26 @@ using namespace facebook::react;
 
 - (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
-  const auto &newProps = static_cast<const RNMBXPointAnnotationProps &>(*props);
-    id coordinate = RNMBXConvertFollyDynamicToId(newProps.coordinate);
+  const auto &newViewProps = static_cast<const RNMBXPointAnnotationProps &>(*props);
+  const auto &oldViewProps = static_cast<const RNMBXPointAnnotationProps &>(*oldProps);
+    id coordinate = RNMBXConvertFollyDynamicToId(newViewProps.coordinate);
     if (coordinate != nil) {
         _view.coordinate = coordinate;
     }
-    id draggable = RNMBXConvertFollyDynamicToId(newProps.draggable);
+    id draggable = RNMBXConvertFollyDynamicToId(newViewProps.draggable);
     if (draggable != nil) {
         _view.draggable = draggable;
     }
-    id idx = RNMBXConvertFollyDynamicToId(newProps.id);
+    id idx = RNMBXConvertFollyDynamicToId(newViewProps.id);
     if (idx != nil) {
         _view.id = idx;
     }
-    id anchor = RNMBXConvertFollyDynamicToId(newProps.anchor);
+    id anchor = RNMBXConvertFollyDynamicToId(newViewProps.anchor);
     if (anchor != nil) {
         _view.anchor = anchor;
     }
+   
+  RNMBX_REMAP_OPTIONAL_PROP_BOOL(selected, reactSelected);
     
   [super updateProps:props oldProps:oldProps];
 }

--- a/src/specs/RNMBXPointAnnotationNativeComponent.ts
+++ b/src/specs/RNMBXPointAnnotationNativeComponent.ts
@@ -28,6 +28,7 @@ export interface NativeProps extends ViewProps {
   draggable: UnsafeMixed<boolean>;
   id: UnsafeMixed<string>;
   anchor: UnsafeMixed<any>;
+  selected: UnsafeMixed<boolean>;
 
   onMapboxPointAnnotationDeselected: DirectEventHandler<OnMapboxPointAnnotationDeselectedEventType>;
   onMapboxPointAnnotationDrag: DirectEventHandler<OnMapboxPointAnnotationDragEventType>;

--- a/src/specs/codegenUtils.ts
+++ b/src/specs/codegenUtils.ts
@@ -1,6 +1,9 @@
 // codegen will generate folly::dynamic in place of this type, but it's not exported by RN
 // since codegen doesn't really follow imports, this way we can trick it into generating the correct type
 // while keeping typescript happy
+//
+// For booleans: UnsafeMixed<boolean> preserves nullability (true/false/null) vs boolean which defaults to false
+// This allows native code to distinguish between "prop not set" vs "prop explicitly set to false"
 export type UnsafeMixed<T> = T;
 
 // Fabric doesn't support optional props, so we need to use UnsafeMixed


### PR DESCRIPTION
## Description

Fixes: #4034

## TODO

- [ ] Fix android select/deselet

## Checklist

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

```jsx
import React from 'react';
import { View } from 'react-native';
import {
  MapView,
  ShapeSource,
  LineLayer,
  Camera,
  PointAnnotation,
} from '@rnmapbox/maps';

export default function BugReportExample() {
  const [selected, setSelected] = React.useState(false);
  React.useEffect(() => {
    console.log('Selected:', selected);
  }, [selected]);

  return (
    <MapView style={{ flex: 1 }} onPress={() => setSelected(false)}>
      <Camera
        defaultSettings={{
          centerCoordinate: [-74.00597, 40.71427],
          zoomLevel: 14,
        }}
      />
      <PointAnnotation
        id="foo"
        coordinate={[-74.00597, 40.71427]}
        selected={selected}
        onSelected={() => {
          console.log('onSelected');
          setSelected(true);
        }}
        onDeselected={() => {
          console.log('onDeselected');
          setSelected(false);
        }}
      >
        <View style={{ height: 40, width: 40, backgroundColor: 'red' }} />
      </PointAnnotation>
    </MapView>
  );
}
```
