### PR TITLE
use puckBearingEnabled instead of iosShowsUserHeadingIndicator

### DIFF
--- a/src/components/UserLocation.tsx
+++ b/src/components/UserLocation.tsx
@@ -259,7 +259,7 @@ class UserLocation extends React.Component<Props, UserLocationState> {
   _renderNative() {
     const { androidRenderMode, showsUserHeadingIndicator } = this.props;
 
-    const props = {
+    const props: React.ComponentProps<typeof LocationPuck> = {
       androidRenderMode,
       puckBearingEnabled: showsUserHeadingIndicator,
       puckBearing: showsUserHeadingIndicator ? 'heading' : undefined,


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Should fix the error
` WARN  LocationPuck: iosShowsUserHeadingIndicator is deprecated, use puckBearingEnabled={true} puckBearing="heading" instead`



## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here  -->
```jsx

```
