### PR TITLE
Add null check for eventEmitter in dispatchCameraChangedEvent

### DIFF
--- a/ios/RNMBX/RNMBXMapViewComponentView.mm
+++ b/ios/RNMBX/RNMBXMapViewComponentView.mm
@@ -120,6 +120,9 @@ using namespace facebook::react;
 }
 
 - (void)dispatchCameraChangedEvent:(NSDictionary*)event {
+    if (self->_eventEmitter == nullptr) {
+        return;
+    }
     const auto [type, json] = RNMBXStringifyEventData(event);
     std::dynamic_pointer_cast<const facebook::react::RNMBXMapViewEventEmitter>(self->_eventEmitter)->onCameraChanged({type, json});
 }


### PR DESCRIPTION
Fixes #4158 
The other handlers like `onPress` and `onLongPress` and `onMapChange` already follow the same approach.