### PR TITLE
fix screenCoordinate evaluation in queryRenderedFeaturesAtPoint

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapView.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapView.kt
@@ -917,7 +917,13 @@ open class RNMBXMapView(private val mContext: Context, var mManager: RNMBXMapVie
             Logger.e("queryRenderedFeaturesAtPoint", "mapbox map is null")
             return
         }
-        val screenCoordinate = ScreenCoordinate(point.x.toDouble(), point.y.toDouble())
+        // JS sends point values in DIP (see getPointInView which divides by display density),
+        // but Mapbox core expects screen pixel coordinates. Convert back to px here.
+        val density: Float = getDisplayDensity()
+        val screenCoordinate = ScreenCoordinate(
+                (point.x * density).toDouble(),
+                (point.y * density).toDouble()
+        )
         val queryGeometry = RenderedQueryGeometry(screenCoordinate)
         val layers = layerIDs?.takeUnless { it.isEmpty() } ?: null;
         val queryOptions = RenderedQueryOptions(layers, filter)


### PR DESCRIPTION
## Description

Fixes #4092

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [x] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [x] I have tested the new feature on `/example` app.
  - [x] In V11 mode/ios
  - [x] In New Architecture mode/ios
  - [x] In V11 mode/android
  - [x] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Changes Description

I converted the `PointF`value received from JS, from DIP to pixels by multiplying by density before building `ScreenCoordinates` object. This fixes the issue, and makes sure that the same value is returned when running and testing the `queryRenderedFeaturesAtPoint` function from either iOS or Android
