### PR TITLE
feat: add `minPitch` support for MapView component

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapView.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapView.kt
@@ -158,6 +158,7 @@ open class RNMBXMapView(private val mContext: Context, var mManager: RNMBXMapVie
     private val mCameraChangeTracker = CameraChangeTracker()
     private var mPreferredFrameRate: Int? = null
     private var mMaxPitch: Double? = null
+    private var mMinPitch: Double? = null
     private lateinit var mMap: MapboxMap
 
     private lateinit var mMapView: MapView
@@ -512,7 +513,8 @@ open class RNMBXMapView(private val mContext: Context, var mManager: RNMBXMapVie
         LOGO(RNMBXMapView::applyLogo),
         SCALEBAR(RNMBXMapView::applyScaleBar),
         COMPASS(RNMBXMapView::applyCompass),
-        MAX_PITCH(RNMBXMapView::applyMaxPitch),;
+        MAX_PITCH(RNMBXMapView::applyMaxPitch),
+        MIN_PITCH(RNMBXMapView::applyMinPitch),;
 
         override fun apply(mapView: RNMBXMapView) {
            _apply(mapView)
@@ -599,6 +601,28 @@ open class RNMBXMapView(private val mContext: Context, var mManager: RNMBXMapVie
             .minZoom(currentBounds.minZoom)
             .minPitch(currentBounds.minPitch)
             .maxPitch(maxPitch)
+
+        mMap.setBounds(builder.build())
+    }
+
+    fun setReactMinPitch(minPitch: Double?) {
+        mMinPitch = minPitch
+        changes.add(Property.MIN_PITCH)
+    }
+
+    private fun applyMinPitch() {
+        val minPitch = mMinPitch ?: return
+        if (!this::mMap.isInitialized) {
+            return
+        }
+
+        val currentBounds = mMap.getBounds()
+        val builder = CameraBoundsOptions.Builder()
+            .bounds(currentBounds.bounds)
+            .maxZoom(currentBounds.maxZoom)
+            .minZoom(currentBounds.minZoom)
+            .minPitch(minPitch)
+            .maxPitch(currentBounds.maxPitch)
 
         mMap.setBounds(builder.build())
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapViewManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapViewManager.kt
@@ -249,6 +249,12 @@ open class RNMBXMapViewManager(context: ReactApplicationContext, val viewTagReso
         map.setReactMaxPitch(if (maxPitch.type == ReadableType.Null) null else maxPitch.asDouble())
     }
 
+    @ReactProp(name = "minPitch")
+    override fun setMinPitch(map: RNMBXMapView, minPitch: Dynamic) {
+        // Allow clearing the limit by passing null from JS
+        map.setReactMinPitch(if (minPitch.type == ReadableType.Null) null else minPitch.asDouble())
+    }
+
     @ReactProp(name = "rotateEnabled")
     override fun setRotateEnabled(map: RNMBXMapView, rotateEnabled: Dynamic) {
         map.withMapView {

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -102,12 +102,14 @@ number
 Maximum allowed pitch in degrees. Mirrors the Mapbox map option `maxPitch`.
 
 
+  
 ### minPitch
 
 ```tsx
 number
 ```
 Minimum allowed pitch in degrees. Mirrors the Mapbox map option `minPitch`.
+
 
   
 ### rotateEnabled

--- a/docs/MapView.md
+++ b/docs/MapView.md
@@ -102,6 +102,13 @@ number
 Maximum allowed pitch in degrees. Mirrors the Mapbox map option `maxPitch`.
 
 
+### minPitch
+
+```tsx
+number
+```
+Minimum allowed pitch in degrees. Mirrors the Mapbox map option `minPitch`.
+
   
 ### rotateEnabled
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -5238,6 +5238,13 @@
         "description": "Maximum allowed pitch in degrees. Mirrors the Mapbox map option `maxPitch`."
       },
       {
+        "name": "minPitch",
+        "required": false,
+        "type": "number",
+        "default": "none",
+        "description": "Minimum allowed pitch in degrees. Mirrors the Mapbox map option `minPitch`."
+      },
+      {
         "name": "rotateEnabled",
         "required": false,
         "type": "boolean",

--- a/ios/RNMBX/RNMBXMapView.swift
+++ b/ios/RNMBX/RNMBXMapView.swift
@@ -424,6 +424,7 @@ open class RNMBXMapView: UIView, RCTInvalidating {
     case rotateEnabled
     case pitchEnabled
     case maxPitch
+    case minPitch
     case onMapChange
     case styleURL
     case gestureSettings
@@ -462,6 +463,8 @@ open class RNMBXMapView: UIView, RCTInvalidating {
         map.applyPitchEnabled()
       case .maxPitch:
         map.applyMaxPitch()
+      case .minPitch:
+        map.applyMinPitch()
       case .gestureSettings:
         map.applyGestureSettings()
       case .preferredFramesPerSecond:
@@ -543,6 +546,30 @@ open class RNMBXMapView: UIView, RCTInvalidating {
         options.minZoom = current.minZoom
         options.minPitch = current.minPitch
         options.maxPitch = maxPitch
+        try mapboxMap.setCameraBounds(with: options)
+      }
+    }
+  }
+
+  var minPitch: Double? = nil
+
+  @objc public func setReactMinPitch(_ value: NSNumber?) {
+    minPitch = value?.doubleValue
+    changed(.minPitch)
+  }
+
+  func applyMinPitch() {
+    guard let minPitch = minPitch else { return }
+
+    withMapboxMap { mapboxMap in
+      logged("RNMBXMapView.applyMinPitch") {
+        let current = mapboxMap.cameraBounds
+        var options = CameraBoundsOptions()
+        options.bounds = current.bounds
+        options.maxZoom = current.maxZoom
+        options.minZoom = current.minZoom
+        options.minPitch = minPitch
+        options.maxPitch = current.maxPitch
         try mapboxMap.setCameraBounds(with: options)
       }
     }

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -212,6 +212,11 @@ type Props = ViewProps & {
   maxPitch?: number;
 
   /**
+   * Minimum allowed pitch in degrees. Mirrors the Mapbox map option `minPitch`.
+   */
+  minPitch?: number;
+
+  /**
    * Enable/Disable rotation on map
    */
   rotateEnabled?: boolean;

--- a/src/specs/RNMBXMapViewNativeComponent.ts
+++ b/src/specs/RNMBXMapViewNativeComponent.ts
@@ -55,6 +55,7 @@ export interface NativeProps extends ViewProps {
   rotateEnabled?: OptionalProp<boolean>;
   pitchEnabled?: OptionalProp<boolean>;
   maxPitch?: OptionalProp<Double>;
+  minPitch?: OptionalProp<Double>;
 
   deselectAnnotationOnTap?: OptionalProp<boolean>;
 


### PR DESCRIPTION
## Description

This adds `minPitch` support for the `MapView` component.

My use case is for a ski area map with 3d terrain, so constraining the view with a minimum pitch is desired.  We've had a `yarn patch` in place adding minPitch for a while but wanted to help upstream this.

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)