### PR TITLE
fix: Could not find view with tag...

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -476,8 +476,8 @@ type Debounced<F> = F & { clear(): void; flush(): void };
 /**
  * MapView backed by Mapbox Native GL
  */
-class MapView extends NativeBridgeComponent(
-  React.PureComponent<Props>,
+class MapView extends NativeBridgeComponent<Props, RNMBXMapViewRefType, typeof React.PureComponent>(
+  React.PureComponent,
   NativeMapViewModule,
 ) {
   static defaultProps: Props = {
@@ -521,7 +521,6 @@ class MapView extends NativeBridgeComponent(
       >,
     ) => void
   >;
-  _nativeRef?: RNMBXMapViewRefType;
   state: {
     isReady: boolean | null;
     region: null;
@@ -1196,13 +1195,6 @@ class MapView extends NativeBridgeComponent(
     }
 
     return this.props.contentInset;
-  }
-
-  _setNativeRef(nativeRef: RNMBXMapViewRefType | null) {
-    if (nativeRef != null) {
-      this._nativeRef = nativeRef;
-      super._runPendingNativeMethods(nativeRef);
-    }
   }
 
   setNativeProps(props: NativeProps) {

--- a/src/components/NativeBridgeComponent.tsx
+++ b/src/components/NativeBridgeComponent.tsx
@@ -10,6 +10,7 @@ export type RNMBEvent<PayloadType = { [key: string]: string }> = {
 
 const NativeBridgeComponent = <
   Props extends object,
+  RefType,
   BaseComponent extends new (...ags: any[]) => React.Component<Props>,
 >(
   Base: BaseComponent,
@@ -21,27 +22,27 @@ const NativeBridgeComponent = <
       method: { name: string; args: NativeArg[] };
       resolver: (value: NativeArg) => void;
     }>;
+    _nativeRef: RefType | null;
 
     constructor(...args: any[]) {
       super(...args);
 
       this._turboModule = turboModule;
       this._preRefMapMethodQueue = [];
+      this._nativeRef = null;
     }
 
-    async _runPendingNativeMethods<RefType>(nativeRef: RefType) {
-      if (nativeRef) {
-        while (this._preRefMapMethodQueue.length > 0) {
-          const item = this._preRefMapMethodQueue.pop();
+    async _runPendingNativeMethods() {
+      while (this._nativeRef != null && this._preRefMapMethodQueue.length > 0) {
+        const item = this._preRefMapMethodQueue.pop();
 
-          if (item && item.method && item.resolver) {
-            const res = await this._runNativeMethod(
-              item.method.name,
-              nativeRef,
-              item.method.args,
-            );
-            item.resolver(res);
-          }
+        if (item && item.method && item.resolver) {
+          const res = await this._runNativeMethod(
+            item.method.name,
+            this._nativeRef,
+            item.method.args,
+          );
+          item.resolver(res);
         }
       }
     }
@@ -62,6 +63,12 @@ const NativeBridgeComponent = <
 
       return runNativeMethod(this._turboModule, methodName, nativeRef, args);
     }
+
+    _setNativeRef(nativeRef: RefType | null) {
+      this._nativeRef = nativeRef
+      this._runPendingNativeMethods();
+    }
+
   };
 
 export default NativeBridgeComponent;

--- a/src/components/PointAnnotation.tsx
+++ b/src/components/PointAnnotation.tsx
@@ -206,11 +206,6 @@ class PointAnnotation extends NativeBridgeComponent(
     this._runNativeMethod('refresh', this._nativeRef, []);
   }
 
-  _setNativeRef(nativeRef: NativePointAnnotationRef | null) {
-    this._nativeRef = nativeRef;
-    super._runPendingNativeMethods(nativeRef);
-  }
-
   render() {
     const props = {
       ...this.props,

--- a/src/components/ShapeSource.tsx
+++ b/src/components/ShapeSource.tsx
@@ -163,10 +163,10 @@ export class ShapeSource extends NativeBridgeComponent(
   }
 
   _setNativeRef(
-    nativeRef: React.Component<NativeProps> & Readonly<NativeMethods>,
+    nativeRef: RNMBXShapeSourceRefType,
   ) {
     this.setNativeRef(nativeRef);
-    super._runPendingNativeMethods(nativeRef);
+    super._setNativeRef(nativeRef);
   }
 
   /**
@@ -317,7 +317,7 @@ export class ShapeSource extends NativeBridgeComponent(
       lineMetrics: this.props.lineMetrics,
       onPress: undefined,
       ref: (
-        nativeRef: React.Component<NativeProps> & Readonly<NativeMethods>,
+        nativeRef: RNMBXShapeSourceRefType,
       ) => this._setNativeRef(nativeRef),
     };
 
@@ -336,3 +336,5 @@ type NativeProps = {
   id: string;
   shape?: string;
 };
+
+type RNMBXShapeSourceRefType = React.Component<NativeProps> & Readonly<NativeMethods>;


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes `Error: Unknown reactTag:`/`view with tag not found`

Before adding this as a patch on our project we got a whole bunch of these `unknown react tag` or `view with tag not found` errors.
The issue is caused by _runPendingNativeMethods using a _nativeRef that could be invalid. This PR makes sure to set and reset the _nativeRef properly and checking it inside _runPendingNativeMethods.
We are using this as a patch for about 6 weeks now and reported errors went down to 0 while no user complains came up at the same time :)