### PR TITLE
docs: remove deprecated download token documentation

### DIFF
--- a/ios/install.md
+++ b/ios/install.md
@@ -25,9 +25,6 @@ Add the following to your `ios/Podfile`:
 
 <br>
 
-You will need to authorize your download of the Maps SDK with a secret access token with the `DOWNLOADS:READ` scope. This [guide](https://docs.mapbox.com/ios/maps/guides/install/#configure-credentials) explains how to configure the secret token under section `Configure your secret token`.
-
-
 Run `pod install` to download the proper mapbox dependency.
 
 ```sh

--- a/plugin/build/withMapbox.d.ts
+++ b/plugin/build/withMapbox.d.ts
@@ -6,6 +6,9 @@ export type MapboxPlugProps = {
      */
     RNMapboxMapsImpl?: 'mapbox';
     RNMapboxMapsVersion?: string;
+    /**
+     * @deprecated Download token is no longer required by Mapbox. Do not set this.
+     */
     RNMapboxMapsDownloadToken?: string;
     RNMapboxMapsUseV11?: boolean;
 };

--- a/plugin/install.md
+++ b/plugin/install.md
@@ -28,15 +28,6 @@ After installing this package, add the [config plugin](https://docs.expo.io/guid
 }
 ```
 
-You'll need to provide a download token. Set the `RNMAPBOX_MAPS_DOWNLOAD_TOKEN` environment variable to your download token (requires the `DOWNLOADS:READ` scope):
-
-```bash
-export RNMAPBOX_MAPS_DOWNLOAD_TOKEN="sk.ey...qg"
-npx expo prebuild
-```
-
-For more information about obtaining a download token, refer to the [iOS guide](https://docs.mapbox.com/ios/maps/guides/install/#configure-credentials), which explains how to configure this token under the section `Configure your secret token`.
-
 If you want to show the user's current location on the map with the [UserLocation](../docs/UserLocation.md) component, you can use the [expo-location](https://docs.expo.dev/versions/latest/sdk/location/) plugin to configure the required `NSLocationWhenInUseUsageDescription` property. Install the plugin with `npx expo install expo-location` and add its config plugin to the plugins array of your `app.{json,config.js,config.ts}`:
 
 ```json
@@ -90,16 +81,6 @@ To use V11 just set the version to a 11 version, see [the ios guide](/ios/instal
     ]
   }
 }
-```
-
-### Download Token Configuration
-
-For Expo projects, we recommend using the `RNMAPBOX_MAPS_DOWNLOAD_TOKEN` environment variable:
-
-```bash
-# Set the environment variable before building
-export RNMAPBOX_MAPS_DOWNLOAD_TOKEN="sk.ey...qg"
-npx expo prebuild
 ```
 
 ## Manual Setup

--- a/plugin/src/withMapbox.ts
+++ b/plugin/src/withMapbox.ts
@@ -37,6 +37,9 @@ export type MapboxPlugProps = {
 
   RNMapboxMapsVersion?: string;
 
+  /**
+   * @deprecated Download token is no longer required by Mapbox. Do not set this.
+   */
   RNMapboxMapsDownloadToken?: string;
 
   RNMapboxMapsUseV11?: boolean;

--- a/rnmapbox-maps.podspec
+++ b/rnmapbox-maps.podspec
@@ -12,7 +12,7 @@
 #           product_name: "Mapbox"
 #         }
 #         ```
-#  $RNMapboxMapsDownloadToken - *expo only* download token
+#  $RNMapboxMapsDownloadToken - *deprecated* download token is no longer required
 #  $RNMapboxMapsCustomPods - use a custom pod for mapbox libs
 
 require 'json'


### PR DESCRIPTION
Download token (RNMAPBOX_MAPS_DOWNLOAD_TOKEN) is no longer required by Mapbox for accessing their SDKs. This cleans up user-facing documentation to remove instructions about setting this token, reducing confusion between download tokens and access tokens.


## Description

Fixes #4121

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here  -->
```jsx

```
