### PR TITLE
docs: remove v10 and old architecture references

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -10,35 +10,19 @@ body:
 
       ---
 
-      ⚠️ **Deprecation Notice** ⚠️
-
-      **v10.x and old architecture (Paper/bridge) issues are deprecated and will not receive attention.**
-
-      Please upgrade to v11+ with new architecture (Fabric/TurboModules) for active support.
+      **Requirements:** This library requires Mapbox Maps SDK v11 and React Native 0.79+ with New Architecture (Fabric/TurboModules).
 
       **For sponsors-only support and resources:** https://github.com/rnmapbox/maps/wiki/SponsorsRepo
       **Become a sponsor for special support:** https://github.com/sponsors/rnmapbox
 
       ---
-- type: dropdown
-  id: mapbox-implementation
-  attributes:
-    label: Mapbox Implementation
-    description: |-
-      Check `RNMapboxMapsImpl` in your Podfile/gradle files. Defaults to `Maplibre`.
-    options:
-      - Mapbox
-      - Mapbox GL
-      - Maplibre
-  validations:
-    required: true
 - type: input
   id: mapbox-version
   attributes:
     label: Mapbox Version
     description: |-
-      Check `RNMapboxMapsVersion` in your Podfile/gradle files, set to `default` if you don't cusomize the version
-    placeholder: 10.7.0
+      Check `RNMapboxMapsVersion` in your Podfile/gradle files, set to `default` if you don't customize the version
+    placeholder: 11.16.2
   validations:
     required: true
 - type: input
@@ -47,18 +31,7 @@ body:
     label: React Native Version
     description: |-
       The React Native version
-    placeholder: 0.73.2
-  validations:
-    required: true
-- type: dropdown
-  id: react-native-architecture
-  attributes:
-    label: React Native Architecture
-    description: |-
-      Select the React Native architecture you're using
-    options:
-      - New Architecture (Fabric/TurboModules)
-      - Old Architecture (Paper/bridge)
+    placeholder: 0.79.0
   validations:
     required: true
 - type: dropdown
@@ -78,8 +51,8 @@ body:
   attributes:
     label: "`@rnmapbox/maps` version"
     description: |-
-      The version of `@rnmapbox/maps`, such as `#main`, `10.0.0-beta.32`
-    value: 10.0.0-beta.11
+      The version of `@rnmapbox/maps`
+    placeholder: 10.3.0
   validations:
     required: true
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_setup.md
+++ b/.github/ISSUE_TEMPLATE/bug_setup.md
@@ -5,11 +5,7 @@ labels: 'bug-setup 🪲'
 assignees: ''
 ---
 
-⚠️ **Deprecation Notice** ⚠️
-
-**v10.x and old architecture (Paper/bridge) issues are deprecated and will not receive attention.**
-
-Please upgrade to v11+ with new architecture (Fabric/TurboModules) for active support.
+**Requirements:** This library requires Mapbox Maps SDK v11 and React Native 0.79+ with New Architecture (Fabric/TurboModules).
 
 **For sponsors-only support and resources:** https://github.com/rnmapbox/maps/wiki/SponsorsRepo
 **Become a sponsor for special support:** https://github.com/sponsors/rnmapbox
@@ -18,10 +14,9 @@ Please upgrade to v11+ with new architecture (Fabric/TurboModules) for active su
 
 ## Environment
 - Dev OS: [e.g. OSX 11.0.1, Win10]
-- @rnmapbox/maps version: [eg. 10.0.15]
-- React Native version: [eg. 0.72.6]
-- React Native Architecture: [New Architecture (Fabric/TurboModules) / Old Architecture (Paper/bridge)]
-- Expo version: [eg. 49.0.0]
+- @rnmapbox/maps version: [eg. 10.3.0]
+- React Native version: [eg. 0.79.0]
+- Expo version: [eg. 54.0.0]
 
 
 ## Steps to reproduce
@@ -29,10 +24,9 @@ Please upgrade to v11+ with new architecture (Fabric/TurboModules) for active su
 <!--- We don't troubleshoot existing projects, please reproduce the issue in a brand new project. If you can't then create a new working project and compare with the one you're having trouble with.  --->
 
 ```sh
-react-native init sample --version react-native@0.60.5
+npx @react-native-community/cli init sample
 cd sample
-npm install rnmapbox/maps#main --save
-# or released version `npm install @rnmapbox/maps@8.0.0-rc1 --save`
-react-native run-android
+npm install @rnmapbox/maps --save
+npx react-native run-android
 ```
 

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -36,14 +36,14 @@ jobs:
     # run that runs on: tag. (Using the GitHub token would
     # not run the workflow to prevent infinite recursion.)
     - name: Check out source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ssh-key: ${{ secrets.DEPLOY_KEY }}
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3.5.1
+      uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '22'
 
     - name: Setup Git
       run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,25 +61,7 @@ yarn generate
 
 ### Building for Different Configurations
 
-#### Mapbox v10 - deprecated
-```bash
-# iOS
-cd example/ios
-RNMBX10=1 pod update MapboxMaps
-
-# Android
-# Edit example/android/gradle.properties: RNMBX10=true
-```
-
-#### New Architecture/Fabric
-```bash
-# iOS
-cd example/ios
-RCT_NEW_ARCH_ENABLED=1 pod update MapboxMaps
-
-# Android
-# Edit example/android/gradle.properties: newArchEnabled=true
-```
+The project uses Mapbox Maps SDK v11 and React Native's New Architecture (Fabric/TurboModules) exclusively.
 
 ## Architecture Overview
 
@@ -91,7 +73,7 @@ RCT_NEW_ARCH_ENABLED=1 pod update MapboxMaps
   - Each component extends either `AbstractLayer` or `AbstractSource` for common functionality
 
 ### Native Bridge
-- **Specs** (`src/specs/`): TurboModule/Fabric component specs for new architecture
+- **Specs** (`src/specs/`): TurboModule/Fabric component specs
 - **Native Components**: Each component has corresponding native implementations:
   - iOS: `ios/RNMBX/RNMBX*.swift` and `RNMBX*ComponentView.mm`
   - Android: `android/src/main/java/` (generated from specs)
@@ -143,4 +125,4 @@ RCT_NEW_ARCH_ENABLED=1 pod update MapboxMaps
 - The example app is the primary way to test changes
 - Native changes require rebuilding the app
 - Web support is experimental and may have limited functionality
-- Support both old and new React Native architectures
+- Requires React Native 0.79+ with New Architecture (Fabric/TurboModules)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,18 +16,7 @@ Some notes about example app:
 
 ### Example app configurations:
 
-- V10: this build with V10 of mapbox
-  To build example in this mode on ios run:
-  ```
-  cd example/ios ; RNMBX10=1 pod update MapboxMaps
-  ```
-  To build example in this mode on android:
-  Change `RNMBX10=true` in `example/android/gradle.properties`
-- NewArchitecture/Fabric:
-  ```
-  cd example/ios ; RCT_NEW_ARCH_ENABLED=1 pod update MapboxMaps
-  ```
-  On android change `newArchEnabled=true` in `example/android/gradle.properties`
+The project uses Mapbox Maps SDK v11 and React Native's New Architecture (Fabric/TurboModules) exclusively.
 
 ### Running example app for Web
 
@@ -49,7 +38,7 @@ Run `yarn generate` to update generated code/documentation.
 We use the following code generators, but check yarn generate for more:
 - `style-spec/v8.json` download from mapbox.com describes properties of layers/sources etc. We generate the following files from it:
   - `MapboxStyles.d.ts` - typescript definitions for different Layer styles
-  - `RNMBXStyle.swift.ejs`/`RNMBXStyleFactoryV10.kt` - ios/android native style setters
+  - `RNMBXStyle.swift.ejs`/`RNMBXStyleFactory.kt` - ios/android native style setters
   - `docs.json` is generated both from style-spec and documentation in our typescript files
 - Document generation:
   - `docs/MapView.md` is generated from `src/components/MapView.tsx` with `react-docgen`

--- a/README.md
+++ b/README.md
@@ -56,11 +56,8 @@ _A community-supported, open-source React Native library for building maps with 
 
 ---
 
-### Supported Implementations 
-At the moment we support Mapbox (v10) and Mapbox (v11) beta.
-We default to Mapbox (v10).
-
-_See [iOS](ios/install.md) & [Android](android/install.md) setup guide for using v11 beta_
+### Supported Implementations
+We support Mapbox Maps SDK v11. See [iOS](ios/install.md) & [Android](android/install.md) setup guides.
 
 
 
@@ -74,7 +71,7 @@ _See [iOS](ios/install.md) & [Android](android/install.md) setup guide for using
 
 - [node](https://nodejs.org)
 - [npm](https://www.npmjs.com/)
-- [React Native](https://facebook.github.io/react-native/) (0.70+, older versions from 0.64+ might or might not work)
+- [React Native](https://facebook.github.io/react-native/) (0.79+)
 
 
 ## Installation

--- a/android/install.md
+++ b/android/install.md
@@ -2,8 +2,7 @@
 
 ## Supported mapbox libraries
 
-We're only supporting mapbox 10.16* and 11.*. The default is 10.16*.
-Next release will be 11.* only so we recommend updatign to 11.*
+We support Mapbox Maps SDK v11.
 
 ### Adding mapbox maven repo
 
@@ -27,39 +26,14 @@ allprojects {
 
 ### Using non default mapbox version
 
-*Warning*: If you set a custom version, make sure you revisit, any time you update @rnmapbox/maps. Setting it to earlier version than what we exepect will likely result in a build error.
+*Warning*: If you set a custom version, make sure you revisit any time you update @rnmapbox/maps. Setting it to an earlier version than what we expect will likely result in a build error.
 
 Set `RNMapboxMapsVersion` in `android/build.gradle > buildscript > ext` section
 
-
 ```groovy
 buildscript {
     ext {
-        RNMapboxMapsVersion = '11.4.1'
-    }
-}
-```
-
-you can also customize all the libraries, should it be neccesary
-
-```groovy
-buildscript {
-    ext {
-        // ...
-        RNMapboxMapsLibs = { // optional - only required if you want to customize it
-            implementation 'com.mapbox.maps:android:10.6.0'
-            implementation 'com.mapbox.mapboxsdk:mapbox-sdk-turf:5.4.1'
-        }
-    }
-}
-```
-
-### Using v11
-
-```groovy
-buildscript {
-    ext {
-        RNMapboxMapsVersion = '11.4.1'
+        RNMapboxMapsVersion = '11.16.2'
     }
 }
 ```

--- a/ios/RNMBX/README.md
+++ b/ios/RNMBX/README.md
@@ -1,1 +1,1 @@
-iOS v10 code
+iOS native code

--- a/ios/install.md
+++ b/ios/install.md
@@ -50,23 +50,10 @@ Read on if you want to edit your Mapbox version or flavor.
 
 ## Using a custom version of the Mapbox SDK
 
-You can also override the version to use. *Warning:* if you set a version, then later update, the `rnamapbox/maps` library it's possible that you'll end up using Mapbox older version than supported. Make sure you revise this value with `@rnmapbox/maps` updates. Also note that for 11.0 or later versions you'll need to set `$RNMapboxMapsUseV11 = true`, see bellow
+You can override the version to use. *Warning:* if you set a version, then later update the `@rnmapbox/maps` library it's possible that you'll end up using an older Mapbox version than supported. Make sure you revise this value with `@rnmapbox/maps` updates.
 
 ```ruby
-# Warning: only for advanced use cases, only do this if you know what you're doing.
-# $RNMapboxMapsVersion = '~> 10.16.2'
-```
-
-<br/>
-
-## V11 support
-
-We have support for mapbox 11.
-
-Add the following to your Podfile:
-
-```ruby
-$RNMapboxMapsVersion = '= 11.13.4'
+$RNMapboxMapsVersion = '= 11.16.2'
 ```
 
 If using expo managed workflow, set the "RNMapboxMapsVersion" variable. See the [expo guide](/plugin/install.md)

--- a/plugin/install.md
+++ b/plugin/install.md
@@ -66,23 +66,6 @@ It's possible to overwrite the native SDK version with `RNMapboxMapsVersion`:
 }
 ```
 
-To use V11 just set the version to a 11 version, see [the ios guide](/ios/install.md):
-
-```json
-{
-  "expo": {
-    "plugins": [
-      [
-        "@rnmapbox/maps",
-        {
-          "RNMapboxMapsVersion": "11.13.4"
-        }
-      ]
-    ]
-  }
-}
-```
-
 ## Manual Setup
 
 For bare workflow projects, you can follow the manual setup guides:


### PR DESCRIPTION
Remove outdated v10, MapLibre, and old architecture (Paper/bridge) references from docs, issue templates, and CI. The project now requires Mapbox v11 and React Native 0.79+ with New Architecture exclusively.