### PR TITLE
fix: upgrade npm for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
           registry-url: 'https://registry.npmjs.org'
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
       - name: Install dependencies and build 🔧
         run: yarn install --immutable
       - name: Publish package on NPM 📦


### PR DESCRIPTION
GitHub runners don't have npm 11.5.1+ which is required for OIDC trusted publishing. This adds a step to upgrade npm before publishing.

See: https://github.com/orgs/community/discussions/173102