### PR TITLE
fix(android): use Arguments.createMap() for RN 0.76-0.79 compatibility

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/modules/RNMBXModule.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/modules/RNMBXModule.kt
@@ -12,8 +12,8 @@ import com.rnmapbox.rnmbx.events.constants.EventTypes
 import com.rnmapbox.rnmbx.modules.RNMBXOfflineModule
 import com.rnmapbox.rnmbx.modules.RNMBXLocationModule
 import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.buildReadableMap
 import com.facebook.react.common.MapBuilder
 import com.mapbox.bindgen.None
 import com.mapbox.common.*
@@ -173,7 +173,7 @@ class RNMBXModule(private val mReactContext: ReactApplicationContext) : ReactCon
     }
 
     @ReactMethod
-    fun addCustomHeaderWithOptions(headerName: String, headerValue: String, options: ReadableMap? = buildReadableMap { }) {
+    fun addCustomHeaderWithOptions(headerName: String, headerValue: String, options: ReadableMap? = Arguments.createMap()) {
         try {
             val urlRegexp = options?.getString("urlRegexp")?.toRegex()
             CustomHttpHeaders.addCustomHeader(headerName, headerValue, CustomHttpHeadersOptions(urlRegexp = urlRegexp))


### PR DESCRIPTION
Fixes build failure on React Native 0.76+ where `buildReadableMap` is not yet available (it was added in RN 0.80). Uses `Arguments.createMap()` which works across all RN versions.

Fixes #4088