### PR TITLE
fix(android): map pans after long-press instead of staying fixed like on iOS

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapView.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapView.kt
@@ -5,6 +5,7 @@ import android.graphics.BitmapFactory
 import android.os.Handler
 import android.os.Looper
 import android.view.Gravity
+import android.view.MotionEvent
 import android.view.View
 import android.view.View.OnLayoutChangeListener
 import android.view.ViewGroup
@@ -177,6 +178,18 @@ open class RNMBXMapView(private val mContext: Context, var mManager: RNMBXMapVie
     private var wasGestureActive = false
     private var isGestureActive = false
 
+    private var mAfterLongPress = false
+
+    override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+        if (mAfterLongPress) {
+            val action = ev.actionMasked
+            if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL) {
+                mAfterLongPress = false
+            }
+        }
+        return super.dispatchTouchEvent(ev)
+    }
+
     var mapViewImpl: String? = null
 
     val mapView: MapView
@@ -294,10 +307,17 @@ open class RNMBXMapView(private val mContext: Context, var mManager: RNMBXMapVie
             }
 
             override fun onMove(moveGestureDetector: MoveGestureDetector): Boolean {
+                if (mAfterLongPress) {
+                    return true // consume the move events that come after a long press, to prevent the map from moving when the user is trying to long press on something
+                }
                 return mapGesture(MapGestureType.Move, moveGestureDetector)
             }
 
             override fun onMoveEnd(moveGestureDetector: MoveGestureDetector) {
+                if (mAfterLongPress) {
+                    mAfterLongPress = false
+                    return
+                }
                 mapGestureEnd(MapGestureType.Move, moveGestureDetector)
             }
         })
@@ -733,6 +753,7 @@ open class RNMBXMapView(private val mContext: Context, var mManager: RNMBXMapVie
         }
         val screenPointPx = mMap?.pixelForCoordinate(point)
         if (screenPointPx != null) {
+            mAfterLongPress = true
             val screenPointDp = toDp(screenPointPx)
             val event = MapClickEvent(_this, LatLng(point), screenPointDp, EventTypes.MAP_LONG_CLICK)
             mManager.handleEvent(event)


### PR DESCRIPTION

## Description

On iOS, long-pressing an item on the map and dragging keeps the map fixed. On android the gesture is allowed through and the map pans instead.

As discussed in #3981.

This PR brings android to feature parity with iOS by consuming the move gesture after a long-press.
To test:
- Long-press a feature on the map 
- Without lifting your finger, drag — the map should stay fixed and the feature should follow your finger
- This already works on iOS - android should now behave the same way


