### PR TITLE
chore: upgrade default versions to 11.16.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,8 +73,8 @@
   },
   "homepage": "https://github.com/rnmapbox/maps#readme",
   "mapbox": {
-    "ios": "~> 11.15.2",
-    "android": "11.15.2"
+    "ios": "~> 11.16.2",
+    "android": "11.16.2"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",


### PR DESCRIPTION
Update default Mapbox Maps SDK version from 11.15.2 to 11.16.2 for both iOS and Android platforms.

- iOS: Update rnmapbox-maps.podspec default version to ~> 11.16.2
- Android: Update android/build.gradle default version to 11.16.2

This brings bug fixes including crash on 3D/satellite styles switching and performance improvements.
