### PR TITLE
fix: variable name 'oldReactStyle' typo

### DIFF
--- a/ios/RNMBX/RNMBXBackgroundLayer.swift
+++ b/ios/RNMBX/RNMBXBackgroundLayer.swift
@@ -30,7 +30,7 @@ public class RNMBXBackgroundLayer: RNMBXLayer {
         styler.backgroundLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
-          oldReactStyle: oldReatStyle,
+          oldReactStyle: oldReactStyle,
           applyUpdater: { (updater) in logged("RNMBXBackgroundLayer.addStyles") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
           }},

--- a/ios/RNMBX/RNMBXCircleLayer.swift
+++ b/ios/RNMBX/RNMBXCircleLayer.swift
@@ -80,7 +80,7 @@ public class RNMBXCircleLayer: RNMBXVectorLayer {
         styler.circleLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
-          oldReactStyle: oldReatStyle,
+          oldReactStyle: oldReactStyle,
           applyUpdater: { (updater) in logged("RNMBXCircleLayer.updateLayer") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
           }},

--- a/ios/RNMBX/RNMBXFillExtrusionLayer.swift
+++ b/ios/RNMBX/RNMBXFillExtrusionLayer.swift
@@ -78,7 +78,7 @@ public class RNMBXFillExtrusionLayer: RNMBXVectorLayer {
         styler.fillExtrusionLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
-          oldReactStyle: oldReatStyle,
+          oldReactStyle: oldReactStyle,
           applyUpdater: { (updater) in logged("RNMBXFillExtrusionLayer.updateLayer") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
           }},

--- a/ios/RNMBX/RNMBXFillLayer.swift
+++ b/ios/RNMBX/RNMBXFillLayer.swift
@@ -80,7 +80,7 @@ public class RNMBXFillLayer: RNMBXVectorLayer {
         styler.fillLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
-          oldReactStyle: oldReatStyle,
+          oldReactStyle: oldReactStyle,
           applyUpdater: { (updater) in logged("RNMBXFillLayer.updateLayer") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout FillLayer) in updater(&layer) }
           }},

--- a/ios/RNMBX/RNMBXHeatmapLayer.swift
+++ b/ios/RNMBX/RNMBXHeatmapLayer.swift
@@ -34,7 +34,7 @@ public class RNMBXHeatmapLayer: RNMBXVectorLayer {
         styler.heatmapLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
-          oldReactStyle: oldReatStyle,
+          oldReactStyle: oldReactStyle,
           applyUpdater: { (updater) in logged("RNMBXHeatmapLayer.updateLayer") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout HeatmapLayer) in updater(&layer) }
           }},

--- a/ios/RNMBX/RNMBXHillshadeLayer.swift
+++ b/ios/RNMBX/RNMBXHillshadeLayer.swift
@@ -73,7 +73,7 @@ public class RNMBXHillshadeLayer: RNMBXLayer {
         styler.hillshadeLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
-          oldReactStyle: oldReatStyle,
+          oldReactStyle: oldReactStyle,
           applyUpdater:{ (updater) in logged("RNMBXHillshadeLayer.updateLayer") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
           }},

--- a/ios/RNMBX/RNMBXLayer.swift
+++ b/ios/RNMBX/RNMBXLayer.swift
@@ -19,10 +19,10 @@ public class RNMBXLayer : UIView, RNMBXMapComponent, RNMBXSourceConsumer {
     didSet { self.optionsChanged() }
   }
 
-  var oldReatStyle: Dictionary<String, Any>? = nil
+  var oldReactStyle: Dictionary<String, Any>? = nil
   @objc public var reactStyle : Dictionary<String, Any>? = nil {
     willSet {
-      oldReatStyle = reactStyle
+      oldReactStyle = reactStyle
     }
     didSet {
       DispatchQueue.main.async {

--- a/ios/RNMBX/RNMBXLineLayer.swift
+++ b/ios/RNMBX/RNMBXLineLayer.swift
@@ -79,7 +79,7 @@ public class RNMBXLineLayer: RNMBXVectorLayer {
         styler.lineLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
-          oldReactStyle: oldReatStyle,
+          oldReactStyle: oldReactStyle,
           applyUpdater: { (updater) in logged("RNMBXLineLayer.updateLayer") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
           }},

--- a/ios/RNMBX/RNMBXModelLayer.swift
+++ b/ios/RNMBX/RNMBXModelLayer.swift
@@ -79,7 +79,7 @@ public class RNMBXModelLayer: RNMBXVectorLayer {
         styler.modelLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
-          oldReactStyle: oldReatStyle,
+          oldReactStyle: oldReactStyle,
           applyUpdater: { (updater) in logged("RNMBXModelLayer.updateLayer") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
           }},

--- a/ios/RNMBX/RNMBXRasterLayer.swift
+++ b/ios/RNMBX/RNMBXRasterLayer.swift
@@ -74,7 +74,7 @@ public class RNMBXRasterLayer: RNMBXLayer {
         styler.rasterLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
-          oldReactStyle: oldReatStyle,
+          oldReactStyle: oldReactStyle,
           applyUpdater:{ (updater) in logged("RNMBXRasterLayer.updateLayer") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
           }},

--- a/ios/RNMBX/RNMBXRasterParticleLayer.swift
+++ b/ios/RNMBX/RNMBXRasterParticleLayer.swift
@@ -73,7 +73,7 @@ public class RNMBXRasterParticleLayer: RNMBXLayer {
         styler.rasterParticleLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
-          oldReactStyle: oldReatStyle,
+          oldReactStyle: oldReactStyle,
           applyUpdater:{ (updater) in logged("RNMBXRasterParticleLayer.updateLayer") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
           }},

--- a/ios/RNMBX/RNMBXSkyLayer.swift
+++ b/ios/RNMBX/RNMBXSkyLayer.swift
@@ -54,7 +54,7 @@ public class RNMBXSkyLayer: RNMBXLayer {
         styler.skyLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
-          oldReactStyle: oldReatStyle,
+          oldReactStyle: oldReactStyle,
           applyUpdater: { (updater) in logged("RNMBXSkyLayer.addStyles") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
           }},

--- a/ios/RNMBX/RNMBXSymbolLayer.swift
+++ b/ios/RNMBX/RNMBXSymbolLayer.swift
@@ -80,7 +80,7 @@ public class RNMBXSymbolLayer: RNMBXVectorLayer {
         styler.symbolLayer(
           layer: &styleLayer,
           reactStyle: reactStyle,
-          oldReactStyle: oldReatStyle,
+          oldReactStyle: oldReactStyle,
           applyUpdater: { (updater) in logged("RNMBXSymbolLayer.updateLayer") {
             try style.updateLayer(withId: self.id, type: LayerType.self) { (layer: inout LayerType) in updater(&layer) }
           }},


### PR DESCRIPTION
## Description

Fixes a small typo in a few Swift files, turning `oldReatStyle` into `oldReactStyle`

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [x] I have tested the new feature on `/example` app.
  - [x] In V11 mode/ios
  - [x] In New Architecture mode/ios
  - [x] In V11 mode/android
  - [x] In New Architecture mode/android
- [x] I added/updated a sample - if a new feature was implemented (`/example`)
