### PR TITLE
fix(android): allow marker view to extend clipping

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewContent.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewContent.kt
@@ -2,11 +2,28 @@ package com.rnmapbox.rnmbx.components.annotation
 
 import android.content.Context
 import android.view.View.MeasureSpec
+import android.view.ViewGroup
 import com.facebook.react.views.view.ReactViewGroup
 
 class RNMBXMarkerViewContent(context: Context): ReactViewGroup(context) {
-
     var inAdd: Boolean = false
+
+    init {
+        allowRenderingOutside()
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        configureParentClipping()
+    }
+
+    private fun configureParentClipping() {
+        val parent = parent
+        if (parent is android.view.ViewGroup) {
+            parent.allowRenderingOutside()
+        }
+    }
+
     // see https://github.com/rnmapbox/maps/pull/3235
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
         if (inAdd) {
@@ -25,6 +42,10 @@ class RNMBXMarkerViewContent(context: Context): ReactViewGroup(context) {
             super.onMeasure(widthMeasureSpec, heightMeasureSpec)
         }
     }
+}
 
+private fun ViewGroup.allowRenderingOutside() {
+    this.clipChildren = false
+    this.clipToPadding = false
 }
 


### PR DESCRIPTION
## Description

Thanks much [unendingblue](https://github.com/unendingblue) for the patch in #3769 

Fixes #3769

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<img width="388" height="663" alt="image" src="https://github.com/user-attachments/assets/4c14fa10-939f-463d-a819-44d280cf3915" />



## Component to reproduce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here  -->
```jsx
import React from 'react';
import { View } from 'react-native';
import { MapView, MarkerView, Camera } from '@rnmapbox/maps';

const MarkerTestMap = () => {
  return (
    <MapView style={{ flex: 1 }}>
      <Camera defaultSettings={{ centerCoordinate: [0, -60], zoomLevel: 12 }} />
      <MarkerView coordinate={[0, -60]}>
        <View style={{ width: 130, aspectRatio: 1, backgroundColor: 'red' }}>
          <View
            style={{
              position: 'absolute',
              top: -50,
              width: 100,
              height: 25,
              backgroundColor: 'green',
            }}
          />
        </View>
      </MarkerView>
    </MapView>
  );
};
export default MarkerTestMap;
```
