### PR TITLE
fix(expo-plugin): allow empty options object for plugin configuration

### DIFF
--- a/plugin/build/withMapbox.js
+++ b/plugin/build/withMapbox.js
@@ -117,7 +117,7 @@ exports.addMapboxInstallerBlock = addMapboxInstallerBlock;
  *
  * https://github.com/rnmapbox/maps/blob/main/ios/install.md#react-native--0600
  */
-const withCocoaPodsInstallerBlocks = (config, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, }) => (0, config_plugins_1.withDangerousMod)(config, [
+const withCocoaPodsInstallerBlocks = (config, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, } = {}) => (0, config_plugins_1.withDangerousMod)(config, [
     'ios',
     async (exportedConfig) => {
         const file = path_1.default.join(exportedConfig.modRequest.platformProjectRoot, 'Podfile');
@@ -131,7 +131,7 @@ const withCocoaPodsInstallerBlocks = (config, { RNMapboxMapsImpl, RNMapboxMapsVe
         return exportedConfig;
     },
 ]);
-const withAndroidPropertiesDownloadToken = (config, { RNMapboxMapsDownloadToken }) => {
+const withAndroidPropertiesDownloadToken = (config, { RNMapboxMapsDownloadToken } = {}) => {
     const key = 'MAPBOX_DOWNLOADS_TOKEN';
     if (RNMapboxMapsDownloadToken) {
         console.warn('⚠️ WARNING: RNMapboxMapsDownloadToken is deprecated. Use RNMAPBOX_MAPS_DOWNLOAD_TOKEN environment variable instead.');
@@ -148,7 +148,7 @@ const withAndroidPropertiesDownloadToken = (config, { RNMapboxMapsDownloadToken 
     }
     return config;
 };
-const withAndroidPropertiesImpl2 = (config, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsUseV11 }) => {
+const withAndroidPropertiesImpl2 = (config, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsUseV11 } = {}) => {
     const keyValues = {
         expoRNMapboxMapsImpl: RNMapboxMapsImpl,
         expoRNMapboxMapsVersion: RNMapboxMapsVersion,
@@ -174,7 +174,7 @@ const withAndroidPropertiesImpl2 = (config, { RNMapboxMapsImpl, RNMapboxMapsVers
     }
     return config;
 };
-const withAndroidProperties = (config, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken, RNMapboxMapsVersion, RNMapboxMapsUseV11, }) => {
+const withAndroidProperties = (config, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken, RNMapboxMapsVersion, RNMapboxMapsUseV11, } = {}) => {
     config = withAndroidPropertiesDownloadToken(config, {
         RNMapboxMapsDownloadToken,
     });
@@ -256,7 +256,7 @@ const addMapboxMavenRepo = (src) => appendContents({
 }).contents;
 exports.addMapboxMavenRepo = addMapboxMavenRepo;
 exports._addMapboxMavenRepo = exports.addMapboxMavenRepo;
-const withAndroidAppGradle = (config) => (0, config_plugins_1.withAppBuildGradle)(config, ({ modResults, ...exportedConfig }) => {
+const withAndroidAppGradle = (config, _props = {}) => (0, config_plugins_1.withAppBuildGradle)(config, ({ modResults, ...exportedConfig }) => {
     if (modResults.language !== 'groovy') {
         config_plugins_1.WarningAggregator.addWarningAndroid('withMapbox', `Cannot automatically configure app build.gradle if it's not groovy`);
         return { modResults, ...exportedConfig };
@@ -264,7 +264,7 @@ const withAndroidAppGradle = (config) => (0, config_plugins_1.withAppBuildGradle
     modResults.contents = addLibCppFilter(modResults.contents);
     return { modResults, ...exportedConfig };
 });
-const withAndroidProjectGradle = (config) => (0, config_plugins_1.withProjectBuildGradle)(config, ({ modResults, ...exportedConfig }) => {
+const withAndroidProjectGradle = (config, _props = {}) => (0, config_plugins_1.withProjectBuildGradle)(config, ({ modResults, ...exportedConfig }) => {
     if (modResults.language !== 'groovy') {
         config_plugins_1.WarningAggregator.addWarningAndroid('withMapbox', `Cannot automatically configure app build.gradle if it's not groovy`);
         return { modResults, ...exportedConfig };
@@ -272,7 +272,7 @@ const withAndroidProjectGradle = (config) => (0, config_plugins_1.withProjectBui
     modResults.contents = (0, exports.addMapboxMavenRepo)(modResults.contents);
     return { modResults, ...exportedConfig };
 });
-const withMapboxAndroid = (config, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken, RNMapboxMapsVersion, RNMapboxMapsUseV11, }) => {
+const withMapboxAndroid = (config, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken, RNMapboxMapsVersion, RNMapboxMapsUseV11, } = {}) => {
     config = withAndroidProperties(config, {
         RNMapboxMapsImpl,
         RNMapboxMapsDownloadToken,
@@ -283,7 +283,7 @@ const withMapboxAndroid = (config, { RNMapboxMapsImpl, RNMapboxMapsDownloadToken
     config = withAndroidAppGradle(config, { RNMapboxMapsImpl });
     return config;
 };
-const withMapbox = (config, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, }) => {
+const withMapbox = (config, { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsDownloadToken, RNMapboxMapsUseV11, } = {}) => {
     config = withMapboxAndroid(config, {
         RNMapboxMapsImpl,
         RNMapboxMapsVersion,

--- a/plugin/src/withMapbox.ts
+++ b/plugin/src/withMapbox.ts
@@ -188,7 +188,7 @@ const withCocoaPodsInstallerBlocks: ConfigPlugin<MapboxPlugProps> = (
     RNMapboxMapsVersion,
     RNMapboxMapsDownloadToken,
     RNMapboxMapsUseV11,
-  },
+  }: MapboxPlugProps = {},
 ) =>
   withDangerousMod(config, [
     'ios',
@@ -216,7 +216,7 @@ const withCocoaPodsInstallerBlocks: ConfigPlugin<MapboxPlugProps> = (
 
 const withAndroidPropertiesDownloadToken: ConfigPlugin<MapboxPlugProps> = (
   config,
-  { RNMapboxMapsDownloadToken },
+  { RNMapboxMapsDownloadToken }: MapboxPlugProps = {},
 ) => {
   const key = 'MAPBOX_DOWNLOADS_TOKEN';
 
@@ -247,7 +247,7 @@ const withAndroidPropertiesDownloadToken: ConfigPlugin<MapboxPlugProps> = (
 
 const withAndroidPropertiesImpl2: ConfigPlugin<MapboxPlugProps> = (
   config,
-  { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsUseV11 },
+  { RNMapboxMapsImpl, RNMapboxMapsVersion, RNMapboxMapsUseV11 }: MapboxPlugProps = {},
 ) => {
   const keyValues = {
     expoRNMapboxMapsImpl: RNMapboxMapsImpl,
@@ -289,7 +289,7 @@ const withAndroidProperties: ConfigPlugin<MapboxPlugProps> = (
     RNMapboxMapsDownloadToken,
     RNMapboxMapsVersion,
     RNMapboxMapsUseV11,
-  },
+  }: MapboxPlugProps = {},
 ) => {
   config = withAndroidPropertiesDownloadToken(config, {
     RNMapboxMapsDownloadToken,
@@ -391,7 +391,7 @@ export const addMapboxMavenRepo = (src: string): string =>
     comment: '//',
   }).contents;
 
-const withAndroidAppGradle: ConfigPlugin<MapboxPlugProps> = (config) =>
+const withAndroidAppGradle: ConfigPlugin<MapboxPlugProps> = (config, _props: MapboxPlugProps = {}) =>
   withAppBuildGradle(config, ({ modResults, ...exportedConfig }) => {
     if (modResults.language !== 'groovy') {
       WarningAggregator.addWarningAndroid(
@@ -407,7 +407,7 @@ const withAndroidAppGradle: ConfigPlugin<MapboxPlugProps> = (config) =>
     return { modResults, ...exportedConfig };
   });
 
-const withAndroidProjectGradle: ConfigPlugin<MapboxPlugProps> = (config) =>
+const withAndroidProjectGradle: ConfigPlugin<MapboxPlugProps> = (config, _props: MapboxPlugProps = {}) =>
   withProjectBuildGradle(config, ({ modResults, ...exportedConfig }) => {
     if (modResults.language !== 'groovy') {
       WarningAggregator.addWarningAndroid(
@@ -430,7 +430,7 @@ const withMapboxAndroid: ConfigPlugin<MapboxPlugProps> = (
     RNMapboxMapsDownloadToken,
     RNMapboxMapsVersion,
     RNMapboxMapsUseV11,
-  },
+  }: MapboxPlugProps = {},
 ) => {
   config = withAndroidProperties(config, {
     RNMapboxMapsImpl,
@@ -451,7 +451,7 @@ const withMapbox: ConfigPlugin<MapboxPlugProps> = (
     RNMapboxMapsVersion,
     RNMapboxMapsDownloadToken,
     RNMapboxMapsUseV11,
-  },
+  }: MapboxPlugProps = {},
 ) => {
   config = withMapboxAndroid(config, {
     RNMapboxMapsImpl,


### PR DESCRIPTION
## Description

Users can now use the plugin without providing options:
- ["@rnmapbox/maps"] instead of requiring ["@rnmapbox/maps", {}]

Previously, all ConfigPlugin functions destructured the options parameter without default values, causing "Cannot destructure property 'RNMapboxMapsImpl' of 'undefined'" errors when options were not provided.

This change adds default empty object values (= {}) to all function parameters that destructure MapboxPlugProps, making all options truly optional as intended.

See #4070
