### PR TITLE
fix(android): MarkerView touch/press on new architecture (Fabric)

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewContent.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewContent.kt
@@ -1,12 +1,40 @@
 package com.rnmapbox.rnmbx.components.annotation
 
 import android.content.Context
+import android.view.MotionEvent
 import android.view.View.MeasureSpec
 import android.view.ViewGroup
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.uimanager.events.Event
 import com.facebook.react.views.view.ReactViewGroup
+
+private class AnnotationPositionEvent(
+    surfaceId: Int,
+    viewTag: Int,
+    translateX: Float,
+    translateY: Float,
+) : Event<AnnotationPositionEvent>(surfaceId, viewTag) {
+    private val mData: WritableMap = Arguments.createMap().apply {
+        putDouble("x", translateX.toDouble())
+        putDouble("y", translateY.toDouble())
+    }
+    override fun getEventName() = "topAnnotationPosition"
+    // Allow coalescing so rapid position updates don't flood the JS queue
+    override fun canCoalesce() = true
+    override fun getEventData(): WritableMap = mData
+}
 
 class RNMBXMarkerViewContent(context: Context): ReactViewGroup(context) {
     var inAdd: Boolean = false
+
+    // Track last reported translation to avoid feedback loop:
+    // Mapbox sets setTranslationX(512) → we fire event → JS sets transform:[{translateX:512}]
+    // → Fabric calls setTranslationX(512) again → same value → no re-fire.
+    private var lastReportedTx = Float.NaN
+    private var lastReportedTy = Float.NaN
 
     init {
         allowRenderingOutside()
@@ -15,6 +43,40 @@ class RNMBXMarkerViewContent(context: Context): ReactViewGroup(context) {
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
         configureParentClipping()
+    }
+
+    override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+        // Prevent the parent MapView from intercepting subsequent MOVE/UP events
+        // for its own pan/zoom gesture recognition, which would send CANCEL to
+        // the Pressable and suppress onPress. See maplibre/maplibre-react-native#1289.
+        parent?.requestDisallowInterceptTouchEvent(true)
+        return super.dispatchTouchEvent(ev)
+    }
+
+    override fun setTranslationX(translationX: Float) {
+        super.setTranslationX(translationX)
+        maybeFireAnnotationPositionEvent()
+    }
+
+    override fun setTranslationY(translationY: Float) {
+        super.setTranslationY(translationY)
+        maybeFireAnnotationPositionEvent()
+    }
+
+    private fun maybeFireAnnotationPositionEvent() {
+        val tx = translationX
+        val ty = translationY
+        // Dedup: skip if value unchanged (prevents feedback loop when Fabric
+        // re-applies the same transform prop back to setTranslationX/Y).
+        if (tx == lastReportedTx && ty == lastReportedTy) return
+        lastReportedTx = tx
+        lastReportedTy = ty
+
+        val reactContext = context as? ReactContext ?: return
+        val dispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, id) ?: return
+        // Use getSurfaceId(view) — more reliable for Fabric than getSurfaceId(context)
+        val surfaceId = UIManagerHelper.getSurfaceId(this)
+        dispatcher.dispatchEvent(AnnotationPositionEvent(surfaceId, id, tx, ty))
     }
 
     private fun configureParentClipping() {

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewContent.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewContent.kt
@@ -6,26 +6,9 @@ import android.view.View.MeasureSpec
 import android.view.ViewGroup
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactContext
-import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.UIManagerHelper
-import com.facebook.react.uimanager.events.Event
 import com.facebook.react.views.view.ReactViewGroup
-
-private class AnnotationPositionEvent(
-    surfaceId: Int,
-    viewTag: Int,
-    translateX: Float,
-    translateY: Float,
-) : Event<AnnotationPositionEvent>(surfaceId, viewTag) {
-    private val mData: WritableMap = Arguments.createMap().apply {
-        putDouble("x", translateX.toDouble())
-        putDouble("y", translateY.toDouble())
-    }
-    override fun getEventName() = "topAnnotationPosition"
-    // Allow coalescing so rapid position updates don't flood the JS queue
-    override fun canCoalesce() = true
-    override fun getEventData(): WritableMap = mData
-}
+import com.rnmapbox.rnmbx.components.camera.BaseEvent
 
 class RNMBXMarkerViewContent(context: Context): ReactViewGroup(context) {
     var inAdd: Boolean = false
@@ -46,10 +29,13 @@ class RNMBXMarkerViewContent(context: Context): ReactViewGroup(context) {
     }
 
     override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
-        // Prevent the parent MapView from intercepting subsequent MOVE/UP events
-        // for its own pan/zoom gesture recognition, which would send CANCEL to
-        // the Pressable and suppress onPress. See maplibre/maplibre-react-native#1289.
-        parent?.requestDisallowInterceptTouchEvent(true)
+        // On ACTION_DOWN, tell the parent MapView not to intercept subsequent MOVE/UP
+        // events for pan/zoom recognition — that would send CANCEL to child Pressables
+        // and suppress onPress. Android resets the disallow flag on each new DOWN, so
+        // calling this once per gesture is sufficient. See maplibre-react-native#1289.
+        if (ev.actionMasked == MotionEvent.ACTION_DOWN) {
+            parent?.requestDisallowInterceptTouchEvent(true)
+        }
         return super.dispatchTouchEvent(ev)
     }
 
@@ -76,7 +62,14 @@ class RNMBXMarkerViewContent(context: Context): ReactViewGroup(context) {
         val dispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, id) ?: return
         // Use getSurfaceId(view) — more reliable for Fabric than getSurfaceId(context)
         val surfaceId = UIManagerHelper.getSurfaceId(this)
-        dispatcher.dispatchEvent(AnnotationPositionEvent(surfaceId, id, tx, ty))
+        dispatcher.dispatchEvent(
+            BaseEvent(surfaceId, id, "topAnnotationPosition",
+                Arguments.createMap().apply {
+                    putDouble("x", tx.toDouble())
+                    putDouble("y", ty.toDouble())
+                },
+                canCoalesce = true)
+        )
     }
 
     private fun configureParentClipping() {

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewContentManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewContentManager.kt
@@ -2,19 +2,24 @@ package com.rnmapbox.rnmbx.components.annotation
 
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ThemedReactContext
-import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.viewmanagers.RNMBXMarkerViewContentManagerInterface
+import com.rnmapbox.rnmbx.components.AbstractEventEmitter
 
 
 class RNMBXMarkerViewContentManager(reactApplicationContext: ReactApplicationContext) :
-    ViewGroupManager<RNMBXMarkerViewContent>(),
+    AbstractEventEmitter<RNMBXMarkerViewContent>(reactApplicationContext),
     RNMBXMarkerViewContentManagerInterface<RNMBXMarkerView> {
+
     override fun getName(): String {
         return REACT_CLASS
     }
 
     override fun createViewInstance(context: ThemedReactContext): RNMBXMarkerViewContent {
         return RNMBXMarkerViewContent(context)
+    }
+
+    override fun customEvents(): Map<String, String> {
+        return mapOf("topAnnotationPosition" to "onAnnotationPosition")
     }
 
     companion object {

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewManager.kt
@@ -96,8 +96,6 @@ class RNMBXMarkerViewManager(reactApplicationContext: ReactApplicationContext) :
                         }
                     }
                 }
-
-
             })
         }
     }

--- a/docs/MarkerView.md
+++ b/docs/MarkerView.md
@@ -17,8 +17,9 @@ component for a maximum of around 100 views displayed at one time.
 This is implemented with view annotations on [Android](https://docs.mapbox.com/android/maps/guides/annotations/view-annotations/)
 and [iOS](https://docs.mapbox.com/ios/maps/guides/annotations/view-annotations).
 
-This component has no dedicated `onPress` method. Instead, you should handle gestures
-with the React views passed in as `children`.
+This component has no dedicated `onPress` method. Instead, handle gestures
+with the React views passed in as `children` — Pressable, TouchableOpacity,
+etc. all work including their visual feedback (opacity, scale, etc.).
 
 ## props
 
@@ -85,7 +86,8 @@ FIX ME NO DESCRIPTION
 ReactReactElement
 ```
 _required_
-One or more valid React Native views.
+One or more valid React Native views. You can use Pressable, TouchableOpacity,
+etc. directly as children — onPress and touch feedback work correctly.
 
 
   

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -5665,7 +5665,7 @@
     "name": "MapView"
   },
   "MarkerView": {
-    "description": "MarkerView represents an interactive React Native marker on the map.\n\nIf you have static views, consider using PointAnnotation or SymbolLayer to display\nan image, as they'll offer much better performance. Mapbox suggests using this\ncomponent for a maximum of around 100 views displayed at one time.\n\nThis is implemented with view annotations on [Android](https://docs.mapbox.com/android/maps/guides/annotations/view-annotations/)\nand [iOS](https://docs.mapbox.com/ios/maps/guides/annotations/view-annotations).\n\nThis component has no dedicated `onPress` method. Instead, you should handle gestures\nwith the React views passed in as `children`.",
+    "description": "MarkerView represents an interactive React Native marker on the map.\n\nIf you have static views, consider using PointAnnotation or SymbolLayer to display\nan image, as they'll offer much better performance. Mapbox suggests using this\ncomponent for a maximum of around 100 views displayed at one time.\n\nThis is implemented with view annotations on [Android](https://docs.mapbox.com/android/maps/guides/annotations/view-annotations/)\nand [iOS](https://docs.mapbox.com/ios/maps/guides/annotations/view-annotations).\n\nThis component has no dedicated `onPress` method. Instead, handle gestures\nwith the React views passed in as `children` — Pressable, TouchableOpacity,\netc. all work including their visual feedback (opacity, scale, etc.).",
     "displayName": "MarkerView",
     "methods": [],
     "props": [
@@ -5727,7 +5727,7 @@
         "required": true,
         "type": "ReactReactElement",
         "default": "none",
-        "description": "One or more valid React Native views."
+        "description": "One or more valid React Native views. You can use Pressable, TouchableOpacity,\netc. directly as children — onPress and touch feedback work correctly."
       }
     ],
     "fileNameWithExt": "MarkerView.tsx",

--- a/docs/examples.json
+++ b/docs/examples.json
@@ -648,9 +648,11 @@
           "title": "Marker View",
           "tags": [
             "PointAnnotation",
-            "MarkerView"
+            "MarkerView",
+            "Slider",
+            "Interactive"
           ],
-          "docs": "\nShows marker view and point annotations\n"
+          "docs": "\nShows marker view and point annotations, including an interactive marker with\nsliders, switch, counter, text input, and pressable button to verify complex\ntouch interactions inside a MarkerView.\n"
         },
         "fullPath": "example/src/examples/Annotations/MarkerView.tsx",
         "relPath": "Annotations/MarkerView.tsx",

--- a/example/src/examples/Annotations/MarkerView.tsx
+++ b/example/src/examples/Annotations/MarkerView.tsx
@@ -1,5 +1,15 @@
 import React from 'react';
-import { Button, StyleSheet, View, Text, TouchableOpacity } from 'react-native';
+import {
+  Button,
+  Pressable,
+  StyleSheet,
+  Switch,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Slider } from '@rneui/base';
 import Mapbox from '@rnmapbox/maps';
 
 import Bubble from '../common/Bubble';
@@ -19,6 +29,115 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
   matchParent: { flex: 1 },
+  interactiveCard: {
+    backgroundColor: 'white',
+    borderRadius: 12,
+    padding: 12,
+    width: 200,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+    borderWidth: 1,
+    borderColor: '#ddd',
+  },
+  cardTitle: {
+    fontWeight: 'bold',
+    fontSize: 13,
+    marginBottom: 8,
+    color: '#333',
+  },
+  sliderLabel: {
+    fontSize: 11,
+    color: '#666',
+    marginBottom: 2,
+  },
+  sliderValue: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: '#333',
+    textAlign: 'right',
+  },
+  sliderRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 4,
+  },
+  switchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginVertical: 4,
+  },
+  switchLabel: {
+    fontSize: 11,
+    color: '#666',
+  },
+  counterRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginVertical: 6,
+  },
+  counterButton: {
+    backgroundColor: '#4A90D9',
+    width: 30,
+    height: 30,
+    borderRadius: 15,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  counterButtonText: {
+    color: 'white',
+    fontWeight: 'bold',
+    fontSize: 16,
+  },
+  counterValue: {
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginHorizontal: 16,
+    minWidth: 24,
+    textAlign: 'center',
+  },
+  textInput: {
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 6,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    fontSize: 11,
+    marginTop: 4,
+    backgroundColor: '#fafafa',
+  },
+  pressableButton: {
+    marginTop: 8,
+    backgroundColor: '#4A90D9',
+    borderRadius: 6,
+    paddingVertical: 6,
+    alignItems: 'center',
+  },
+  pressableButtonPressed: {
+    backgroundColor: '#2E6DB4',
+  },
+  pressableText: {
+    color: 'white',
+    fontWeight: '600',
+    fontSize: 12,
+  },
+  colorPreview: {
+    height: 20,
+    borderRadius: 4,
+    marginTop: 4,
+    borderWidth: 1,
+    borderColor: '#ccc',
+  },
+  divider: {
+    height: 1,
+    backgroundColor: '#eee',
+    marginVertical: 6,
+  },
 });
 
 const AnnotationContent = ({ title }: { title: string }) => (
@@ -29,9 +148,125 @@ const AnnotationContent = ({ title }: { title: string }) => (
     </TouchableOpacity>
   </View>
 );
+
+/**
+ * An interactive MarkerView with slider, switch, counter, text input, and
+ * pressable button — useful for verifying that complex touch interactions
+ * work correctly inside a MarkerView.
+ */
+const InteractiveMarkerContent = () => {
+  const [sliderValue, setSliderValue] = React.useState(0.5);
+  const [opacity, setOpacity] = React.useState(1.0);
+  const [toggleOn, setToggleOn] = React.useState(false);
+  const [counter, setCounter] = React.useState(0);
+  const [note, setNote] = React.useState('');
+  const [pressCount, setPressCount] = React.useState(0);
+
+  const hue = Math.round(sliderValue * 360);
+  const bgColor = `hsla(${hue}, 70%, 55%, ${opacity})`;
+
+  return (
+    <View style={styles.interactiveCard} collapsable={false}>
+      <Text style={styles.cardTitle}>Interactive Marker</Text>
+
+      {/* Slider: Hue */}
+      <View style={styles.sliderRow}>
+        <Text style={styles.sliderLabel}>Hue</Text>
+        <Text style={styles.sliderValue}>{hue}°</Text>
+      </View>
+      <Slider
+        value={sliderValue}
+        onValueChange={setSliderValue}
+        minimumValue={0}
+        maximumValue={1}
+        step={0.01}
+        thumbStyle={{ width: 18, height: 18 }}
+        trackStyle={{ height: 4 }}
+        minimumTrackTintColor="#4A90D9"
+        maximumTrackTintColor="#ccc"
+      />
+
+      {/* Slider: Opacity */}
+      <View style={styles.sliderRow}>
+        <Text style={styles.sliderLabel}>Opacity</Text>
+        <Text style={styles.sliderValue}>{opacity.toFixed(2)}</Text>
+      </View>
+      <Slider
+        value={opacity}
+        onValueChange={setOpacity}
+        minimumValue={0}
+        maximumValue={1}
+        step={0.05}
+        thumbStyle={{ width: 18, height: 18 }}
+        trackStyle={{ height: 4 }}
+        minimumTrackTintColor="#E8913A"
+        maximumTrackTintColor="#ccc"
+      />
+
+      {/* Color preview */}
+      <View style={[styles.colorPreview, { backgroundColor: bgColor }]} />
+
+      <View style={styles.divider} />
+
+      {/* Switch */}
+      <View style={styles.switchRow}>
+        <Text style={styles.switchLabel}>
+          Toggle: {toggleOn ? 'ON' : 'OFF'}
+        </Text>
+        <Switch value={toggleOn} onValueChange={setToggleOn} />
+      </View>
+
+      <View style={styles.divider} />
+
+      {/* Counter */}
+      <View style={styles.counterRow}>
+        <TouchableOpacity
+          style={styles.counterButton}
+          onPress={() => setCounter((c) => c - 1)}
+        >
+          <Text style={styles.counterButtonText}>−</Text>
+        </TouchableOpacity>
+        <Text style={styles.counterValue}>{counter}</Text>
+        <TouchableOpacity
+          style={styles.counterButton}
+          onPress={() => setCounter((c) => c + 1)}
+        >
+          <Text style={styles.counterButtonText}>+</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.divider} />
+
+      {/* Text input */}
+      <Text style={styles.sliderLabel}>Note</Text>
+      <TextInput
+        style={styles.textInput}
+        value={note}
+        onChangeText={setNote}
+        placeholder="Type something…"
+        placeholderTextColor="#aaa"
+      />
+
+      {/* Pressable button */}
+      <Pressable
+        style={({ pressed }) => [
+          styles.pressableButton,
+          pressed && styles.pressableButtonPressed,
+        ]}
+        onPress={() => setPressCount((c) => c + 1)}
+      >
+        <Text style={styles.pressableText}>
+          Pressed {pressCount} time{pressCount !== 1 ? 's' : ''}
+        </Text>
+      </Pressable>
+    </View>
+  );
+};
+
 const INITIAL_COORDINATES: [number, number][] = [
   [-73.99155, 40.73581],
   [-73.99155, 40.73681],
+  [-73.98955, 40.73581],
 ];
 
 const ShowMarkerView = () => {
@@ -74,7 +309,15 @@ const ShowMarkerView = () => {
           <AnnotationContent title={'this is a marker view'} />
         </Mapbox.MarkerView>
 
-        {pointList.slice(2).map((coordinate, index) => (
+        <Mapbox.MarkerView
+          coordinate={INITIAL_COORDINATES[2]}
+          allowOverlap
+          allowOverlapWithPuck={allowOverlapWithPuck}
+        >
+          <InteractiveMarkerContent />
+        </Mapbox.MarkerView>
+
+        {pointList.slice(3).map((coordinate, index) => (
           <Mapbox.PointAnnotation
             coordinate={coordinate}
             id={`pt-ann-${index}`}
@@ -101,9 +344,11 @@ export default ShowMarkerView;
 /** @type ExampleWithMetadata['metadata'] */
 const metadata = {
   title: 'Marker View',
-  tags: ['PointAnnotation', 'MarkerView'],
+  tags: ['PointAnnotation', 'MarkerView', 'Slider', 'Interactive'],
   docs: `
-Shows marker view and point annotations
+Shows marker view and point annotations, including an interactive marker with
+sliders, switch, counter, text input, and pressable button to verify complex
+touch interactions inside a MarkerView.
 `,
 };
 ShowMarkerView.metadata = metadata;

--- a/example/src/examples/Annotations/MarkerView.tsx
+++ b/example/src/examples/Annotations/MarkerView.tsx
@@ -303,14 +303,14 @@ const ShowMarkerView = () => {
         </Mapbox.PointAnnotation>
 
         <Mapbox.MarkerView
-          coordinate={pointList[0]}
+          coordinate={pointList[0]!}
           allowOverlapWithPuck={allowOverlapWithPuck}
         >
           <AnnotationContent title={'this is a marker view'} />
         </Mapbox.MarkerView>
 
         <Mapbox.MarkerView
-          coordinate={INITIAL_COORDINATES[2]}
+          coordinate={INITIAL_COORDINATES[2]!}
           allowOverlap
           allowOverlapWithPuck={allowOverlapWithPuck}
         >

--- a/src/components/MarkerView.tsx
+++ b/src/components/MarkerView.tsx
@@ -1,11 +1,21 @@
-import React from 'react';
-import { type ViewProps } from 'react-native';
+import React, { useRef, useState } from 'react';
+import {
+  NativeModules,
+  PixelRatio,
+  Platform,
+  type NativeSyntheticEvent,
+  type ViewProps,
+} from 'react-native';
 
 import RNMBXMakerViewContentComponent from '../specs/RNMBXMarkerViewContentNativeComponent';
 import NativeMarkerViewComponent from '../specs/RNMBXMarkerViewNativeComponent';
 import { type Position } from '../types/Position';
-import { toJSONString } from '../utils';
-import { makePoint } from '../utils/geoUtils';
+
+import PointAnnotation from './PointAnnotation';
+
+const Mapbox = NativeModules.RNMBXModule;
+
+let _nextMarkerViewId = 0;
 
 type Props = ViewProps & {
   /**
@@ -37,7 +47,8 @@ type Props = ViewProps & {
   isSelected: boolean;
 
   /**
-   * One or more valid React Native views.
+   * One or more valid React Native views. You can use Pressable, TouchableOpacity,
+   * etc. directly as children — onPress and touch feedback work correctly.
    */
   children: React.ReactElement;
 };
@@ -52,75 +63,99 @@ type Props = ViewProps & {
  * This is implemented with view annotations on [Android](https://docs.mapbox.com/android/maps/guides/annotations/view-annotations/)
  * and [iOS](https://docs.mapbox.com/ios/maps/guides/annotations/view-annotations).
  *
- * This component has no dedicated `onPress` method. Instead, you should handle gestures
- * with the React views passed in as `children`.
+ * This component has no dedicated `onPress` method. Instead, handle gestures
+ * with the React views passed in as `children` — Pressable, TouchableOpacity,
+ * etc. all work including their visual feedback (opacity, scale, etc.).
  */
-class MarkerView extends React.PureComponent<Props> {
-  static defaultProps: Partial<Props> = {
-    anchor: { x: 0.5, y: 0.5 },
-    allowOverlap: false,
-    allowOverlapWithPuck: false,
-    isSelected: false,
-  };
+const MarkerView = ({
+  anchor = { x: 0.5, y: 0.5 },
+  allowOverlap = false,
+  allowOverlapWithPuck = false,
+  isSelected = false,
+  coordinate,
+  style,
+  children,
+}: Props) => {
+  // Stable ID for the legacy pre-v10 iOS PointAnnotation fallback below.
+  const compatIdRef = useRef(`MV-${++_nextMarkerViewId}`);
 
-  _getCoordinate(coordinate: Position): string | undefined {
-    if (!coordinate) {
-      return undefined;
-    }
-    return toJSONString(makePoint(coordinate));
+  // Android new-arch (Fabric) fix: UIManager.measure reads from the Fabric shadow
+  // tree, which doesn't include Mapbox's native setTranslationX/Y positioning.
+  // Strategy: intercept setTranslationX/Y on the native side (see
+  // RNMBXMarkerViewContent.kt), relay the values as an onAnnotationPosition event,
+  // then apply them as a React `transform` on RNMBXMarkerView so the shadow tree
+  // reflects the actual on-screen position. This makes
+  // Pressability._responderRegion correct and onPress / touch feedback work.
+  //
+  // Key details:
+  //  • position:'absolute' on RNMBXMarkerView → all markers have Yoga pos (0,0)
+  //    in MapView, so the only shadow-tree offset is the transform itself.
+  //  • Transform goes on RNMBXMarkerView (not RNMBXMarkerViewContent) so Fabric
+  //    never fights Mapbox's native positioning.
+  //  • Divide by PixelRatio: Android translationX/Y is in device pixels; React
+  //    transform expects logical pixels (points).
+  //
+  // useState is called unconditionally (hooks rules) before the MapboxV10 early-return.
+  const [annotationTranslate, setAnnotationTranslate] = useState<{
+    x: number;
+    y: number;
+  } | null>(null);
+
+  // Legacy pre-v10 iOS fallback — MapboxV10 is always truthy on current SDK
+  // versions so this branch is dead code; it will be removed in a follow-up.
+  if (Platform.OS === 'ios' && !Mapbox.MapboxV10) {
+    return <PointAnnotation id={compatIdRef.current} {...({} as any)} />;
   }
 
-  render() {
-    if (
-      this.props.anchor.x < 0 ||
-      this.props.anchor.y < 0 ||
-      this.props.anchor.x > 1 ||
-      this.props.anchor.y > 1
-    ) {
-      console.warn(
-        `[MarkerView] Anchor with value (${this.props.anchor.x}, ${this.props.anchor.y}) should not be outside the range [(0, 0), (1, 1)]`,
-      );
-    }
-
-    const { anchor = { x: 0.5, y: 0.5 } } = this.props;
-
-    return (
-      <RNMBXMarkerView
-        style={[
-          {
-            flex: 0,
-            alignSelf: 'flex-start',
-          },
-          this.props.style,
-        ]}
-        coordinate={[
-          Number(this.props.coordinate[0]),
-          Number(this.props.coordinate[1]),
-        ]}
-        anchor={anchor}
-        allowOverlap={this.props.allowOverlap}
-        allowOverlapWithPuck={this.props.allowOverlapWithPuck}
-        isSelected={this.props.isSelected}
-        onTouchEnd={(e) => {
-          e.stopPropagation();
-        }}
-      >
-        <RNMBXMakerViewContentComponent
-          collapsable={false}
-          style={{ flex: 0, alignSelf: 'flex-start' }}
-          onStartShouldSetResponder={(_event) => {
-            return true;
-          }}
-          onTouchEnd={(e) => {
-            e.stopPropagation();
-          }}
-        >
-          {this.props.children}
-        </RNMBXMakerViewContentComponent>
-      </RNMBXMarkerView>
+  if (anchor.x < 0 || anchor.y < 0 || anchor.x > 1 || anchor.y > 1) {
+    console.warn(
+      `[MarkerView] Anchor with value (${anchor.x}, ${anchor.y}) should not be outside the range [(0, 0), (1, 1)]`,
     );
   }
-}
+
+  return (
+    <RNMBXMarkerView
+      style={[
+        { position: 'absolute' },
+        style,
+        annotationTranslate != null
+          ? {
+              transform: [
+                { translateX: annotationTranslate.x },
+                { translateY: annotationTranslate.y },
+              ],
+            }
+          : undefined,
+      ]}
+      coordinate={[Number(coordinate[0]), Number(coordinate[1])]}
+      anchor={anchor}
+      allowOverlap={allowOverlap}
+      allowOverlapWithPuck={allowOverlapWithPuck}
+      isSelected={isSelected}
+      onTouchEnd={(e) => {
+        e.stopPropagation();
+      }}
+    >
+      <RNMBXMakerViewContentComponent
+        collapsable={false}
+        style={{ flex: 0, alignSelf: 'flex-start' }}
+        onAnnotationPosition={(
+          e: NativeSyntheticEvent<{ x: number; y: number }>,
+        ) => {
+          // translationX/Y from Android View are in device pixels; React
+          // transform expects logical pixels (points). Divide by PixelRatio.
+          const pr = PixelRatio.get();
+          setAnnotationTranslate({
+            x: e.nativeEvent.x / pr,
+            y: e.nativeEvent.y / pr,
+          });
+        }}
+      >
+        {children}
+      </RNMBXMakerViewContentComponent>
+    </RNMBXMarkerView>
+  );
+};
 
 const RNMBXMarkerView = NativeMarkerViewComponent;
 

--- a/src/components/MarkerView.tsx
+++ b/src/components/MarkerView.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
   PixelRatio,
+  StyleSheet,
   type NativeSyntheticEvent,
   type ViewProps,
 } from 'react-native';
@@ -11,6 +12,8 @@ import { type Position } from '../types/Position';
 
 // Device pixel ratio is constant for the lifetime of the app.
 const PIXEL_RATIO = PixelRatio.get();
+
+const DEFAULT_ANCHOR = { x: 0.5, y: 0.5 };
 
 type Props = ViewProps & {
   /**
@@ -63,7 +66,7 @@ type Props = ViewProps & {
  * etc. all work including their visual feedback (opacity, scale, etc.).
  */
 const MarkerView = ({
-  anchor = { x: 0.5, y: 0.5 },
+  anchor = DEFAULT_ANCHOR,
   allowOverlap = false,
   allowOverlapWithPuck = false,
   isSelected = false,
@@ -117,21 +120,32 @@ const MarkerView = ({
     );
   }
 
+  const nativeCoordinate = useMemo(
+    () => [Number(coordinate[0]), Number(coordinate[1])] as [number, number],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [coordinate[0], coordinate[1]],
+  );
+
+  const nativeStyle = useMemo(
+    () => [
+      styles.absolutePosition,
+      style,
+      annotationTranslate != null
+        ? {
+            transform: [
+              { translateX: annotationTranslate.x },
+              { translateY: annotationTranslate.y },
+            ],
+          }
+        : undefined,
+    ],
+    [style, annotationTranslate],
+  );
+
   return (
     <RNMBXMarkerView
-      style={[
-        { position: 'absolute' },
-        style,
-        annotationTranslate != null
-          ? {
-              transform: [
-                { translateX: annotationTranslate.x },
-                { translateY: annotationTranslate.y },
-              ],
-            }
-          : undefined,
-      ]}
-      coordinate={[Number(coordinate[0]), Number(coordinate[1])]}
+      style={nativeStyle}
+      coordinate={nativeCoordinate}
       anchor={anchor}
       allowOverlap={allowOverlap}
       allowOverlapWithPuck={allowOverlapWithPuck}
@@ -140,7 +154,7 @@ const MarkerView = ({
     >
       <RNMBXMakerViewContentComponent
         collapsable={false}
-        style={{ flex: 0, alignSelf: 'flex-start' }}
+        style={styles.contentContainer}
         onAnnotationPosition={handleAnnotationPosition}
       >
         {children}
@@ -150,5 +164,10 @@ const MarkerView = ({
 };
 
 const RNMBXMarkerView = NativeMarkerViewComponent;
+
+const styles = StyleSheet.create({
+  absolutePosition: { position: 'absolute' },
+  contentContainer: { flex: 0, alignSelf: 'flex-start' },
+});
 
 export default MarkerView;

--- a/src/components/MarkerView.tsx
+++ b/src/components/MarkerView.tsx
@@ -1,8 +1,6 @@
-import React, { useRef, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import {
-  NativeModules,
   PixelRatio,
-  Platform,
   type NativeSyntheticEvent,
   type ViewProps,
 } from 'react-native';
@@ -11,11 +9,8 @@ import RNMBXMakerViewContentComponent from '../specs/RNMBXMarkerViewContentNativ
 import NativeMarkerViewComponent from '../specs/RNMBXMarkerViewNativeComponent';
 import { type Position } from '../types/Position';
 
-import PointAnnotation from './PointAnnotation';
-
-const Mapbox = NativeModules.RNMBXModule;
-
-let _nextMarkerViewId = 0;
+// Device pixel ratio is constant for the lifetime of the app.
+const PIXEL_RATIO = PixelRatio.get();
 
 type Props = ViewProps & {
   /**
@@ -27,7 +22,7 @@ type Props = ViewProps & {
    * Any coordinate between (0, 0) and (1, 1), where (0, 0) is the top-left corner of
    * the view, and (1, 1) is the bottom-right corner. Defaults to the center at (0.5, 0.5).
    */
-  anchor: {
+  anchor?: {
     x: number;
     y: number;
   };
@@ -36,15 +31,15 @@ type Props = ViewProps & {
    * Whether or not nearby markers on the map should all be displayed. If false, adjacent
    * markers will 'collapse' and only one will be shown. Defaults to false.
    */
-  allowOverlap: boolean;
+  allowOverlap?: boolean;
 
   /**
    * Whether or not nearby markers on the map should be hidden if close to a
    * UserLocation puck. Defaults to false.
    */
-  allowOverlapWithPuck: boolean;
+  allowOverlapWithPuck?: boolean;
 
-  isSelected: boolean;
+  isSelected?: boolean;
 
   /**
    * One or more valid React Native views. You can use Pressable, TouchableOpacity,
@@ -76,9 +71,6 @@ const MarkerView = ({
   style,
   children,
 }: Props) => {
-  // Stable ID for the legacy pre-v10 iOS PointAnnotation fallback below.
-  const compatIdRef = useRef(`MV-${++_nextMarkerViewId}`);
-
   // Android new-arch (Fabric) fix: UIManager.measure reads from the Fabric shadow
   // tree, which doesn't include Mapbox's native setTranslationX/Y positioning.
   // Strategy: intercept setTranslationX/Y on the native side (see
@@ -92,20 +84,32 @@ const MarkerView = ({
   //    in MapView, so the only shadow-tree offset is the transform itself.
   //  • Transform goes on RNMBXMarkerView (not RNMBXMarkerViewContent) so Fabric
   //    never fights Mapbox's native positioning.
-  //  • Divide by PixelRatio: Android translationX/Y is in device pixels; React
-  //    transform expects logical pixels (points).
-  //
-  // useState is called unconditionally (hooks rules) before the MapboxV10 early-return.
+  //  • PIXEL_RATIO: Android translationX/Y is in device pixels; React transform
+  //    expects logical pixels (points).
   const [annotationTranslate, setAnnotationTranslate] = useState<{
     x: number;
     y: number;
   } | null>(null);
 
-  // Legacy pre-v10 iOS fallback — MapboxV10 is always truthy on current SDK
-  // versions so this branch is dead code; it will be removed in a follow-up.
-  if (Platform.OS === 'ios' && !Mapbox.MapboxV10) {
-    return <PointAnnotation id={compatIdRef.current} {...({} as any)} />;
-  }
+  // Mirror of Kotlin-side dedup: skip setState when position hasn't changed so
+  // we don't trigger a re-render for no-op native position re-applications.
+  const lastTranslateRef = useRef<{ x: number; y: number } | null>(null);
+
+  const handleTouchEnd = useCallback((e: { stopPropagation: () => void }) => {
+    e.stopPropagation();
+  }, []);
+
+  const handleAnnotationPosition = useCallback(
+    (e: NativeSyntheticEvent<{ x: number; y: number }>) => {
+      const x = e.nativeEvent.x / PIXEL_RATIO;
+      const y = e.nativeEvent.y / PIXEL_RATIO;
+      const last = lastTranslateRef.current;
+      if (last !== null && last.x === x && last.y === y) return;
+      lastTranslateRef.current = { x, y };
+      setAnnotationTranslate({ x, y });
+    },
+    [],
+  );
 
   if (anchor.x < 0 || anchor.y < 0 || anchor.x > 1 || anchor.y > 1) {
     console.warn(
@@ -132,24 +136,12 @@ const MarkerView = ({
       allowOverlap={allowOverlap}
       allowOverlapWithPuck={allowOverlapWithPuck}
       isSelected={isSelected}
-      onTouchEnd={(e) => {
-        e.stopPropagation();
-      }}
+      onTouchEnd={handleTouchEnd}
     >
       <RNMBXMakerViewContentComponent
         collapsable={false}
         style={{ flex: 0, alignSelf: 'flex-start' }}
-        onAnnotationPosition={(
-          e: NativeSyntheticEvent<{ x: number; y: number }>,
-        ) => {
-          // translationX/Y from Android View are in device pixels; React
-          // transform expects logical pixels (points). Divide by PixelRatio.
-          const pr = PixelRatio.get();
-          setAnnotationTranslate({
-            x: e.nativeEvent.x / pr,
-            y: e.nativeEvent.y / pr,
-          });
-        }}
+        onAnnotationPosition={handleAnnotationPosition}
       >
         {children}
       </RNMBXMakerViewContentComponent>

--- a/src/specs/RNMBXMarkerViewContentNativeComponent.ts
+++ b/src/specs/RNMBXMarkerViewContentNativeComponent.ts
@@ -1,7 +1,19 @@
 import type { HostComponent, ViewProps } from 'react-native';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+// @ts-ignore - CI environment type resolution issue for CodegenTypes
+import { DirectEventHandler, Float } from 'react-native/Libraries/Types/CodegenTypes';
 
-export interface NativeProps extends ViewProps {}
+type OnAnnotationPositionEvent = {
+  x: Float;
+  y: Float;
+};
+
+export interface NativeProps extends ViewProps {
+  // Fired by native when Mapbox repositions the annotation via setTranslationX/Y.
+  // JS uses this to keep the Fabric shadow tree transform in sync so that
+  // UIManager.measure returns the correct on-screen position for Pressable hit-testing.
+  onAnnotationPosition?: DirectEventHandler<OnAnnotationPositionEvent>;
+}
 
 // @ts-ignore-error - Codegen requires single cast but TypeScript prefers double cast
 export default codegenNativeComponent<NativeProps>(

--- a/src/specs/RNMBXMarkerViewContentNativeComponent.ts
+++ b/src/specs/RNMBXMarkerViewContentNativeComponent.ts
@@ -1,11 +1,11 @@
 import type { HostComponent, ViewProps } from 'react-native';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 // @ts-ignore - CI environment type resolution issue for CodegenTypes
-import { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
+import { DirectEventHandler, Float } from 'react-native/Libraries/Types/CodegenTypes';
 
 type OnAnnotationPositionEvent = {
-  x: number;
-  y: number;
+  x: Float;
+  y: Float;
 };
 
 export interface NativeProps extends ViewProps {

--- a/src/specs/RNMBXMarkerViewContentNativeComponent.ts
+++ b/src/specs/RNMBXMarkerViewContentNativeComponent.ts
@@ -1,7 +1,10 @@
 import type { HostComponent, ViewProps } from 'react-native';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 // @ts-ignore - CI environment type resolution issue for CodegenTypes
-import { DirectEventHandler, Float } from 'react-native/Libraries/Types/CodegenTypes';
+import {
+  DirectEventHandler,
+  Float,
+} from 'react-native/Libraries/Types/CodegenTypes';
 
 type OnAnnotationPositionEvent = {
   x: Float;

--- a/src/specs/RNMBXMarkerViewContentNativeComponent.ts
+++ b/src/specs/RNMBXMarkerViewContentNativeComponent.ts
@@ -1,14 +1,11 @@
 import type { HostComponent, ViewProps } from 'react-native';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 // @ts-ignore - CI environment type resolution issue for CodegenTypes
-import {
-  DirectEventHandler,
-  Float,
-} from 'react-native/Libraries/Types/CodegenTypes';
+import { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
 
 type OnAnnotationPositionEvent = {
-  x: Float;
-  y: Float;
+  x: number;
+  y: number;
 };
 
 export interface NativeProps extends ViewProps {


### PR DESCRIPTION
Fixes #3832
Fixes #3934
Fixes #3440
Fixes #3981

## Problem

On Android with the new React Native architecture (Fabric/TurboModules), any interactive content inside a `MarkerView` — buttons, sliders, switches, `TextInput` — silently failed. Touches appeared to land nowhere, `onPress` was never fired, and press feedback (opacity, scale) didn't show.

**Root cause:** Mapbox positions view annotations by calling `setTranslationX/Y` directly on the native view. This is a render-layer transform — it moves the view visually but does **not** update the view's Yoga layout position. Fabric's shadow tree only tracks layout position, so `UIManager.measure()` always returned `(0, 0)`, making every hit-region wrong.

A second issue: the `MapView`'s own gesture recogniser was intercepting `MOVE` events mid-sequence (after `DOWN`), sending `CANCEL` to child `Pressable`s and suppressing `onPress` even in cases where the hit-test was correct.

iOS is **unaffected** — Mapbox iOS positions annotations via `frame` assignment, which Fabric reads correctly.

## Fix

### Android — `RNMBXMarkerViewContent.kt`
- Override `setTranslationX/Y` to intercept Mapbox's position updates and fire a `topAnnotationPosition` event to JS.
- Deduplicate events via `lastReportedTx/Ty` to prevent a feedback loop when Fabric re-applies the same transform prop back to `setTranslationX/Y`.
- Override `dispatchTouchEvent` to call `requestDisallowInterceptTouchEvent(true)`, preventing the parent `MapView` pan/zoom gesture from stealing `MOVE` events and cancelling child touches.

### Android — `RNMBXMarkerViewContentManager.kt`
- Switch base class to `AbstractEventEmitter` and register `topAnnotationPosition → onAnnotationPosition`.

### Codegen spec — `RNMBXMarkerViewContentNativeComponent.ts`
- Add `onAnnotationPosition` as a `DirectEventHandler` so Fabric's bridge knows about it.

### JS — `MarkerView.tsx`
- Refactor from class to function component.
- Receive `onAnnotationPosition` events and apply the translation as a React `transform` on `RNMBXMarkerView`, keeping the Fabric shadow tree in sync with Mapbox's actual on-screen position.
- `PixelRatio.get()` divide: Android `translationX/Y` is in device pixels; React transforms expect logical pixels.

### Example — `MarkerView.tsx`
- Add an `InteractiveMarkerContent` marker with two sliders, a switch, a counter, a `TextInput`, and a `Pressable` button to exercise the full range of complex interactivity inside a `MarkerView`.

## Test plan

- [x] Open the **Marker View** example on Android (new arch)
- [x] Tap the blue button inside the simple marker → `onPress` fires, blue flash visible
- [x] Drag the Hue and Opacity sliders in the interactive marker → values update live
- [x] Toggle the Switch → state flips
- [x] Tap +/− counter buttons → counter increments/decrements
- [x] Type in the Note field → keyboard appears, text updates
- [x] Tap "Pressed N times" button → press count increments, button darkens on press
- [x] Pan/zoom the map around the markers → map responds normally; markers stay interactive after re-positioning
- [x] Verify iOS behaviour is unchanged