### PR TITLE
Replace deprecated react-native deep imports in RNMBXMapView codegen

### DIFF
--- a/src/specs/RNMBXMapViewNativeComponent.ts
+++ b/src/specs/RNMBXMapViewNativeComponent.ts
@@ -1,14 +1,8 @@
 import type { HostComponent, ViewProps } from 'react-native';
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
-import {
-  BubblingEventHandler,
-  DirectEventHandler,
-  Int32,
-  Double,
-  // @ts-ignore - CI environment type resolution issue for CodegenTypes
-} from 'react-native/Libraries/Types/CodegenTypes';
+import { codegenNativeComponent } from 'react-native';
 
 import type { Point, UnsafeMixed } from './codegenUtils';
+import type { CodegenTypes } from 'react-native';
 
 // see https://github.com/rnmapbox/maps/wiki/FabricOptionalProp
 type OptionalProp<T> = UnsafeMixed<T>;
@@ -44,7 +38,7 @@ export interface NativeProps extends ViewProps {
   compassEnabled?: OptionalProp<boolean>;
   compassFadeWhenNorth?: OptionalProp<boolean>;
   compassPosition?: UnsafeMixed<any>;
-  compassViewPosition?: OptionalProp<Int32>;
+  compassViewPosition?: OptionalProp<CodegenTypes.Int32>;
   compassViewMargins?: OptionalProp<Point>;
 
   scaleBarEnabled?: OptionalProp<boolean>;
@@ -54,7 +48,7 @@ export interface NativeProps extends ViewProps {
   scrollEnabled?: OptionalProp<boolean>;
   rotateEnabled?: OptionalProp<boolean>;
   pitchEnabled?: OptionalProp<boolean>;
-  maxPitch?: OptionalProp<Double>;
+  maxPitch?: OptionalProp<CodegenTypes.Double>;
 
   deselectAnnotationOnTap?: OptionalProp<boolean>;
 
@@ -76,13 +70,13 @@ export interface NativeProps extends ViewProps {
   // iOS only
   compassImage?: OptionalProp<string>;
 
-  onPress?: BubblingEventHandler<OnPressEventType>;
-  onLongPress?: DirectEventHandler<OnPressEventType>;
-  onMapChange?: DirectEventHandler<OnMapChangeEventType>;
-  onCameraChanged?: DirectEventHandler<OnCameraChangedEventType>;
+  onPress?: CodegenTypes.BubblingEventHandler<OnPressEventType>;
+  onLongPress?: CodegenTypes.DirectEventHandler<OnPressEventType>;
+  onMapChange?: CodegenTypes.DirectEventHandler<OnMapChangeEventType>;
+  onCameraChanged?: CodegenTypes.DirectEventHandler<OnCameraChangedEventType>;
 
   mapViewImpl?: OptionalProp<string>;
-  preferredFramesPerSecond?: OptionalProp<Int32>;
+  preferredFramesPerSecond?: OptionalProp<CodegenTypes.Int32>;
 }
 
 // @ts-ignore-error - Codegen requires single cast but TypeScript prefers double cast
@@ -137,9 +131,9 @@ type OnMapChangeEventTypeActual = {
 
 export type NativeMapViewActual = HostComponent<
   Omit<NativeProps, 'onCameraChanged' | 'onLongPress' | 'onMapChange'> & {
-    onCameraChanged?: DirectEventHandler<OnCameraChangedEventTypeActual>;
-    onLongPress?: DirectEventHandler<OnPressEventTypeActual>;
-    onPress?: DirectEventHandler<OnPressEventTypeActual>;
-    onMapChange?: DirectEventHandler<OnMapChangeEventTypeActual>;
+    onCameraChanged?: CodegenTypes.DirectEventHandler<OnCameraChangedEventTypeActual>;
+    onLongPress?: CodegenTypes.DirectEventHandler<OnPressEventTypeActual>;
+    onPress?: CodegenTypes.DirectEventHandler<OnPressEventTypeActual>;
+    onMapChange?: CodegenTypes.DirectEventHandler<OnMapChangeEventTypeActual>;
   }
 >;


### PR DESCRIPTION
<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes `ReactNativeJS: Deep imports from the 'react-native' package are deprecated ('react-native/Libraries/Utilities/codegenNativeComponent'). Source: maps/src/specs/RNMBXMapViewNativeComponent.ts 2:0`

Also, use CodegenTypes like here https://github.com/facebook/react-native/blob/0e175ce5b6c80a21237f5cd0f20c9876fa975935/packages/react-native/types/__typetests__/fabric-component-sample.ts#L11

<!-- OR, if you're implementing a new feature: -->


## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [ ] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here  -->
```jsx

```
