### PR TITLE
fix(ios): use RNMBXViewResolver for native module view lookups

### DIFF
--- a/ios/RNMBX/RNMBXCameraModule.h
+++ b/ios/RNMBX/RNMBXCameraModule.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import "RNMBXViewResolver.h"
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #import "rnmapbox_maps_specs.h"
@@ -9,9 +10,9 @@
 
 @interface RNMBXCameraModule : NSObject
 #ifdef RCT_NEW_ARCH_ENABLED
-<NativeRNMBXCameraModuleSpec>
+<NativeRNMBXCameraModuleSpec, RNMBXViewResolverDelegate>
 #else
-<RCTBridgeModule>
+<RCTBridgeModule, RNMBXViewResolverDelegate>
 #endif
 
 @end

--- a/ios/RNMBX/RNMBXCameraModule.mm
+++ b/ios/RNMBX/RNMBXCameraModule.mm
@@ -36,22 +36,14 @@ RCT_EXPORT_MODULE();
 
 - (void)withCamera:(nonnull NSNumber*)viewRef block:(void (^)(RNMBXCamera *))block reject:(RCTPromiseRejectBlock)reject methodName:(NSString *)methodName
 {
-#ifdef RCT_NEW_ARCH_ENABLED
-    [self.viewRegistry_DEPRECATED addUIBlock:^(RCTViewRegistry *viewRegistry) {
-    RNMBXCameraComponentView *componentView = [self.viewRegistry_DEPRECATED viewForReactTag:viewRef];
-        RNMBXCamera *view = componentView.contentView;
-        
-#else
-    [self.bridge.uiManager
-     addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-        RNMBXCamera *view = [uiManager viewForReactTag:viewRef];
-#endif // RCT_NEW_ARCH_ENABLED
-        if (view != nil) {
-           block(view);
-        } else {
-            reject(methodName, [NSString stringWithFormat:@"Unknown reactTag: %@", viewRef], nil);
-        }
-    }];
+    [RNMBXViewResolver withViewRef:viewRef
+                          delegate:self
+                     expectedClass:[RNMBXCamera class]
+                             block:^(UIView *view) {
+                                 block((RNMBXCamera *)view);
+                             }
+                            reject:reject
+                        methodName:methodName];
 }
 
 RCT_EXPORT_METHOD(updateCameraStop:(nonnull NSNumber *)viewRef

--- a/ios/RNMBX/RNMBXImageModule.h
+++ b/ios/RNMBX/RNMBXImageModule.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import "RNMBXViewResolver.h"
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #import "rnmapbox_maps_specs.h"
@@ -9,9 +10,9 @@
 
 @interface RNMBXImageModule : NSObject
 #ifdef RCT_NEW_ARCH_ENABLED
-<NativeRNMBXImageModuleSpec>
+<NativeRNMBXImageModuleSpec, RNMBXViewResolverDelegate>
 #else
-<RCTBridgeModule>
+<RCTBridgeModule, RNMBXViewResolverDelegate>
 #endif
 
 @end

--- a/ios/RNMBX/RNMBXImageModule.mm
+++ b/ios/RNMBX/RNMBXImageModule.mm
@@ -27,22 +27,14 @@ RCT_EXPORT_MODULE();
 
 - (void)withImage:(nonnull NSNumber*)viewRef block:(void (^)(RNMBXImage *))block reject:(RCTPromiseRejectBlock)reject methodName:(NSString *)methodName
 {
-#ifdef RCT_NEW_ARCH_ENABLED
-    [self.viewRegistry_DEPRECATED addUIBlock:^(RCTViewRegistry *viewRegistry) {
-        RNMBXImageComponentView *componentView = [self.viewRegistry_DEPRECATED viewForReactTag:viewRef];
-        RNMBXImage *view = componentView.contentView;
-
-#else
-    [self.bridge.uiManager
-     addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-        RNMBXImage *view = [uiManager viewForReactTag:viewRef];
-#endif // RCT_NEW_ARCH_ENABLED
-        if (view != nil) {
-           block(view);
-        } else {
-            reject(methodName, [NSString stringWithFormat:@"Unknown reactTag: %@", viewRef], nil);
-        }
-    }];
+    [RNMBXViewResolver withViewRef:viewRef
+                          delegate:self
+                     expectedClass:[RNMBXImage class]
+                             block:^(UIView *view) {
+                                 block((RNMBXImage *)view);
+                             }
+                            reject:reject
+                        methodName:methodName];
 }
 
 

--- a/ios/RNMBX/RNMBXPointAnnotationModule.h
+++ b/ios/RNMBX/RNMBXPointAnnotationModule.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import "RNMBXViewResolver.h"
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #import "rnmapbox_maps_specs.h"
@@ -9,9 +10,9 @@
 
 @interface RNMBXPointAnnotationModule : NSObject
 #ifdef RCT_NEW_ARCH_ENABLED
-<NativeRNMBXPointAnnotationModuleSpec>
+<NativeRNMBXPointAnnotationModuleSpec, RNMBXViewResolverDelegate>
 #else
-<RCTBridgeModule>
+<RCTBridgeModule, RNMBXViewResolverDelegate>
 #endif
 
 @end

--- a/ios/RNMBX/RNMBXPointAnnotationModule.mm
+++ b/ios/RNMBX/RNMBXPointAnnotationModule.mm
@@ -27,22 +27,14 @@ RCT_EXPORT_MODULE();
 
 - (void)withPointAnnotation:(nonnull NSNumber*)viewRef block:(void (^)(RNMBXPointAnnotation *))block reject:(RCTPromiseRejectBlock)reject methodName:(NSString *)methodName
 {
-#ifdef RCT_NEW_ARCH_ENABLED
-    [self.viewRegistry_DEPRECATED addUIBlock:^(RCTViewRegistry *viewRegistry) {
-        RNMBXPointAnnotationComponentView *componentView = [self.viewRegistry_DEPRECATED viewForReactTag:viewRef];
-        RNMBXPointAnnotation *view = componentView.contentView;
-        
-#else
-    [self.bridge.uiManager
-     addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-        RNMBXPointAnnotation *view = [uiManager viewForReactTag:viewRef];
-#endif // RCT_NEW_ARCH_ENABLED
-        if (view != nil) {
-           block(view);
-        } else {
-            reject(methodName, [NSString stringWithFormat:@"Unknown reactTag: %@", viewRef], nil);
-        }
-    }];
+    [RNMBXViewResolver withViewRef:viewRef
+                          delegate:self
+                     expectedClass:[RNMBXPointAnnotation class]
+                             block:^(UIView *view) {
+                                 block((RNMBXPointAnnotation *)view);
+                             }
+                            reject:reject
+                        methodName:methodName];
 }
 
 

--- a/ios/RNMBX/RNMBXShapeSourceModule.h
+++ b/ios/RNMBX/RNMBXShapeSourceModule.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import "RNMBXViewResolver.h"
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #import "rnmapbox_maps_specs.h"
@@ -9,9 +10,9 @@
 
 @interface RNMBXShapeSourceModule : NSObject
 #ifdef RCT_NEW_ARCH_ENABLED
-<NativeRNMBXShapeSourceModuleSpec>
+<NativeRNMBXShapeSourceModuleSpec, RNMBXViewResolverDelegate>
 #else
-<RCTBridgeModule>
+<RCTBridgeModule, RNMBXViewResolverDelegate>
 #endif
 
 @end

--- a/ios/RNMBX/RNMBXShapeSourceModule.mm
+++ b/ios/RNMBX/RNMBXShapeSourceModule.mm
@@ -27,22 +27,14 @@ RCT_EXPORT_MODULE();
 
 - (void)withShapeSource:(nonnull NSNumber*)viewRef block:(void (^)(RNMBXShapeSource *))block reject:(RCTPromiseRejectBlock)reject methodName:(NSString *)methodName
 {
-#ifdef RCT_NEW_ARCH_ENABLED
-    [self.viewRegistry_DEPRECATED addUIBlock:^(RCTViewRegistry *viewRegistry) {
-        RNMBXShapeSourceComponentView *componentView = [self.viewRegistry_DEPRECATED viewForReactTag:viewRef];
-        RNMBXShapeSource *view = componentView.contentView;
-        
-#else
-    [self.bridge.uiManager
-     addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-        RNMBXShapeSource *view = [uiManager viewForReactTag:viewRef];
-#endif // RCT_NEW_ARCH_ENABLED
-        if (view != nil) {
-           block(view);
-        } else {
-            reject(methodName, [NSString stringWithFormat:@"Unknown reactTag: %@", viewRef], nil);
-        }
-    }];
+    [RNMBXViewResolver withViewRef:viewRef
+                          delegate:self
+                     expectedClass:[RNMBXShapeSource class]
+                             block:^(UIView *view) {
+                                 block((RNMBXShapeSource *)view);
+                             }
+                            reject:reject
+                        methodName:methodName];
 }
 
 

--- a/ios/RNMBX/RNMBXViewportModule.h
+++ b/ios/RNMBX/RNMBXViewportModule.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import "RNMBXViewResolver.h"
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #import "rnmapbox_maps_specs.h"
@@ -9,9 +10,9 @@
 
 @interface RNMBXViewportModule : NSObject
 #ifdef RCT_NEW_ARCH_ENABLED
-<NativeRNMBXViewportModuleSpec>
+<NativeRNMBXViewportModuleSpec, RNMBXViewResolverDelegate>
 #else
-<RCTBridgeModule>
+<RCTBridgeModule, RNMBXViewResolverDelegate>
 #endif
 
 @end

--- a/ios/RNMBX/RNMBXViewportModule.mm
+++ b/ios/RNMBX/RNMBXViewportModule.mm
@@ -36,22 +36,14 @@ RCT_EXPORT_MODULE();
 
 - (void)withViewport:(nonnull NSNumber*)viewRef block:(void (^)(RNMBXViewport *))block reject:(RCTPromiseRejectBlock)reject methodName:(NSString *)methodName
 {
-#ifdef RCT_NEW_ARCH_ENABLED
-    [self.viewRegistry_DEPRECATED addUIBlock:^(RCTViewRegistry *viewRegistry) {
-    RNMBXViewportComponentView *componentView = [self.viewRegistry_DEPRECATED viewForReactTag:viewRef];
-        RNMBXViewport *view = componentView.contentView;
-        
-#else
-    [self.bridge.uiManager
-     addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-        RNMBXViewport *view = [uiManager viewForReactTag:viewRef];
-#endif // RCT_NEW_ARCH_ENABLED
-        if (view != nil) {
-           block(view);
-        } else {
-            reject(methodName, [NSString stringWithFormat:@"Unknown reactTag: %@", viewRef], nil);
-        }
-    }];
+    [RNMBXViewResolver withViewRef:viewRef
+                          delegate:self
+                     expectedClass:[RNMBXViewport class]
+                             block:^(UIView *view) {
+                                 block((RNMBXViewport *)view);
+                             }
+                            reject:reject
+                        methodName:methodName];
 }
 
 RCT_EXPORT_METHOD(getState:(nonnull NSNumber *)viewRef


### PR DESCRIPTION
## Summary
Fixes "Unknown reactTag" errors when calling native methods immediately after receiving a ref callback on iOS.

**Before:** Native modules immediately rejected with "Unknown reactTag" when the JS ref was available but native view wasn't registered yet.

**After:** Uses `RNMBXViewResolver` (already used by MapView) which polls with progressive delays until the view is found.

See #4098 

## Affected modules
- ShapeSource
- PointAnnotation
- Image
- Camera
- Viewport

## Reproducer

```tsx
const BugReportExample = () => {
  const [showShapeSource, setShowShapeSource] = useState(false);
  const shapeSourceRef = { current: null as ShapeSource | null };

  const handleRef = (ref: ShapeSource | null) => {
    shapeSourceRef.current = ref;
    if (ref) {
      // This would fail with "Unknown reactTag" before the fix
      ref.getClusterExpansionZoom(someFeature)
        .then((zoom) => console.log('Got zoom:', zoom))
        .catch((err) => console.error('Error:', err.message));
    }
  };

  return (
    <MapView style={{ flex: 1 }}>
      <Camera centerCoordinate={[-74.00597, 40.71427]} zoomLevel={14} />
      {showShapeSource && (
        <ShapeSource ref={handleRef} id="test" shape={features} cluster>
          <CircleLayer id="circles" />
        </ShapeSource>
      )}
    </MapView>
  );
};
```

**Before fix:**
```
[handleRef] Error #0: Unknown reactTag: 2502
[handleRef] Error #1: Unknown reactTag: 2502
```

**After fix:** View resolution succeeds, method executes normally.