### PR TITLE
fix: issue with maxPitch MapView config setting not propagating to native components

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXCamera.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXCamera.kt
@@ -182,10 +182,13 @@ class RNMBXCamera(private val mContext: Context, private val mManager: RNMBXCame
 
     private fun updateMaxBounds(mapView: RNMBXMapView) {
         val map = mapView.getMapboxMap()
+        val currentBounds = map.getBounds()
         val builder = CameraBoundsOptions.Builder()
         builder.bounds(mMaxBounds?.toBounds())
         builder.minZoom(mMinZoomLevel ?: 0.0) // Passing null does not reset this value.
         builder.maxZoom(mMaxZoomLevel ?: 25.0) // Passing null does not reset this value.
+        builder.minPitch(currentBounds.minPitch)
+        builder.maxPitch(currentBounds.maxPitch)
         map.setBounds(builder.build())
         mCameraStop?.let { updateCamera(it, mapView) }
     }

--- a/ios/RNMBX/RNMBXCamera.swift
+++ b/ios/RNMBX/RNMBXCamera.swift
@@ -331,8 +331,9 @@ open class RNMBXCamera : RNMBXMapAndMapViewComponentBase {
   
   func _updateMaxBounds() {
     withMapView { map in
+      let current = map.mapboxMap.cameraBounds
       var options = CameraBoundsOptions()
-      
+
       if let maxBounds = self.maxBoundsFeature {
         logged("RNMBXCamera._updateMaxBounds._toCoordinateBounds") {
           options.bounds = try self._toCoordinateBounds(maxBounds)
@@ -342,7 +343,9 @@ open class RNMBXCamera : RNMBXMapAndMapViewComponentBase {
       }
       options.minZoom = self.minZoomLevel?.CGFloat
       options.maxZoom = self.maxZoomLevel?.CGFloat
-      
+      options.minPitch = current.minPitch
+      options.maxPitch = current.maxPitch
+
       logged("RNMBXCamera._updateMaxBounds") {
         try map.mapboxMap.setCameraBounds(with: options)
       }

--- a/ios/RNMBX/RNMBXMapViewComponentView.mm
+++ b/ios/RNMBX/RNMBXMapViewComponentView.mm
@@ -192,6 +192,11 @@ using namespace facebook::react;
     RNMBX_REMAP_OPTIONAL_PROP_BOOL(rotateEnabled, reactRotateEnabled)
 
     RNMBX_REMAP_OPTIONAL_PROP_BOOL(pitchEnabled, reactPitchEnabled)
+
+    id maxPitch = RNMBXConvertFollyDynamicToId(newViewProps.maxPitch);
+    if (maxPitch != nil) {
+        _view.reactMaxPitch = maxPitch;
+    }
   
     RNMBX_REMAP_OPTIONAL_PROP_NSDictionary(gestureSettings, reactGestureSettings)
 


### PR DESCRIPTION
## Description

Fixes #4138

- iOS fix: maxPitch prop in iOS Fabric component view not getting propagated from javascript in the remap logic
- Android/iOS fix: issue with min/max pitch config settings getting disposed when camera bounds are changed and `updateMaxBounds` handler is called

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [x] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video
Android:

https://github.com/user-attachments/assets/7b1de0cd-07af-46fc-bf29-1a1a025fb102

iOS:

https://github.com/user-attachments/assets/e5d51da7-1018-454d-a50a-cf7d1309209b



## Component to reproduce the issue you're fixing

Use the following code to replace `BugReportExample.js`

```jsx
import React from 'react';
import {View, TouchableOpacity, Text, StyleSheet} from 'react-native';
import {
  Images,
  MapView,
  ShapeSource,
  SymbolLayer,
  CircleLayer,
  Camera,
  VectorSource,
  LineLayer,
  RasterArraySource,
  RasterParticleLayer,
} from '@rnmapbox/maps';

const features = {
  type: 'FeatureCollection',
  features: [
    {
      type: 'Feature',
      id: 'a-feature',
      properties: {
        icon: 'example',
        text: 'example-icon-and-label',
      },
      geometry: {
        type: 'Point',
        coordinates: [-74.00597, 40.71427],
      },
    },
    {
      type: 'Feature',
      id: 'b-feature',
      properties: {
        text: 'just-label',
      },
      geometry: {
        type: 'Point',
        coordinates: [-74.001097, 40.71527],
      },
    },
    {
      type: 'Feature',
      id: 'c-feature',
      properties: {
        icon: 'example',
      },
      geometry: {
        type: 'Point',
        coordinates: [-74.00697, 40.72427],
      },
    },
  ],
};

const aLine = {
  type: 'LineString',
  coordinates: [
    [-74.00597, 40.71427],
    [-74.00697, 40.71527],
  ],
};


class BugReportExample extends React.Component {
  state = {
    pitch: 0,
  };

  changePitch(delta) {
    this.setState((prev) => ({
      pitch: prev.pitch + delta,
    }));
  }

  render() {
    const { pitch } = this.state;
    return (
      <View style={{flex: 1}}>
        <MapView pitchEnabled maxPitch={45.5} style={{flex: 1}}>
          <Camera
            centerCoordinate={[-74.00597, 40.71427]}
            zoomLevel={14}
            pitch={pitch}
          />
          <ShapeSource id="idStreetLayer" shape={aLine}>
            <LineLayer id="idStreetLayer" />
          </ShapeSource>
        </MapView>
        <View style={pitchStyles.controls}>
          <TouchableOpacity
            style={pitchStyles.button}
            onPress={() => this.changePitch(-5)}>
            <Text style={pitchStyles.buttonText}>- Pitch</Text>
          </TouchableOpacity>
          <Text style={pitchStyles.label}>{pitch}°</Text>
          <TouchableOpacity
            style={pitchStyles.button}
            onPress={() => this.changePitch(5)}>
            <Text style={pitchStyles.buttonText}>+ Pitch</Text>
          </TouchableOpacity>
        </View>
      </View>
    );
  }
}

const pitchStyles = StyleSheet.create({
  controls: {
    flexDirection: 'row',
    justifyContent: 'center',
    alignItems: 'center',
    padding: 50,
  },
  button: {
    backgroundColor: '#4A90D9',
    paddingHorizontal: 16,
    paddingVertical: 10,
    borderRadius: 6,
    marginHorizontal: 8,
  },
  buttonText: {
    color: '#fff',
    fontWeight: 'bold',
  },
  label: {
    fontSize: 16,
    fontWeight: 'bold',
    minWidth: 40,
    textAlign: 'center',
  },
});

export default BugReportExample;

```
