### PR TITLE
fix: migrate npm publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -22,6 +25,4 @@ jobs:
       - name: Install dependencies and build 🔧
         run: yarn install --immutable
       - name: Publish package on NPM 📦
-        run: npm publish ${{ github.event.release.prerelease && '--tag next' || ''}}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN_RNMAPBOX }}
+        run: npm publish --provenance --access public ${{ github.event.release.prerelease && '--tag next' || ''}}


### PR DESCRIPTION
npm classic tokens were revoked on Dec 9, 2025. This migrates to OIDC trusted publishing.

**Required manual step**: Configure trusted publisher on npmjs.com for @rnmapbox/maps with GitHub Actions (org: rnmapbox, repo: maps, workflow: publish.yml)