### PR TITLE
increase timeout to 500ms

### DIFF
--- a/ios/RNMBX/Utils/RNMBXViewResolver.mm
+++ b/ios/RNMBX/Utils/RNMBXViewResolver.mm
@@ -84,7 +84,7 @@
     }
 
     NSTimeInterval elapsed = [[NSDate date] timeIntervalSinceDate:startTime];
-    if (elapsed >= 0.2) { // 200ms timeout
+    if (elapsed >= 0.5) { // 500ms timeout
         NSString *errorMsg = [NSString stringWithFormat:@"Could not find view with tag %@ in %@ after %d attempts over %.1fms",
                       viewRef, methodName, (int)attemptCount + 1, elapsed * 1000];
         NSLog(@"%@", errorMsg);


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes #3492

We've been seeing the same behaviour when unmount/mount the map view. For a simpler mapview 200ms works fine but for a more complex map it can go over the 200ms timeout. If it go over the 200ms mark, then non of the callbacks are being set to the map resulting behaviour described in #3836.

This PR increase the timeout to 500ms to give sufficient time before it give up.

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here  -->
```jsx

```
