### PR TITLE
fix: export setup-jest.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
       "default": "./lib/module/index.js"
     },
     "./package.json": "./package.json",
-    "./app.plugin.js": "./app.plugin.js"
+    "./app.plugin.js": "./app.plugin.js",
+    "./setup-jest": "./setup-jest.js"
   },
   "files": [
     "src",


### PR DESCRIPTION
## Description

Fixes #4094

Adds `setup-jest.js` to pacakge exports.

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)
