### PR TITLE
fix(ios, newarch): fix custom location provider

### DIFF
--- a/ios/RNMBX/RNMBXCustomLocationProvider.swift
+++ b/ios/RNMBX/RNMBXCustomLocationProvider.swift
@@ -36,7 +36,9 @@ public class RNMBXCustomLocationProvider: UIView, RNMBXMapComponent {
   
   @objc
   override public func didSetProps(_ props: [String]) {
-    changes.apply(self)
+    if customLocationProvider != nil {
+      changes.apply(self)
+    }
   }
   
   var customLocationProvider: CustomLocationProvider? = nil
@@ -49,6 +51,7 @@ public class RNMBXCustomLocationProvider: UIView, RNMBXMapComponent {
     self.map = map
     if let mapView = map.mapView {
       installCustomeLocationProviderIfNeeded(mapView: mapView)
+      changes.apply(self)
     }
   }
   

--- a/ios/RNMBX/RNMBXCustomLocationProviderComponentView.mm
+++ b/ios/RNMBX/RNMBXCustomLocationProviderComponentView.mm
@@ -12,6 +12,8 @@
 #import <react/renderer/components/rnmapbox_maps_specs/Props.h>
 #import <react/renderer/components/rnmapbox_maps_specs/RCTComponentViewHelpers.h>
 
+#import "RNMBXFabricPropConvert.h"
+
 using namespace facebook::react;
 
 @interface RNMBXCustomLocationProviderComponentView () <RCTRNMBXCustomLocationProviderViewProtocol>
@@ -30,7 +32,7 @@ using namespace facebook::react;
 - (instancetype)initWithFrame:(CGRect)frame
 {
   if (self = [super initWithFrame:frame]) {
-    static const auto defaultProps = std::make_shared<const RNMBXCircleLayerProps>();
+    static const auto defaultProps = std::make_shared<const RNMBXCustomLocationProviderProps>();
     _props = defaultProps;
       [self prepareView];
   }
@@ -49,12 +51,20 @@ using namespace facebook::react;
 
 + (ComponentDescriptorProvider)componentDescriptorProvider
 {
-  return concreteComponentDescriptorProvider<RNMBXCircleLayerComponentDescriptor>();
+  return concreteComponentDescriptorProvider<RNMBXCustomLocationProviderComponentDescriptor>();
 }
 
 - (void)updateProps:(const Props::Shared &)props oldProps:(const Props::Shared &)oldProps
 {
+  const auto &oldViewProps = static_cast<const RNMBXCustomLocationProviderProps &>(*oldProps);
+  const auto &newViewProps = static_cast<const RNMBXCustomLocationProviderProps &>(*props);
+
+  RNMBX_OPTIONAL_PROP_NumberArray(coordinate)
+  RNMBX_OPTIONAL_PROP_NSNumber(heading)
+
   [super updateProps:props oldProps:oldProps];
+
+  [_view didSetProps:@[]];
 }
 
 - (void)prepareForRecycle

--- a/ios/RNMBX/RNMBXFabricPropConvert.h
+++ b/ios/RNMBX/RNMBXFabricPropConvert.h
@@ -13,6 +13,7 @@ NSNumber* RNMBXPropConvert_Optional_BOOL_NSNumber(const folly::dynamic &dyn, NSS
 BOOL RNMBXPropConvert_Optional_BOOL(const folly::dynamic &dyn, NSString* propertyName);
 NSString* RNMBXPropConvert_Optional_NSString(const folly::dynamic &dyn, NSString* propertyName);
 NSNumber* RNMBXPropConvert_Optional_NSNumber(const folly::dynamic &dyn, NSString* propertyName);
+NSArray<NSNumber*>* RNMBXPropConvert_Optional_NumberArray(const folly::dynamic &dyn, NSString* propertyName);
 id RNMBXPropConvert_Optional_ExpressionDouble(const folly::dynamic &dyn, NSString* propertyName);
 BOOL RNMBXPropConvert_BOOL(const folly::dynamic &dyn, NSString* propertyName);
 NSDictionary* RNMBXPropConvert_Optional_NSDictionary(const folly::dynamic &dyn, NSString* propertyName);
@@ -37,6 +38,11 @@ NSDictionary* RNMBXPropConvert_Optional_NSDictionary(const folly::dynamic &dyn, 
 #define RNMBX_OPTIONAL_PROP_NSString(name) \
   if ((!oldProps.get() || oldViewProps.name != newViewProps.name) && !newViewProps.name.isNull()) { \
     _view.name = RNMBXPropConvert_Optional_NSString(newViewProps.name, @#name); \
+  }
+
+#define RNMBX_OPTIONAL_PROP_NumberArray(name) \
+  if ((!oldProps.get() || oldViewProps.name != newViewProps.name) && !newViewProps.name.isNull()) { \
+    _view.name = RNMBXPropConvert_Optional_NumberArray(newViewProps.name, @#name); \
   }
 
 #define RNMBX_OPTIONAL_PROP_NSNumber(name) \

--- a/ios/RNMBX/RNMBXFabricPropConvert.mm
+++ b/ios/RNMBX/RNMBXFabricPropConvert.mm
@@ -153,4 +153,8 @@ NSDictionary* RNMBXPropConvert_Optional_NSDictionary(const folly::dynamic &dyn, 
   return RNMBXPropConvert_ID(dyn);
 }
 
+NSArray<NSNumber*> * RNMBXPropConvert_Optional_NumberArray(const folly::dynamic &dyn, NSString* propertyName) {
+  return RNMBXPropConvert_ID(dyn);
+}
+
 #endif


### PR DESCRIPTION
## Description

Fixes #3703

Fixed CustomLocationProvider on iOS, new arch:
- property updates are properly propagates
- property updates before the component is added to map, are executed when it's actually added to map

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here  -->
```jsx

```
