### PR TITLE
Exposes the tile count limit overwrite for offline legacy

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/modules/RNMBXOfflineModuleLegacy.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/modules/RNMBXOfflineModuleLegacy.kt
@@ -375,6 +375,16 @@ class RNMBXOfflineModuleLegacy(private val mReactContext: ReactApplicationContex
     }
 
     @ReactMethod
+    fun setTileCountLimit(tileCountLimit: Int) {
+        UiThreadUtil.runOnUiThread {
+            val offlineRegionManager = getOfflineRegionManager {
+                RNMBXModule.getAccessToken(mReactContext)
+            }
+            offlineRegionManager.setOfflineMapboxTileCountLimit(tileCountLimit.toLong())
+        }
+    }
+
+    @ReactMethod
     fun resetDatabase(promise: Promise) {
         UiThreadUtil.runOnUiThread {
             var purgedCount = 0

--- a/docs/OfflineManagerLegacy.md
+++ b/docs/OfflineManagerLegacy.md
@@ -133,4 +133,20 @@ const offlinePack = await Mapbox.offlineManagerLegacy.getPack();
 ```
 
 
+### setTileCountLimit(limit)
+
+Sets the maximum number of Mapbox-hosted tiles that may be downloaded and stored on the current device.<br/>The Mapbox Terms of Service prohibit changing or bypassing this limit without permission from Mapbox.
+
+#### arguments
+| Name | Type | Required | Description  |
+| ---- | :--: | :------: | :----------: |
+| `limit` | `Number` | `Yes` | Map tile limit count. |
+
+
+
+```javascript
+Mapbox.offlineManagerLegacy.setTileCountLimit(1000);
+```
+
+
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -8620,6 +8620,29 @@
             "name": "OfflinePack"
           }
         }
+      },
+      {
+        "name": "setTileCountLimit",
+        "description": "Sets the maximum number of Mapbox-hosted tiles that may be downloaded and stored on the current device.\nThe Mapbox Terms of Service prohibit changing or bypassing this limit without permission from Mapbox.",
+        "params": [
+          {
+            "name": "limit",
+            "description": "Map tile limit count.",
+            "type": {
+              "name": "Number"
+            },
+            "optional": false
+          }
+        ],
+        "examples": [
+          "Mapbox.offlineManagerLegacy.setTileCountLimit(1000);"
+        ],
+        "returns": {
+          "description": "",
+          "type": {
+            "name": "void"
+          }
+        }
       }
     ]
   },

--- a/ios/RNMBX/Offline/RNMBXOfflineModuleLegacy.m
+++ b/ios/RNMBX/Offline/RNMBXOfflineModuleLegacy.m
@@ -14,6 +14,8 @@ RCT_EXTERN_METHOD(pausePackDownload:(NSString *)name
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(setTileCountLimit:(nonnull NSNumber *)limit)
+
 RCT_EXTERN_METHOD(getPackStatus:(NSString *)name
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)

--- a/ios/RNMBX/Offline/RNMBXOfflineModuleLegacy.swift
+++ b/ios/RNMBX/Offline/RNMBXOfflineModuleLegacy.swift
@@ -364,6 +364,11 @@ func getRegionByName(name: String, offlineRegions: [OfflineRegion]) -> OfflineRe
   }
 
   @objc
+  func setTileCountLimit(_ limit: NSNumber) {
+    self.offlineRegionManager.setOfflineMapboxTileCountLimitForLimit(limit.uint64Value)
+  }
+
+  @objc
   func resetDatabase(_ resolver: @escaping RCTPromiseResolveBlock,
     rejecter: @escaping RCTPromiseRejectBlock)
   {

--- a/src/modules/offline/offlineManagerLegacy.ts
+++ b/src/modules/offline/offlineManagerLegacy.ts
@@ -159,6 +159,20 @@ class OfflineManagerLegacy {
     return this._offlinePacks[name];
   }
 
+  /**
+   * Sets the maximum number of Mapbox-hosted tiles that may be downloaded and stored on the current device.
+   * The Mapbox Terms of Service prohibit changing or bypassing this limit without permission from Mapbox.
+   *
+   * @example
+   * Mapbox.offlineManagerLegacy.setTileCountLimit(1000);
+   *
+   * @param {Number} limit Map tile limit count.
+   * @return {void}
+   */
+  setTileCountLimit(limit: number): void {
+    MapboxOfflineManager.setTileCountLimit(limit);
+  }
+
   async _initialize(forceInit?: boolean): Promise<boolean> {
     if (this._hasInitialized && !forceInit) {
       return true;


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

This pull request adds the formerly unimplemented offline legacy feature known as `setTileCountLimit` for both iOS and Android. This method is used to set the maximum number of Mapbox-hosted tiles that may be downloaded and stored on the current device. Without this feature, I was left with a default small tile count limit that did not work well with my use case. To clarify, I'm using the legacy offline maps because my use case requires increased fidelity when zoomed in close on the map.

I've tested with the new architecture on both Android and iOS. I've also been using my fork of this repo with the `setTileCountLimit` additions in a production application for over 6 months. 

Fixes #4017 

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [X] I've read `CONTRIBUTING.md`
- [X] I updated the doc/other generated code with running `yarn generate` in the root folder
- [X] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [X] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [X] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here  -->
I don't think there's a reason to create a component to reproduce this because these changes implement a part of the legacy offline map api that wasn't implemented before.
```jsx
```
