### PR TITLE
refactor: Consolidate addCustomHeader API to a single method

### DIFF
--- a/__tests__/interface.test.js
+++ b/__tests__/interface.test.js
@@ -96,7 +96,6 @@ describe('Public Interface', () => {
       'requestAndroidLocationPermissions',
       'getAnnotationsLayerID',
       'addCustomHeader',
-      'addCustomHeaderWithOptions',
       'removeCustomHeader',
 
       // animated

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -26,11 +26,11 @@ const styles = StyleSheet.create({
 });
 
 Mapbox.addCustomHeader('Custom-Header', 'global-header-value');
-Mapbox.addCustomHeaderWithOptions('Mapbox-Api-Header-Value', 'api-header-value', {
+Mapbox.addCustomHeader('Mapbox-Api-Header-Value', 'api-header-value', {
   urlRegexp: '^https:\/\/api\.mapbox\.com\/(.*)$',
 });
 // This header will not be added to requests to api.mapbox.com
-Mapbox.addCustomHeaderWithOptions('Other-Api-Header-Value', 'other-api-header-value', {
+Mapbox.addCustomHeader('Other-Api-Header-Value', 'other-api-header-value', {
   urlRegexp: '^https:\/\/api\.other\.com\/(.*)$',
 });
 Mapbox.setAccessToken(config.get('accessToken'));

--- a/src/RNMBXModule.ts
+++ b/src/RNMBXModule.ts
@@ -58,6 +58,24 @@ if (NativeModules.RNMBXModule == null) {
   }
 }
 
+/**
+ * Add a custom header to HTTP requests.
+ * @param headerName - The name of the header
+ * @param headerValue - The value of the header
+ * @param options - Optional configuration. If provided with urlRegexp, the header will only be added to URLs matching the regex
+ */
+function addCustomHeader(
+  headerName: string,
+  headerValue: string,
+  options?: { urlRegexp?: string },
+): void {
+  if (options) {
+    RNMBXModule.addCustomHeaderWithOptions(headerName, headerValue, options);
+  } else {
+    RNMBXModule.addCustomHeader(headerName, headerValue);
+  }
+}
+
 export const {
   StyleURL,
   OfflinePackDownloadState,
@@ -65,8 +83,6 @@ export const {
   StyleSource,
   TileServers,
   removeCustomHeader,
-  addCustomHeader,
-  addCustomHeaderWithOptions,
   setAccessToken,
   setWellKnownTileServer,
   clearData,
@@ -74,3 +90,5 @@ export const {
   setTelemetryEnabled,
   setConnected,
 } = RNMBXModule;
+
+export { addCustomHeader };


### PR DESCRIPTION
## Description

This change unifies the JS API for adding custom headers by providing a single addCustomHeader method with an optional options parameter, instead of having two separate methods (addCustomHeader and addCustomHeaderWithOptions).

The implementation conditionally calls the appropriate native method based on whether options are provided, maintaining compatibility with both native implementations while presenting a cleaner API to users.

See #3988

Changes:
- Modified RNMBXModule.ts to create a wrapper function that routes to the appropriate native method based on the presence of options
- Updated example/src/App.js to use the unified API
- Updated interface test to reflect the single public method


