### PR TITLE
chore: Store default Mapbox iOS and Android versions in package.json

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,13 @@
 def defaultMapboxMapsImpl = "mapbox"
-def defaultMapboxMapsVersion = "11.15.2"
+
+def getDefaultMapboxMapsVersion() {
+    def packageJson = new groovy.json.JsonSlurper().parseText(
+        new File(projectDir.getPath(), "../package.json").text
+    )
+    return packageJson.mapbox.android
+}
+
+def defaultMapboxMapsVersion = getDefaultMapboxMapsVersion()
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback

--- a/package.json
+++ b/package.json
@@ -72,6 +72,10 @@
     "url": "https://github.com/rnmapbox/maps/issues"
   },
   "homepage": "https://github.com/rnmapbox/maps#readme",
+  "mapbox": {
+    "ios": "~> 11.15.2",
+    "android": "11.15.2"
+  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public"

--- a/rnmapbox-maps.podspec
+++ b/rnmapbox-maps.podspec
@@ -20,7 +20,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 ## Warning: these lines are scanned by autogenerate.js
-rnMapboxMapsDefaultMapboxVersion = '~> 11.15.2'
+rnMapboxMapsDefaultMapboxVersion = package['mapbox']['ios']
 
 rnMapboxMapsDefaultImpl = 'mapbox'
 

--- a/scripts/autogenHelpers/generateCodeWithEjs.mjs
+++ b/scripts/autogenHelpers/generateCodeWithEjs.mjs
@@ -2,6 +2,7 @@ import ejs from 'ejs';
 import path from 'path';
 import fs from 'fs';
 import styleSpecJSON from '../../style-spec/v8.json' with { type: 'json' };
+import packageJSON from '../../package.json' with { type: 'json' };
 import * as url from 'url';
 
 import prettier from 'prettier';
@@ -12,33 +13,25 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
 import { camelCase } from './globals.mjs';
 
 function readIosVersion() {
-  const podspecPath = path.join(__dirname, '..', '..', 'rnmapbox-maps.podspec');
-  const lines = fs.readFileSync(podspecPath, 'utf8').split('\n');
-  const mapboxLineRegex =
-    /^\s*rnMapboxMapsDefaultMapboxVersion\s*=\s*'~>\s+(\d+\.\d+)(\.\d+)?'$/;
-  const mapboxLine = lines.filter((i) => mapboxLineRegex.exec(i))[0];
+  const iosVersion = packageJSON.mapbox.ios;
+  // Extract version number from format like "~> 11.15.2"
+  const versionMatch = iosVersion.match(/(\d+\.\d+)(\.\d+)?/);
+  if (!versionMatch) {
+    throw new Error(`Invalid iOS version format in package.json: ${iosVersion}`);
+  }
 
   return {
     v10: '10.19.0',
-    v11: `${mapboxLineRegex.exec(mapboxLine)[1]}.0`,
+    v11: `${versionMatch[1]}.0`,
   };
 }
 
 function readAndroidVersion() {
-  const buildGradlePath = path.join(
-    __dirname,
-    '..',
-    '..',
-    'android',
-    'build.gradle',
-  );
-  const lines = fs.readFileSync(buildGradlePath, 'utf8').split('\n');
-  const mapboxV10LineRegex =
-    /^\s*def\s+defaultMapboxMapsVersion\s+=\s+"(\d+\.\d+\.\d+)"$/;
-  const mapboxV10Line = lines.filter((i) => mapboxV10LineRegex.exec(i))[0];
+  const androidVersion = packageJSON.mapbox.android;
+
   return {
     v10: '10.19.0',
-    v11: mapboxV10LineRegex.exec(mapboxV10Line)[1],
+    v11: androidVersion,
   };
 }
 


### PR DESCRIPTION
This change centralizes the default Mapbox SDK versions in package.json instead of hardcoding them in platform-specific build files.

Changes:
- Added "mapbox" section to package.json with iOS and Android version fields
- Updated android/build.gradle to read default version from package.json
- Updated rnmapbox-maps.podspec to read default version from package.json
- Updated scripts/autogenHelpers/generateCodeWithEjs.mjs to read versions from package.json

This makes version management easier and provides a single source of truth for default SDK versions. Users can still override these versions using $RNMapboxMapsVersion (iOS) and RNMapboxMapsVersion (Android) as before.

Inspired by: https://github.com/rive-app/rive-react-native/pull/382
