### PR TITLE
fix(ios): fix draggable attribue on point annotation

### DIFF
--- a/ios/RNMBX/RNMBXPointAnnotationComponentView.mm
+++ b/ios/RNMBX/RNMBXPointAnnotationComponentView.mm
@@ -128,7 +128,7 @@ using namespace facebook::react;
   const auto &newViewProps = static_cast<const RNMBXPointAnnotationProps &>(*props);
 
   RNMBX_OPTIONAL_PROP_NSString(coordinate)
-  RNMBX_OPTIONAL_PROP_BOOL(draggable);
+  RNMBX_OPTIONAL_PROP_BOOL(draggable)
   RNMBX_OPTIONAL_PROP_NSString(id)
   RNMBX_OPTIONAL_PROP_NSDictionary(anchor)
 


### PR DESCRIPTION
## Description

Fixes #3899 

In fabric boolean was not properly interpreted, but the pointer was converted to BOOL which was always tue

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

## Component to reproduce the issue you're fixing

In examples Annotations/ShowPointAnnotation.tsx add draggable={false} and test that they cannot be dragged after long press
