### PR TITLE
fix: enable verbatimModuleSyntax in tsconfig.json

### DIFF
--- a/example/src/examples/Animations/AnimatedLineOffsets.tsx
+++ b/example/src/examples/Animations/AnimatedLineOffsets.tsx
@@ -1,5 +1,5 @@
 import { memo, useRef, useState, useMemo, useCallback } from 'react';
-import { Button, StyleProp, View, ViewStyle } from 'react-native';
+import { Button, type StyleProp, View, type ViewStyle } from 'react-native';
 import {
   Camera,
   Logger,
@@ -8,7 +8,7 @@ import {
   __experimental,
   LineLayer,
 } from '@rnmapbox/maps';
-import { Position } from 'geojson';
+import { type Position } from 'geojson';
 import { Divider, Slider, Text } from '@rneui/base';
 import { SafeAreaView } from 'react-native-safe-area-context';
 // @ts-ignore - @turf packages have type resolution issues with package.json exports

--- a/example/src/examples/Animations/AnimatedPoint.tsx
+++ b/example/src/examples/Animations/AnimatedPoint.tsx
@@ -7,10 +7,10 @@ import {
   CircleLayer,
   __experimental,
 } from '@rnmapbox/maps';
-import { Position } from 'geojson';
+import { type Position } from 'geojson';
 import { Divider, Slider, Text } from '@rneui/base';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { View, Button, StyleProp, ViewStyle } from 'react-native';
+import { View, Button, type StyleProp, type ViewStyle } from 'react-native';
 
 import type { ExampleWithMetadata } from '../common/ExampleMetadata';
 

--- a/example/src/examples/Annotations/CustomCallout.tsx
+++ b/example/src/examples/Annotations/CustomCallout.tsx
@@ -2,11 +2,17 @@ import { useState } from 'react';
 import Mapbox, { type SymbolLayerStyle } from '@rnmapbox/maps';
 // @ts-ignore - @turf packages have type resolution issues with package.json exports
 import { Feature } from '@turf/helpers';
-import { StyleProp, Text, TextStyle, View, ViewStyle } from 'react-native';
+import {
+  type StyleProp,
+  Text,
+  type TextStyle,
+  View,
+  type ViewStyle,
+} from 'react-native';
 
 import exampleIcon from '../../assets/pin.png';
 import sheet from '../../styles/sheet';
-import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
+import { type ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
 
 const defaultCamera = {
   centerCoordinate: [12.338, 45.4385],

--- a/example/src/examples/Annotations/ShowPointAnnotation.tsx
+++ b/example/src/examples/Annotations/ShowPointAnnotation.tsx
@@ -9,11 +9,11 @@ import {
   ShapeSource,
   getAnnotationsLayerID,
 } from '@rnmapbox/maps';
-import { Point, Position } from 'geojson';
+import { type Point, type Position } from 'geojson';
 import { Button } from '@rneui/base';
 
 import Bubble from '../common/Bubble';
-import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
+import { type ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
 
 const ANNOTATION_SIZE = 40;
 

--- a/example/src/examples/BugReportExampleTS.tsx
+++ b/example/src/examples/BugReportExampleTS.tsx
@@ -7,7 +7,7 @@ import {
   ShapeSource,
   SymbolLayer,
 } from '@rnmapbox/maps';
-import { FeatureCollection } from 'geojson';
+import { type FeatureCollection } from 'geojson';
 import { Button } from 'react-native';
 
 const styles = {

--- a/example/src/examples/CacheOffline/CacheManagement.tsx
+++ b/example/src/examples/CacheOffline/CacheManagement.tsx
@@ -12,9 +12,9 @@ import {
 import sheet from '../../styles/sheet';
 import { DEFAULT_CENTER_COORDINATE } from '../../utils';
 import BaseExamplePropTypes, {
-  BaseExampleProps,
+  type BaseExampleProps,
 } from '../common/BaseExamplePropTypes';
-import { ExampleWithMetadata } from '../common/ExampleMetadata';
+import { type ExampleWithMetadata } from '../common/ExampleMetadata';
 
 const styles = StyleSheet.create({
   button: {

--- a/example/src/examples/CacheOffline/OfflineExample.tsx
+++ b/example/src/examples/CacheOffline/OfflineExample.tsx
@@ -8,7 +8,7 @@ import Mapbox, {
 } from '@rnmapbox/maps';
 import { Button, Dimensions, TextInput } from 'react-native';
 
-import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
+import { type ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
 
 const CENTER_COORD: [number, number] = [-73.970895, 40.723279];
 const MAPBOX_VECTOR_TILE_SIZE = 512;

--- a/example/src/examples/CacheOffline/OfflineTilesets.tsx
+++ b/example/src/examples/CacheOffline/OfflineTilesets.tsx
@@ -10,7 +10,7 @@ import {
   VectorSource,
 } from '@rnmapbox/maps';
 
-import { ExampleWithMetadata } from '../common/ExampleMetadata';
+import { type ExampleWithMetadata } from '../common/ExampleMetadata';
 
 const packName = 'map-with-3d-terrain-pack';
 const STYLE_URL = 'mapbox://styles/mapbox/satellite-streets-v11';

--- a/example/src/examples/Camera/Fit.tsx
+++ b/example/src/examples/Camera/Fit.tsx
@@ -4,7 +4,7 @@ import isEqual from 'lodash.isequal';
 import { MapView, Camera, StyleURL, type CameraBounds } from '@rnmapbox/maps';
 
 import sheet from '../../styles/sheet';
-import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
+import { type ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
 
 // Assertion function to ensure camera is not null
 function assertCameraNotNull(camera: Camera | null): asserts camera is Camera {

--- a/example/src/examples/LineLayer/DrawPolyline.tsx
+++ b/example/src/examples/LineLayer/DrawPolyline.tsx
@@ -3,7 +3,7 @@ import { Button, View } from 'react-native';
 import {
   useState,
   useRef,
-  ComponentProps,
+  type ComponentProps,
   useMemo,
   forwardRef,
   type ElementRef,

--- a/example/src/examples/Map/CameraGestureObserver.tsx
+++ b/example/src/examples/Map/CameraGestureObserver.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import { MapView, Camera, CameraGestureObserver, type OnMapSteadyEvent } from '@rnmapbox/maps';
 
-import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
+import { type ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
 
 const styles = StyleSheet.create({
   container: {

--- a/example/src/examples/Map/DynamicUrl.tsx
+++ b/example/src/examples/Map/DynamicUrl.tsx
@@ -9,7 +9,7 @@ import {
 } from '@rnmapbox/maps';
 
 import Bubble from '../common/Bubble';
-import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
+import { type ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
 
 const randomCountries = [
   {

--- a/example/src/examples/Map/LocalizeLabels.tsx
+++ b/example/src/examples/Map/LocalizeLabels.tsx
@@ -2,7 +2,7 @@ import { Camera, MapView } from '@rnmapbox/maps';
 
 const CENTER_COORD = [-74.00597, 40.71427];
 
-import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
+import { type ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
 
 const LocalizeLabels = () => {
   return (

--- a/example/src/examples/Map/MapFps.tsx
+++ b/example/src/examples/Map/MapFps.tsx
@@ -3,7 +3,7 @@ import Mapbox from '@rnmapbox/maps';
 import { Button } from '@rneui/base';
 
 import sheet from '../../styles/sheet';
-import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
+import { type ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
 
 const MapFps = () => {
   const [frameRate, setFrameRate] = useState(60);

--- a/example/src/examples/Map/MapInModal.tsx
+++ b/example/src/examples/Map/MapInModal.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { Button, Text } from 'react-native';
 import { MapView } from '@rnmapbox/maps';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { ParamListBase } from '@react-navigation/native';
+import { type NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { type ParamListBase } from '@react-navigation/native';
 
 type MapInModalProps = {
   navigation?: NativeStackNavigationProp<ParamListBase, string, undefined>;

--- a/example/src/examples/Map/MapUnMount.tsx
+++ b/example/src/examples/Map/MapUnMount.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { Button } from 'react-native';
 
 import sheet from '../../styles/sheet';
-import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
+import { type ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
 
 const MapUnMount = () => {
   const [isMounted, setIsMounted] = useState(true);

--- a/example/src/examples/Map/Ornaments.tsx
+++ b/example/src/examples/Map/Ornaments.tsx
@@ -1,10 +1,15 @@
 import { MapView, Camera, Images } from '@rnmapbox/maps';
 import { useState } from 'react';
-import { Button, ImageSourcePropType, StyleSheet, Text } from 'react-native';
+import {
+  Button,
+  type ImageSourcePropType,
+  StyleSheet,
+  Text,
+} from 'react-native';
 import { Divider } from '@rneui/base';
 
 import Bubble from '../common/Bubble';
-import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
+import { type ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
 
 type CompassImage = 'compass1' | 'compass2';
 const images: Record<CompassImage, ImageSourcePropType> = {

--- a/example/src/examples/Map/ShowMap.tsx
+++ b/example/src/examples/Map/ShowMap.tsx
@@ -5,7 +5,7 @@ import { ButtonGroup } from '@rneui/base';
 
 import sheet from '../../styles/sheet';
 import { onSortOptions } from '../../utils';
-import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
+import { type ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
 
 const ShowMap = () => {
   const _mapOptions = Object.keys(Mapbox.StyleURL)

--- a/example/src/examples/Map/ShowMapLocalStyle.tsx
+++ b/example/src/examples/Map/ShowMapLocalStyle.tsx
@@ -3,7 +3,7 @@ import { Alert } from 'react-native';
 import Mapbox from '@rnmapbox/maps';
 
 import sheet from '../../styles/sheet';
-import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
+import { type ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
 
 const style = JSON.stringify(require('../../assets/map-styleURL-style.json'));
 

--- a/example/src/examples/SymbolCircleLayer/Earthquakes.tsx
+++ b/example/src/examples/SymbolCircleLayer/Earthquakes.tsx
@@ -1,14 +1,14 @@
 import {
   Camera,
   CircleLayer,
-  CircleLayerStyle,
+  type CircleLayerStyle,
   MapView,
   ShapeSource,
   SymbolLayer,
-  SymbolLayerStyle,
+  type SymbolLayerStyle,
   StyleURL,
 } from '@rnmapbox/maps';
-import { FeatureCollection } from 'geojson';
+import { type FeatureCollection } from 'geojson';
 import React, { useRef, useState } from 'react';
 import { FAB, Icon, ListItem } from '@rneui/base';
 import moment from 'moment';
@@ -17,8 +17,8 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import earthQuakesJSON from '../../assets/earthquakes.json';
 import { SF_OFFICE_COORDINATE } from '../../utils';
-import { ExampleWithMetadata } from '../common/ExampleMetadata';
-import { BaseExampleProps } from '../common/BaseExamplePropTypes';
+import { type ExampleWithMetadata } from '../common/ExampleMetadata';
+import { type BaseExampleProps } from '../common/BaseExamplePropTypes';
 
 const layerStyles: {
   singlePoint: CircleLayerStyle;

--- a/example/src/examples/SymbolCircleLayer/ImageScaleTests.tsx
+++ b/example/src/examples/SymbolCircleLayer/ImageScaleTests.tsx
@@ -6,8 +6,8 @@ import {
   Camera,
   CircleLayer,
 } from '@rnmapbox/maps';
-import { ComponentProps } from 'react';
-import { View, Image, Text, ImageSourcePropType } from 'react-native';
+import { type ComponentProps } from 'react';
+import { View, Image, Text, type ImageSourcePropType } from 'react-native';
 
 const styles = {
   mapView: { flex: 1 },

--- a/example/src/examples/SymbolCircleLayer/ShapeSourceIcon.tsx
+++ b/example/src/examples/SymbolCircleLayer/ShapeSourceIcon.tsx
@@ -7,13 +7,13 @@ import {
   SymbolLayer,
   ShapeSource,
 } from '@rnmapbox/maps';
-import { StyleProp, Text, ViewStyle } from 'react-native';
-import { FeatureCollection } from 'geojson';
+import { type StyleProp, Text, type ViewStyle } from 'react-native';
+import { type FeatureCollection } from 'geojson';
 
 import exampleIcon from '../../assets/example.png';
 import pinIcon from '../../assets/pin.png';
-import { SymbolLayerStyleProps } from '../../../../src/utils/MapboxStyles';
-import { ExampleWithMetadata } from '../common/ExampleMetadata';
+import { type SymbolLayerStyleProps } from '../../../../src/utils/MapboxStyles';
+import { type ExampleWithMetadata } from '../common/ExampleMetadata';
 
 const styles: {
   icon: SymbolLayerStyleProps;

--- a/example/src/examples/UserLocation/CustomNativeUserLocation.tsx
+++ b/example/src/examples/UserLocation/CustomNativeUserLocation.tsx
@@ -9,7 +9,7 @@ import {
   Image,
 } from '@rnmapbox/maps';
 
-import { ExampleWithMetadata } from '../common/ExampleMetadata';
+import { type ExampleWithMetadata } from '../common/ExampleMetadata';
 
 const styles = { matchParent: { flex: 1 } };
 

--- a/example/src/examples/UserLocation/UserLocationPadding.tsx
+++ b/example/src/examples/UserLocation/UserLocationPadding.tsx
@@ -8,7 +8,7 @@ import {
 import { ButtonGroup } from '@rneui/base';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
-import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-example-doc
+import { type ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-example-doc
 
 enum Alignment {
   Top = 'TOP',

--- a/example/src/examples/UserLocation/UserLocationRenderMode.tsx
+++ b/example/src/examples/UserLocation/UserLocationRenderMode.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from 'react';
+import { type ReactNode, useState } from 'react';
 import {
   MapView,
   CircleLayer,
@@ -12,7 +12,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { ButtonGroup, Text } from '@rneui/base';
 
 import { DEFAULT_CENTER_COORDINATE } from '../../utils';
-import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
+import { type ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
 
 const SettingsGroup = ({
   children,

--- a/example/src/examples/UserLocation/UserLocationUpdates.tsx
+++ b/example/src/examples/UserLocation/UserLocationUpdates.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react';
 import { Text } from 'react-native';
-import { MapView, Camera, UserLocation, Location } from '@rnmapbox/maps';
+import { MapView, Camera, UserLocation, type Location } from '@rnmapbox/maps';
 
 import Bubble from '../common/Bubble';
-import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-example-doc
+import { type ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-example-doc
 
 const UserLocationUpdates = () => {
   const [location, setLocation] = useState<Location>();

--- a/example/src/examples/V10/CameraAnimation.tsx
+++ b/example/src/examples/V10/CameraAnimation.tsx
@@ -1,21 +1,21 @@
 import { CheckBox, Divider, Slider, Button } from '@rneui/base';
 import {
   Camera,
-  CameraAnimationMode,
-  CameraBounds,
+  type CameraAnimationMode,
+  type CameraBounds,
   CircleLayer,
   Logger,
   MapView,
   ShapeSource,
 } from '@rnmapbox/maps';
 import bbox from '@turf/bbox';
-import { Feature, Point, Position } from 'geojson';
+import { type Feature, type Point, type Position } from 'geojson';
 import { useCallback, useMemo, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import colors from '../../styles/colors';
-import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
+import { type ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
 
 Logger.setLogLevel('verbose');
 

--- a/example/src/examples/V10/FeatureState.tsx
+++ b/example/src/examples/V10/FeatureState.tsx
@@ -1,7 +1,7 @@
-import { ComponentProps, useCallback, useRef } from 'react';
+import { type ComponentProps, useCallback, useRef } from 'react';
 import { Camera, FillLayer, MapView, ShapeSource } from '@rnmapbox/maps';
 
-import { ExampleWithMetadata } from '../common/ExampleMetadata';
+import { type ExampleWithMetadata } from '../common/ExampleMetadata';
 
 type CustomProperties = {
   normalColor: string;

--- a/example/src/examples/V10/GlobeProjection.tsx
+++ b/example/src/examples/V10/GlobeProjection.tsx
@@ -10,7 +10,7 @@ import {
   Camera,
 } from '@rnmapbox/maps';
 
-import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
+import { type ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
 
 Logger.setLogLevel('verbose');
 

--- a/example/src/examples/V10/Markers.tsx
+++ b/example/src/examples/V10/Markers.tsx
@@ -2,9 +2,9 @@ import { useCallback, useEffect, useState } from 'react';
 import { StyleSheet, Pressable, Text, View } from 'react-native';
 import { Button, Divider } from '@rneui/base';
 import { Camera, Logger, MapView, MarkerView } from '@rnmapbox/maps';
-import { Position } from 'geojson';
+import { type Position } from 'geojson';
 
-import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
+import { type ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
 
 Logger.setLogLevel('verbose');
 

--- a/example/src/examples/common/Page.tsx
+++ b/example/src/examples/common/Page.tsx
@@ -3,9 +3,9 @@ import { View } from 'react-native';
 import sheet from '../../styles/sheet';
 import colors from '../../styles/colors';
 
-import { BaseExampleProps } from './BaseExamplePropTypes';
+import { type BaseExampleProps } from './BaseExamplePropTypes';
 import MapHeader from './MapHeader';
-import { ReactNode } from 'react';
+import { type ReactNode } from 'react';
 
 export type PageProps = BaseExampleProps & { children: ReactNode };
 

--- a/example/src/scenes/GroupAndItem.tsx
+++ b/example/src/scenes/GroupAndItem.tsx
@@ -12,7 +12,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { BaseExampleProps } from '../examples/common/BaseExamplePropTypes';
 
 import MapHeader from '../examples/common/MapHeader';
-import Page, { PageProps } from '../examples/common/Page';
+import Page, { type PageProps } from '../examples/common/Page';
 import sheet from '../styles/sheet';
 // ANIMATIONS
 import * as Animations from '../examples/Animations';

--- a/plugin/src/withMapbox.ts
+++ b/plugin/src/withMapbox.ts
@@ -2,7 +2,7 @@ import { promises } from 'fs';
 import path from 'path';
 
 import {
-  ConfigPlugin,
+  type ConfigPlugin,
   createRunOncePlugin,
   withDangerousMod,
   withGradleProperties,
@@ -15,7 +15,7 @@ import {
   mergeContents,
   createGeneratedHeaderComment,
   removeGeneratedContents,
-  MergeResults,
+  type MergeResults,
 } from './generateCode';
 
 let pkg: { name: string; version?: string } = {

--- a/scripts/autogenHelpers/examplesJsonSchema.ts
+++ b/scripts/autogenHelpers/examplesJsonSchema.ts
@@ -1,4 +1,4 @@
-import { ExampleMetadata } from '../../example/src/examples/common/ExampleMetadata';
+import { type ExampleMetadata } from '../../example/src/examples/common/ExampleMetadata';
 
 export type { ExampleMetadata } from '../../example/src/examples/common/ExampleMetadata';
 

--- a/src/Mapbox.native.ts
+++ b/src/Mapbox.native.ts
@@ -45,7 +45,7 @@ export { default as BackgroundLayer } from './components/BackgroundLayer';
 export { default as CustomLocationProvider } from './components/CustomLocationProvider';
 export { Terrain } from './components/Terrain';
 export { default as CameraGestureObserver } from './components/CameraGestureObserver';
-export { OnMapSteadyEvent } from './specs/RNMBXCameraGestureObserverNativeComponent';
+export { type OnMapSteadyEvent } from './specs/RNMBXCameraGestureObserverNativeComponent';
 export {
   default as locationManager,
   type Location,

--- a/src/components/AbstractLayer.tsx
+++ b/src/components/AbstractLayer.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { NativeMethods, processColor } from 'react-native';
+import { type NativeMethods, processColor } from 'react-native';
 
 import { getFilter } from '../utils/filterUtils';
 import type {
   AllLayerStyleProps,
   FilterExpression,
 } from '../utils/MapboxStyles';
-import { StyleValue, transformStyle } from '../utils/StyleValue';
+import { type StyleValue, transformStyle } from '../utils/StyleValue';
 import type { BaseProps } from '../types/BaseProps';
 
 type PropsBase = BaseProps & {

--- a/src/components/AbstractSource.tsx
+++ b/src/components/AbstractSource.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { NativeMethods } from 'react-native';
+import { type NativeMethods } from 'react-native';
 
 import type { BaseProps } from '../types/BaseProps';
 

--- a/src/components/Annotation.tsx
+++ b/src/components/Annotation.tsx
@@ -1,11 +1,11 @@
-import React, { ReactElement } from 'react';
+import React, { type ReactElement } from 'react';
 import { Animated as RNAnimated, Easing } from 'react-native';
-import { Point } from 'geojson';
+import { type Point } from 'geojson';
 
 import Animated from '../utils/animated/Animated';
 import { AnimatedPoint } from '../classes';
-import { OnPressEvent } from '../types/OnPressEvent';
-import { SymbolLayerStyle } from '../Mapbox';
+import { type OnPressEvent } from '../types/OnPressEvent';
+import { type SymbolLayerStyle } from '../Mapbox';
 
 import { SymbolLayer } from './SymbolLayer';
 

--- a/src/components/Callout.tsx
+++ b/src/components/Callout.tsx
@@ -1,11 +1,11 @@
-import React, { ReactNode } from 'react';
+import React, { type ReactNode } from 'react';
 import {
   View,
   Text,
   Animated,
   StyleSheet,
-  ViewStyle,
-  ViewProps,
+  type ViewStyle,
+  type ViewProps,
 } from 'react-native';
 
 import RNMBXCalloutNativeComponent from '../specs/RNMBXCalloutNativeComponent';

--- a/src/components/Camera.tsx
+++ b/src/components/Camera.tsx
@@ -9,7 +9,7 @@ import React, {
 } from 'react';
 import { NativeModules } from 'react-native';
 
-import { MapboxGLEvent } from '../types';
+import { type MapboxGLEvent } from '../types';
 import { type Position } from '../types/Position';
 import { makeLatLngBounds, makePoint } from '../utils/geoUtils';
 import { type NativeRefType } from '../utils/nativeRef';

--- a/src/components/CameraGestureObserver.tsx
+++ b/src/components/CameraGestureObserver.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react';
 import type { ViewProps } from 'react-native';
 import RNMBXCameraGestureObserverNativeComponent, {
-  OnMapSteadyEvent,
+  type OnMapSteadyEvent,
 } from '../specs/RNMBXCameraGestureObserverNativeComponent';
 
 type Props = ViewProps & {

--- a/src/components/CircleLayer.tsx
+++ b/src/components/CircleLayer.tsx
@@ -5,7 +5,7 @@ import type {
   FilterExpression,
   CircleLayerStyleProps,
 } from '../utils/MapboxStyles';
-import { StyleValue } from '../utils/StyleValue';
+import { type StyleValue } from '../utils/StyleValue';
 import RNMBXCircleLayerNativeComponent from '../specs/RNMBXCircleLayerNativeComponent';
 
 import AbstractLayer from './AbstractLayer';

--- a/src/components/CustomLocationProvider.tsx
+++ b/src/components/CustomLocationProvider.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react';
 
 import RNMBXCustomLocationProvider from '../specs/RNMBXCustomLocationProviderNativeComponent';
-import { Position } from '../types/Position';
+import { type Position } from '../types/Position';
 
 export type Props = {
   /**

--- a/src/components/FillExtrusionLayer.tsx
+++ b/src/components/FillExtrusionLayer.tsx
@@ -5,7 +5,7 @@ import type {
   FilterExpression,
   FillExtrusionLayerStyleProps,
 } from '../utils/MapboxStyles';
-import { StyleValue } from '../utils/StyleValue';
+import { type StyleValue } from '../utils/StyleValue';
 import RNMBXFillExtrusionLayerNativeComponent from '../specs/RNMBXFillExtrusionLayerNativeComponent';
 
 import AbstractLayer from './AbstractLayer';

--- a/src/components/HeadingIndicator.tsx
+++ b/src/components/HeadingIndicator.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import headingIcon from '../assets/heading.png';
-import { BaseProps } from '../types/BaseProps';
+import { type BaseProps } from '../types/BaseProps';
 
 import { SymbolLayer } from './SymbolLayer';
 import Images from './Images';

--- a/src/components/HillshadeLayer.tsx
+++ b/src/components/HillshadeLayer.tsx
@@ -5,7 +5,7 @@ import type {
   FilterExpression,
   HillshadeLayerStyleProps,
 } from '../utils/MapboxStyles';
-import { StyleValue } from '../utils/StyleValue';
+import { type StyleValue } from '../utils/StyleValue';
 import RNMBXHillshadeLayerNativeComponent from '../specs/RNMBXHillshadeLayerNativeComponent';
 
 import AbstractLayer from './AbstractLayer';

--- a/src/components/Image.tsx
+++ b/src/components/Image.tsx
@@ -1,4 +1,4 @@
-import React, { memo, forwardRef, ReactElement } from 'react';
+import React, { memo, forwardRef, type ReactElement } from 'react';
 import { findNodeHandle } from 'react-native';
 
 import RNMBXImageNativeComponent from '../specs/RNMBXImageNativeComponent';

--- a/src/components/ImageSource.tsx
+++ b/src/components/ImageSource.tsx
@@ -5,7 +5,7 @@ import {
   isNumber,
   resolveImagePath,
 } from '../utils';
-import { BaseProps } from '../types/BaseProps';
+import { type BaseProps } from '../types/BaseProps';
 import RNMBXImageSourceNativeComponent from '../specs/RNMBXImageSourceNativeComponent';
 
 import AbstractSource from './AbstractSource';

--- a/src/components/Images.tsx
+++ b/src/components/Images.tsx
@@ -1,6 +1,9 @@
-import React, { ReactNode, ReactElement } from 'react';
-import { Image as RNImage, ImageURISource } from 'react-native';
-import { ImageSourcePropType, ImageResolvedAssetSource } from 'react-native';
+import React, { type ReactNode, type ReactElement } from 'react';
+import { Image as RNImage, type ImageURISource } from 'react-native';
+import {
+  type ImageSourcePropType,
+  type ImageResolvedAssetSource,
+} from 'react-native';
 
 import RNMBXImagesNativeComponent from '../specs/RNMBXImagesNativeComponent';
 

--- a/src/components/LineLayer.tsx
+++ b/src/components/LineLayer.tsx
@@ -4,7 +4,7 @@ import type {
   FilterExpression,
   LineLayerStyleProps,
 } from '../utils/MapboxStyles';
-import { StyleValue } from '../utils/StyleValue';
+import { type StyleValue } from '../utils/StyleValue';
 import RNMBXLineLayerNativeComponent from '../specs/RNMBXLineLayerNativeComponent';
 
 import AbstractLayer from './AbstractLayer';

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -3,11 +3,11 @@ import {
   View,
   StyleSheet,
   NativeModules,
-  ViewProps,
-  NativeSyntheticEvent,
-  NativeMethods,
-  HostComponent,
-  LayoutChangeEvent,
+  type ViewProps,
+  type NativeSyntheticEvent,
+  type NativeMethods,
+  type HostComponent,
+  type LayoutChangeEvent,
 } from 'react-native';
 import debounce from 'debounce';
 

--- a/src/components/ModelLayer.tsx
+++ b/src/components/ModelLayer.tsx
@@ -4,7 +4,7 @@ import type {
   FilterExpression,
   ModelLayerStyleProps,
 } from '../utils/MapboxStyles';
-import { StyleValue } from '../utils/StyleValue';
+import { type StyleValue } from '../utils/StyleValue';
 import RNMBXModelLayerNativeComponent from '../specs/RNMBXModelLayerNativeComponent';
 
 import AbstractLayer from './AbstractLayer';

--- a/src/components/NativeBridgeComponent.tsx
+++ b/src/components/NativeBridgeComponent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TurboModule } from 'react-native';
+import { type TurboModule } from 'react-native';
 
 import { type NativeArg, runNativeMethod } from '../utils';
 

--- a/src/components/PointAnnotation.tsx
+++ b/src/components/PointAnnotation.tsx
@@ -1,12 +1,17 @@
-import React, { SyntheticEvent, type Component } from 'react';
+import React, { type SyntheticEvent, type Component } from 'react';
 import { StyleSheet, type ViewProps } from 'react-native';
-import { Feature, GeoJsonProperties, Geometry, Point } from 'geojson';
+import {
+  type Feature,
+  type GeoJsonProperties,
+  type Geometry,
+  type Point,
+} from 'geojson';
 
 import { toJSONString, isFunction } from '../utils';
 import checkRequiredProps from '../utils/checkRequiredProps';
 import { makePoint } from '../utils/geoUtils';
 import { type BaseProps } from '../types/BaseProps';
-import { Position } from '../types/Position';
+import { type Position } from '../types/Position';
 import RNMBXPointAnnotationNativeComponent from '../specs/RNMBXPointAnnotationNativeComponent';
 import NativeRNMBXPointAnnotationModule from '../specs/NativeRNMBXPointAnnotationModule';
 

--- a/src/components/RasterArraySource.tsx
+++ b/src/components/RasterArraySource.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { NativeModules } from 'react-native';
 
 import { cloneReactChildrenWithProps } from '../utils';
-import { BaseProps } from '../types/BaseProps';
+import { type BaseProps } from '../types/BaseProps';
 import RNMBXRasterArraySourceNativeComponent from '../specs/RNMBXRasterArraySourceNativeComponent';
 
 import AbstractSource from './AbstractSource';

--- a/src/components/RasterLayer.tsx
+++ b/src/components/RasterLayer.tsx
@@ -5,7 +5,7 @@ import type {
   FilterExpression,
   RasterLayerStyleProps,
 } from '../utils/MapboxStyles';
-import { StyleValue } from '../utils/StyleValue';
+import { type StyleValue } from '../utils/StyleValue';
 import RNMBXRasterLayerNativeComponent from '../specs/RNMBXRasterLayerNativeComponent';
 
 import AbstractLayer from './AbstractLayer';

--- a/src/components/RasterParticleLayer.tsx
+++ b/src/components/RasterParticleLayer.tsx
@@ -5,7 +5,7 @@ import type {
   FilterExpression,
   RasterParticleLayerStyleProps,
 } from '../utils/MapboxStyles';
-import { StyleValue } from '../utils/StyleValue';
+import { type StyleValue } from '../utils/StyleValue';
 import RNMBXRasterParticleLayerNativeComponent from '../specs/RNMBXRasterParticleLayerNativeComponent';
 
 import AbstractLayer from './AbstractLayer';

--- a/src/components/RasterSource.tsx
+++ b/src/components/RasterSource.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { NativeModules } from 'react-native';
 
 import { cloneReactChildrenWithProps } from '../utils';
-import { BaseProps } from '../types/BaseProps';
+import { type BaseProps } from '../types/BaseProps';
 import RNMBXRasterSourceNativeComponent from '../specs/RNMBXRasterSourceNativeComponent';
 
 import AbstractSource from './AbstractSource';

--- a/src/components/ShapeSource.tsx
+++ b/src/components/ShapeSource.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {
-  NativeMethods,
+  type NativeMethods,
   NativeModules,
-  NativeSyntheticEvent,
+  type NativeSyntheticEvent,
 } from 'react-native';
 
 import RNMBXShapeSourceNativeComponent from '../specs/RNMBXShapeSourceNativeComponent';
@@ -14,8 +14,8 @@ import {
   isAndroid,
 } from '../utils';
 import { copyPropertiesAsDeprecated } from '../utils/deprecation';
-import { OnPressEvent } from '../types/OnPressEvent';
-import { ShapeAnimatorInterface } from '../shapeAnimators';
+import { type OnPressEvent } from '../types/OnPressEvent';
+import { type ShapeAnimatorInterface } from '../shapeAnimators';
 
 import AbstractSource from './AbstractSource';
 import NativeBridgeComponent from './NativeBridgeComponent';

--- a/src/components/SkyLayer.tsx
+++ b/src/components/SkyLayer.tsx
@@ -5,7 +5,7 @@ import type {
   FilterExpression,
   SkyLayerStyleProps,
 } from '../utils/MapboxStyles';
-import { StyleValue } from '../utils/StyleValue';
+import { type StyleValue } from '../utils/StyleValue';
 import RNMBXSkyLayerNativeComponent from '../specs/RNMBXSkyLayerNativeComponent';
 
 import AbstractLayer from './AbstractLayer';

--- a/src/components/SymbolLayer.tsx
+++ b/src/components/SymbolLayer.tsx
@@ -1,4 +1,4 @@
-import React, { JSX } from 'react';
+import React, { type JSX } from 'react';
 import { View, NativeModules } from 'react-native';
 
 import type {

--- a/src/components/UserLocation.tsx
+++ b/src/components/UserLocation.tsx
@@ -1,8 +1,8 @@
-import React, { ReactElement } from 'react';
+import React, { type ReactElement } from 'react';
 
 import locationManager from '../modules/location/locationManager';
 import { type Location } from '../modules/location/locationManager';
-import { CircleLayerStyle } from '../Mapbox';
+import { type CircleLayerStyle } from '../Mapbox';
 
 import Annotation from './Annotation';
 import CircleLayer from './CircleLayer';

--- a/src/components/VectorSource.tsx
+++ b/src/components/VectorSource.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { NativeModules, NativeSyntheticEvent } from 'react-native';
+import { NativeModules, type NativeSyntheticEvent } from 'react-native';
 
 import RNMBXVectorSourceNativeComponent from '../specs/RNMBXVectorSourceNativeComponent';
 import { cloneReactChildrenWithProps, isFunction } from '../utils';
 import { copyPropertiesAsDeprecated } from '../utils/deprecation';
-import { OnPressEvent } from '../types/OnPressEvent';
+import { type OnPressEvent } from '../types/OnPressEvent';
 
 import AbstractSource from './AbstractSource';
 

--- a/src/modules/location/locationManager.ts
+++ b/src/modules/location/locationManager.ts
@@ -2,11 +2,11 @@ import {
   NativeModules,
   NativeEventEmitter,
   AppState,
-  NativeEventSubscription,
-  EmitterSubscription,
+  type NativeEventSubscription,
+  type EmitterSubscription,
   type AppStateStatus,
   Platform,
-  EventSubscription,
+  type EventSubscription,
 } from 'react-native';
 
 import NativeRNMBXLocationModule from '../../specs/NativeRNMBXLocationModule';

--- a/src/modules/offline/offlineManager.ts
+++ b/src/modules/offline/offlineManager.ts
@@ -1,7 +1,7 @@
 import {
   NativeModules,
   NativeEventEmitter,
-  EventSubscription,
+  type EventSubscription,
 } from 'react-native';
 
 import { isUndefined, isFunction, isAndroid } from '../../utils';

--- a/src/shapeAnimators/ChangeLineOffsetsShapeAnimator.ts
+++ b/src/shapeAnimators/ChangeLineOffsetsShapeAnimator.ts
@@ -5,7 +5,7 @@ import NativeRNMBXChangeLineOffsetsShapeAnimatorModule from '../specs/NativeRNMB
 
 import ShapeAnimatorManager from './ShapeAnimatorManager';
 
-import { ShapeAnimatorInterface } from '.';
+import { type ShapeAnimatorInterface } from '.';
 
 export default class ChangeLineOffsetsShapeAnimator
   implements ShapeAnimatorInterface

--- a/src/shapeAnimators/MovePointShapeAnimator.ts
+++ b/src/shapeAnimators/MovePointShapeAnimator.ts
@@ -1,9 +1,9 @@
-import { Position } from '../types/Position';
+import { type Position } from '../types/Position';
 import NativeRNMBXMovePointShapeAnimatorModule from '../specs/NativeRNMBXMovePointShapeAnimatorModule';
 
 import ShapeAnimatorManager from './ShapeAnimatorManager';
 
-import { ShapeAnimatorInterface } from '.';
+import { type ShapeAnimatorInterface } from '.';
 
 export default class MovePointShapeAnimator implements ShapeAnimatorInterface {
   __nativeTag: number;

--- a/src/specs/RNMBXCameraNativeComponent.ts
+++ b/src/specs/RNMBXCameraNativeComponent.ts
@@ -1,9 +1,9 @@
 import type { HostComponent, ViewProps } from 'react-native';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import {
-  DirectEventHandler,
-  Double,
-  Int32,
+  type DirectEventHandler,
+  type Double,
+  type Int32,
   // @ts-ignore - CI environment type resolution issue for CodegenTypes
 } from 'react-native/Libraries/Types/CodegenTypes';
 

--- a/src/specs/RNMBXCustomLocationProviderNativeComponent.ts
+++ b/src/specs/RNMBXCustomLocationProviderNativeComponent.ts
@@ -5,7 +5,7 @@ import { Double } from 'react-native/Libraries/Types/CodegenTypes';
 
 import type { Position } from '../types/Position';
 
-import { UnsafeMixed } from './codegenUtils';
+import { type UnsafeMixed } from './codegenUtils';
 
 // see https://github.com/rnmapbox/maps/wiki/FabricOptionalProp
 type OptionalProp<T> = UnsafeMixed<T>;

--- a/src/specs/RNMBXImageSourceNativeComponent.ts
+++ b/src/specs/RNMBXImageSourceNativeComponent.ts
@@ -1,7 +1,7 @@
 import type { HostComponent, ViewProps } from 'react-native';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-import { UnsafeMixed } from './codegenUtils';
+import { type UnsafeMixed } from './codegenUtils';
 
 export interface NativeProps extends ViewProps {
   id: UnsafeMixed<string>;

--- a/src/specs/RNMBXMapViewNativeComponent.ts
+++ b/src/specs/RNMBXMapViewNativeComponent.ts
@@ -1,10 +1,10 @@
 import type { HostComponent, ViewProps } from 'react-native';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import {
-  BubblingEventHandler,
-  DirectEventHandler,
-  Int32,
-  Double,
+  type BubblingEventHandler,
+  type DirectEventHandler,
+  type Int32,
+  type Double,
   // @ts-ignore - CI environment type resolution issue for CodegenTypes
 } from 'react-native/Libraries/Types/CodegenTypes';
 

--- a/src/specs/RNMBXMarkerViewNativeComponent.ts
+++ b/src/specs/RNMBXMarkerViewNativeComponent.ts
@@ -3,9 +3,9 @@ import type { HostComponent, ViewProps } from 'react-native';
 import { Int32 } from 'react-native/Libraries/Types/CodegenTypes';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-import { Position } from '../types/Position';
+import { type Position } from '../types/Position';
 
-import { UnsafeMixed } from './codegenUtils';
+import { type UnsafeMixed } from './codegenUtils';
 
 type Point = {
   x: Int32;

--- a/src/specs/RNMBXModelLayerNativeComponent.ts
+++ b/src/specs/RNMBXModelLayerNativeComponent.ts
@@ -4,9 +4,9 @@ import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNati
 import { Double, Int32 } from 'react-native/Libraries/Types/CodegenTypes';
 
 import type { FilterExpression } from '../utils/MapboxStyles';
-import { StyleValue } from '../utils/StyleValue';
+import { type StyleValue } from '../utils/StyleValue';
 
-import { UnsafeMixed } from './codegenUtils';
+import { type UnsafeMixed } from './codegenUtils';
 
 // @{codepart-replace-start(CommonLayerNativeComponentsProps.codepart-ts)}
 // see https://github.com/rnmapbox/maps/wiki/FabricOptionalProp

--- a/src/specs/RNMBXModelsNativeComponent.ts
+++ b/src/specs/RNMBXModelsNativeComponent.ts
@@ -1,7 +1,7 @@
 import type { HostComponent, ViewProps } from 'react-native';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-import { UnsafeMixed } from './codegenUtils';
+import { type UnsafeMixed } from './codegenUtils';
 
 type Asset = {
   __packager_asset?: boolean;

--- a/src/specs/RNMBXNativeUserLocationNativeComponent.ts
+++ b/src/specs/RNMBXNativeUserLocationNativeComponent.ts
@@ -7,7 +7,7 @@ import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNati
 
 import type { Expression } from '../utils/MapboxStyles';
 
-import { UnsafeMixed } from './codegenUtils';
+import { type UnsafeMixed } from './codegenUtils';
 
 type Value<T> = T | Expression;
 

--- a/src/specs/RNMBXRasterArraySourceNativeComponent.ts
+++ b/src/specs/RNMBXRasterArraySourceNativeComponent.ts
@@ -3,7 +3,7 @@ import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNati
 // @ts-ignore - CI environment type resolution issue for CodegenTypes
 import { Double } from 'react-native/Libraries/Types/CodegenTypes';
 
-import { UnsafeMixed } from './codegenUtils';
+import { type UnsafeMixed } from './codegenUtils';
 
 export interface NativeProps extends ViewProps {
   id: UnsafeMixed<string>;

--- a/src/specs/RNMBXRasterDemSourceNativeComponent.ts
+++ b/src/specs/RNMBXRasterDemSourceNativeComponent.ts
@@ -3,7 +3,7 @@ import type { HostComponent, ViewProps } from 'react-native';
 import { Double } from 'react-native/Libraries/Types/CodegenTypes';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
-import { UnsafeMixed } from './codegenUtils';
+import { type UnsafeMixed } from './codegenUtils';
 
 export interface NativeProps extends ViewProps {
   id: UnsafeMixed<string>;

--- a/src/specs/RNMBXRasterSourceNativeComponent.ts
+++ b/src/specs/RNMBXRasterSourceNativeComponent.ts
@@ -3,7 +3,7 @@ import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNati
 // @ts-ignore - CI environment type resolution issue for CodegenTypes
 import { Double } from 'react-native/Libraries/Types/CodegenTypes';
 
-import { UnsafeMixed } from './codegenUtils';
+import { type UnsafeMixed } from './codegenUtils';
 
 export interface NativeProps extends ViewProps {
   id: UnsafeMixed<string>;

--- a/src/specs/RNMBXShapeSourceNativeComponent.ts
+++ b/src/specs/RNMBXShapeSourceNativeComponent.ts
@@ -1,9 +1,9 @@
 import type { HostComponent, ViewProps } from 'react-native';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import {
-  DirectEventHandler,
-  Double,
-  Int32,
+  type DirectEventHandler,
+  type Double,
+  type Int32,
   // @ts-ignore - CI environment type resolution issue for CodegenTypes
 } from 'react-native/Libraries/Types/CodegenTypes';
 

--- a/src/specs/RNMBXVectorSourceNativeComponent.ts
+++ b/src/specs/RNMBXVectorSourceNativeComponent.ts
@@ -1,8 +1,8 @@
 import type { HostComponent, ViewProps } from 'react-native';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import {
-  DirectEventHandler,
-  Double,
+  type DirectEventHandler,
+  type Double,
   // @ts-ignore - CI environment type resolution issue for CodegenTypes
 } from 'react-native/Libraries/Types/CodegenTypes';
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
-import { SyntheticEvent } from 'react';
+import { type SyntheticEvent } from 'react';
 import { Animated } from 'react-native';
-import { GeoJsonObject } from 'geojson';
+import { type GeoJsonObject } from 'geojson';
 
 // General.
 

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -1,5 +1,5 @@
 import {
-  EmitterSubscription,
+  type EmitterSubscription,
   NativeEventEmitter,
   NativeModules,
 } from 'react-native';

--- a/src/utils/StyleValue.ts
+++ b/src/utils/StyleValue.ts
@@ -4,7 +4,7 @@ import BridgeValue, {
   type RawValueType,
   type StyleValueJSON,
 } from './BridgeValue';
-import { AllLayerStyleProps } from './MapboxStyles';
+import { type AllLayerStyleProps } from './MapboxStyles';
 import { getStyleType } from './styleMap';
 
 export type StyleValue = {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,10 +1,10 @@
-import React, { ReactNode } from 'react';
+import React, { type ReactNode } from 'react';
 import {
   findNodeHandle,
   Platform,
   Image,
-  ImageSourcePropType,
-  TurboModule,
+  type ImageSourcePropType,
+  type TurboModule,
 } from 'react-native';
 
 export function isAndroid(): boolean {

--- a/src/utils/nativeRef.ts
+++ b/src/utils/nativeRef.ts
@@ -1,4 +1,4 @@
-import { RefObject, type Component, type MutableRefObject } from 'react';
+import { type RefObject, type Component, type MutableRefObject } from 'react';
 import { type NativeMethods, type HostComponent } from 'react-native';
 
 /**

--- a/src/web/components/Camera.tsx
+++ b/src/web/components/Camera.tsx
@@ -1,7 +1,11 @@
-import { Component, ContextType } from 'react';
+import { Component, type ContextType } from 'react';
 
-import { CameraProps, CameraStop, CameraRef } from '../../components/Camera';
-import { Position } from '../../types/Position';
+import {
+  type CameraProps,
+  type CameraStop,
+  type CameraRef,
+} from '../../components/Camera';
+import { type Position } from '../../types/Position';
 import MapContext from '../MapContext';
 
 function isArray<T>(value: T | ArrayLike<T>): value is ArrayLike<T> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,8 +27,7 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "ESNext",
-    // TODO: Re-enable verbatimModuleSyntax and fix type-only imports (217 errors)
-    // "verbatimModuleSyntax": true
+    "verbatimModuleSyntax": true
   },
   "exclude": [
     "**/*.codepart.ts"


### PR DESCRIPTION
## Description

Enabled `verbatimModuleSyntax` in tsconfig.json and added `type` in front of types imports.

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [x] I have tested the new feature on `/example` app.
  - [x] In V11 mode/ios
  - [x] In New Architecture mode/ios
  - [x] In V11 mode/android
  - [x] In New Architecture mode/android
- [x] I added/updated a sample - if a new feature was implemented (`/example`)

