### PR TITLE
fix(codegen): move things out of #ifdef to fix codegen on < RN 0.81

### DIFF
--- a/ios/RNMBX/RNMBXRasterArraySourceComponentView.mm
+++ b/ios/RNMBX/RNMBXRasterArraySourceComponentView.mm
@@ -13,10 +13,10 @@
 
 using namespace facebook::react;
 
-#if RNMBX_11
-
 @interface RNMBXRasterArraySourceComponentView () <RCTRNMBXRasterArraySourceViewProtocol>
 @end
+
+#if RNMBX_11
 
 @implementation RNMBXRasterArraySourceComponentView {
     RNMBXRasterArraySource *_view;
@@ -117,18 +117,10 @@ using namespace facebook::react;
 
 @end
 
-Class<RCTComponentViewProtocol> RNMBXRasterArraySourceCls(void)
-{
-  return RNMBXRasterArraySourceComponentView.class;
-}
-
 #else // !RNMBX_11
 
 // RasterArraySource is only available in Mapbox v11+
 // Provide a stub implementation for v10 builds
-
-@interface RNMBXRasterArraySourceComponentView () <RCTRNMBXRasterArraySourceViewProtocol>
-@end
 
 @implementation RNMBXRasterArraySourceComponentView
 
@@ -158,11 +150,12 @@ Class<RCTComponentViewProtocol> RNMBXRasterArraySourceCls(void)
 
 @end
 
+#endif // RNMBX_11
+
 Class<RCTComponentViewProtocol> RNMBXRasterArraySourceCls(void)
 {
   return RNMBXRasterArraySourceComponentView.class;
 }
 
-#endif // RNMBX_11
 
 #endif // RCT_NEW_ARCH_ENABLED

--- a/ios/RNMBX/RNMBXRasterParticleLayerComponentView.mm
+++ b/ios/RNMBX/RNMBXRasterParticleLayerComponentView.mm
@@ -14,10 +14,10 @@
 
 using namespace facebook::react;
 
-#if RNMBX_11
-
 @interface RNMBXRasterParticleLayerComponentView () <RCTRNMBXRasterParticleLayerViewProtocol>
 @end
+
+#if RNMBX_11
 
 @implementation RNMBXRasterParticleLayerComponentView {
     RNMBXRasterParticleLayer *_view;
@@ -70,18 +70,7 @@ using namespace facebook::react;
 
 @end
 
-Class<RCTComponentViewProtocol> RNMBXRasterParticleLayerCls(void)
-{
-  return RNMBXRasterParticleLayerComponentView.class;
-}
-
 #else // !RNMBX_11
-
-// RasterParticleLayer is only available in Mapbox v11+
-// Provide a stub implementation for v10 builds
-
-@interface RNMBXRasterParticleLayerComponentView () <RCTRNMBXRasterParticleLayerViewProtocol>
-@end
 
 @implementation RNMBXRasterParticleLayerComponentView
 
@@ -111,11 +100,11 @@ Class<RCTComponentViewProtocol> RNMBXRasterParticleLayerCls(void)
 
 @end
 
+#endif // RNMBX_11
+
 Class<RCTComponentViewProtocol> RNMBXRasterParticleLayerCls(void)
 {
   return RNMBXRasterParticleLayerComponentView.class;
 }
-
-#endif // RNMBX_11
 
 #endif // RCT_NEW_ARCH_ENABLED


### PR DESCRIPTION
So older codgens are confused by #ifdef-s, simplify that.

## Description

Fixes #4103 

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here  -->
```jsx

```
