### PR TITLE
Update RNMapboxMapsVersion in install.md

### DIFF
--- a/plugin/install.md
+++ b/plugin/install.md
@@ -20,13 +20,15 @@ After installing this package, add the [config plugin](https://docs.expo.io/guid
       [
         "@rnmapbox/maps",
         {
-          "RNMapboxMapsVersion": "11.13.4"
+          "RNMapboxMapsVersion": "11.15.0"
         }
       ]
     ]
   }
 }
 ```
+
+You can review the current map versions for [iOS](https://github.com/mapbox/mapbox-maps-ios/releases) and [Android](https://github.com/mapbox/mapbox-maps-android/releases) to determine the version required.
 
 You'll need to provide a download token. Set the `RNMAPBOX_MAPS_DOWNLOAD_TOKEN` environment variable to your download token (requires the `DOWNLOADS:READ` scope):
 


### PR DESCRIPTION
## Description

Related to #4069

I too ran into a build issue when trying to upgrade and migrate towards using the download token as an environment variable. The version in the docs won't build for Expo - so I've updated it to a version that works (see the related issue) and linked to where users can see the current available versions.

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [x] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)