### PR TITLE
fix(ci): use generic iOS Simulator destination for CI build

### DIFF
--- a/example/.detoxrc.js
+++ b/example/.detoxrc.js
@@ -23,7 +23,7 @@ module.exports = {
     'ios.debug.ci': {
       type: 'ios.app',
       build:
-        "FORCE_BUNDLING=1 xcodebuild -quiet -workspace ios/RNMapboxExample.xcworkspace -configuration Debug -scheme RNMapboxExample DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=1 GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS DEBUG_RCT_BUNDLE=1' -sdk iphonesimulator -derivedDataPath ios/build -destination 'platform=iOS Simulator,OS=18.6,arch=arm64,name=iPhone SE (3rd generation)'",
+        "FORCE_BUNDLING=1 xcodebuild -quiet -workspace ios/RNMapboxExample.xcworkspace -configuration Debug -scheme RNMapboxExample DISABLE_MANUAL_TARGET_ORDER_BUILD_WARNING=1 GCC_PREPROCESSOR_DEFINITIONS='$GCC_PREPROCESSOR_DEFINITIONS DEBUG_RCT_BUNDLE=1' -sdk iphonesimulator -derivedDataPath ios/build -destination 'generic/platform=iOS Simulator'",
       binaryPath:
         'ios/build/Build/Products/Debug-iphonesimulator/RNMapboxExample.app',
     },
@@ -40,7 +40,6 @@ module.exports = {
       type: 'ios.simulator',
       device: {
         type: 'iPhone SE (3rd generation)',
-        os: '18.2',
       },
     },
   },


### PR DESCRIPTION
## Summary
- Use `generic/platform=iOS Simulator` as the xcodebuild destination for CI builds instead of pinning to a specific OS version and device name, which can fail when simulators aren't pre-created on the runner
- Remove pinned `os` version from the detox simulator.ci device config so it picks whatever iOS version is available