### PR TITLE
fix: remove bridge! force-unwrap that crashes on RN 0.84+ bridgeless mode

### DIFF
--- a/ios/RNMBX/RNMBXAtmosphereComponentView.mm
+++ b/ios/RNMBX/RNMBXAtmosphereComponentView.mm
@@ -3,6 +3,7 @@
 #import "RNMBXFabricHelpers.h"
 
 #import <React/RCTBridge+Private.h>
+#import "RNMBXBridgeManager.h"
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 
@@ -40,7 +41,7 @@ using namespace facebook::react;
 - (void)prepareView
 {
     _view =  [[RNMBXAtmosphere alloc] init];
-    _view.bridge = [RCTBridge currentBridge];
+    _view.bridge = [RNMBXBridgeManager currentBridge];
 
     self.contentView = _view;
 }

--- a/ios/RNMBX/RNMBXBackgroundLayerComponentView.mm
+++ b/ios/RNMBX/RNMBXBackgroundLayerComponentView.mm
@@ -3,6 +3,7 @@
 #import "RNMBXFabricHelpers.h"
 
 #import <React/RCTBridge+Private.h>
+#import "RNMBXBridgeManager.h"
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 
@@ -40,7 +41,7 @@ using namespace facebook::react;
 - (void)prepareView
 {
   _view =  [[RNMBXBackgroundLayer alloc] init];
-  _view.bridge = [RCTBridge currentBridge];
+  _view.bridge = [RNMBXBridgeManager currentBridge];
   self.contentView = _view;
 }
 

--- a/ios/RNMBX/RNMBXBridgeManager.h
+++ b/ios/RNMBX/RNMBXBridgeManager.h
@@ -1,0 +1,8 @@
+#import <React/RCTBridge.h>
+
+@interface RNMBXBridgeManager : NSObject
+
++ (void)setBridge:(RCTBridge *)bridge;
++ (RCTBridge *)currentBridge;
+
+@end

--- a/ios/RNMBX/RNMBXBridgeManager.m
+++ b/ios/RNMBX/RNMBXBridgeManager.m
@@ -1,0 +1,16 @@
+#import "RNMBXBridgeManager.h"
+#import <React/RCTBridge+Private.h>
+
+static __weak RCTBridge *_rnmbxBridge = nil;
+
+@implementation RNMBXBridgeManager
+
++ (void)setBridge:(RCTBridge *)bridge {
+    _rnmbxBridge = bridge;
+}
+
++ (RCTBridge *)currentBridge {
+    return [RCTBridge currentBridge] ?: _rnmbxBridge;
+}
+
+@end

--- a/ios/RNMBX/RNMBXCircleLayerComponentView.mm
+++ b/ios/RNMBX/RNMBXCircleLayerComponentView.mm
@@ -5,6 +5,7 @@
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTBridge+Private.h>
+#import "RNMBXBridgeManager.h"
 
 #import <react/renderer/components/rnmapbox_maps_specs/ComponentDescriptors.h>
 #import <react/renderer/components/rnmapbox_maps_specs/EventEmitters.h>
@@ -40,7 +41,7 @@ using namespace facebook::react;
 - (void)prepareView
 {
   _view =  [[RNMBXCircleLayer alloc] init];
-  _view.bridge = [RCTBridge currentBridge];
+  _view.bridge = [RNMBXBridgeManager currentBridge];
   self.contentView = _view;
 }
 

--- a/ios/RNMBX/RNMBXFillExtrusionLayerComponentView.mm
+++ b/ios/RNMBX/RNMBXFillExtrusionLayerComponentView.mm
@@ -5,6 +5,7 @@
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTBridge+Private.h>
+#import "RNMBXBridgeManager.h"
 
 #import <react/renderer/components/rnmapbox_maps_specs/ComponentDescriptors.h>
 #import <react/renderer/components/rnmapbox_maps_specs/EventEmitters.h>
@@ -40,7 +41,7 @@ using namespace facebook::react;
 - (void)prepareView
 {
   _view =  [[RNMBXFillExtrusionLayer alloc] init];
-  _view.bridge = [RCTBridge currentBridge];
+  _view.bridge = [RNMBXBridgeManager currentBridge];
  self.contentView = _view;
 }
 

--- a/ios/RNMBX/RNMBXFillLayerComponentView.mm
+++ b/ios/RNMBX/RNMBXFillLayerComponentView.mm
@@ -5,6 +5,7 @@
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTBridge+Private.h>
+#import "RNMBXBridgeManager.h"
 
 #import <react/renderer/components/rnmapbox_maps_specs/ComponentDescriptors.h>
 #import <react/renderer/components/rnmapbox_maps_specs/EventEmitters.h>
@@ -40,7 +41,7 @@ using namespace facebook::react;
 - (void)prepareView
 {
   _view =  [[RNMBXFillLayer alloc] init];
-  _view.bridge = [RCTBridge currentBridge];
+  _view.bridge = [RNMBXBridgeManager currentBridge];
   self.contentView = _view;
 }
 

--- a/ios/RNMBX/RNMBXHeatmapLayerComponentView.mm
+++ b/ios/RNMBX/RNMBXHeatmapLayerComponentView.mm
@@ -5,6 +5,7 @@
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTBridge+Private.h>
+#import "RNMBXBridgeManager.h"
 
 #import <react/renderer/components/rnmapbox_maps_specs/ComponentDescriptors.h>
 #import <react/renderer/components/rnmapbox_maps_specs/EventEmitters.h>
@@ -40,7 +41,7 @@ using namespace facebook::react;
 - (void)prepareView
 {
   _view =  [[RNMBXHeatmapLayer alloc] init];
-  _view.bridge = [RCTBridge currentBridge];
+  _view.bridge = [RNMBXBridgeManager currentBridge];
   self.contentView = _view;
 }
 #pragma mark - RCTComponentViewProtocol

--- a/ios/RNMBX/RNMBXHillshadeLayerComponentView.mm
+++ b/ios/RNMBX/RNMBXHillshadeLayerComponentView.mm
@@ -5,6 +5,7 @@
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTBridge+Private.h>
+#import "RNMBXBridgeManager.h"
 
 #import <react/renderer/components/rnmapbox_maps_specs/ComponentDescriptors.h>
 #import <react/renderer/components/rnmapbox_maps_specs/EventEmitters.h>
@@ -40,7 +41,7 @@ using namespace facebook::react;
 - (void)prepareView
 {
   _view =  [[RNMBXHillshadeLayer alloc] init];
-  _view.bridge = [RCTBridge currentBridge];
+  _view.bridge = [RNMBXBridgeManager currentBridge];
   self.contentView = _view;
 }
 

--- a/ios/RNMBX/RNMBXImageModule.h
+++ b/ios/RNMBX/RNMBXImageModule.h
@@ -14,3 +14,4 @@
 @end
 
 #endif
+

--- a/ios/RNMBX/RNMBXImageModule.mm
+++ b/ios/RNMBX/RNMBXImageModule.mm
@@ -4,15 +4,28 @@
 
 #import "RNMBXImageModule.h"
 #import "RNMBXImageComponentView.h"
+#import "RNMBXBridgeManager.h"
 
 #import "rnmapbox_maps-Swift.pre.h"
 
-@implementation RNMBXImageModule
+@implementation RNMBXImageModule {
+    id _bridgeBacking;
+}
 
 RCT_EXPORT_MODULE();
 
 @synthesize viewRegistry_DEPRECATED = _viewRegistry_DEPRECATED;
-@synthesize bridge = _bridge;
+
+- (void)setBridge:(RCTBridge *)bridge {
+    _bridgeBacking = bridge;
+    if (bridge != nil) {
+        [RNMBXBridgeManager setBridge:bridge];
+    }
+}
+
+- (RCTBridge *)bridge {
+    return _bridgeBacking;
+}
 
 - (dispatch_queue_t)methodQueue
 {

--- a/ios/RNMBX/RNMBXImageQueue.swift
+++ b/ios/RNMBX/RNMBXImageQueue.swift
@@ -67,7 +67,15 @@ class RNMBXImageQueueOperation : Operation {
     
     DispatchQueue.global(qos: .default).async {
       if let weakSelf = weakSelf {
-        let loader : RCTImageLoaderProtocol = weakSelf.bridge!.module(forName: "ImageLoader", lazilyLoadIfNecessary: true) as! RCTImageLoaderProtocol
+        guard let bridge = weakSelf.bridge else {
+          Logger.log(level: .error, message: "RNMBXImageQueue: bridge is nil, cannot load image")
+          if let completionHandler = weakSelf.completionHandler {
+            completionHandler(NSError(domain: "RNMBXImageQueue", code: 1, userInfo: [NSLocalizedDescriptionKey: "bridge is nil"]), nil)
+          }
+          _ = weakSelf.setState(state:.Finished, except:.Finished)
+          return
+        }
+        let loader : RCTImageLoaderProtocol = bridge.module(forName: "ImageLoader", lazilyLoadIfNecessary: true) as! RCTImageLoaderProtocol
         
         let cancellationBlock = loader.loadImage(with: weakSelf.urlRequest, size: .zero, scale: CGFloat(weakSelf.scale), clipped: true, resizeMode: .stretch, progressBlock: { _,_  in }, partialLoad: { _ in }) { error, image in
           if let completionHandler = weakSelf.completionHandler {

--- a/ios/RNMBX/RNMBXImages.swift
+++ b/ios/RNMBX/RNMBXImages.swift
@@ -130,6 +130,10 @@ open class RNMBXImages : UIView, RNMBXMapComponent {
     }
     
     if missingImages.count > 0 {
+      guard let bridge = bridge else {
+        Logger.log(level: .error, message: "RNMBXImages: bridge is nil, cannot fetch images. Use nativeAssetImages instead.")
+        return
+      }
       RNMBXUtils.fetchImages(bridge, style: style, objects: missingImages, forceUpdate: true) { name, image in
         self.loadedImages.insert(name)
         self.imageManager?.resolve(name: name, image: image)

--- a/ios/RNMBX/RNMBXImagesComponentView.mm
+++ b/ios/RNMBX/RNMBXImagesComponentView.mm
@@ -5,6 +5,7 @@
 #include "RNMBXImageComponentView.h"
 
 #import <React/RCTBridge+Private.h>
+#import "RNMBXBridgeManager.h"
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 
@@ -42,7 +43,7 @@ using namespace facebook::react;
 - (void)prepareView
 {
     _view = [[RNMBXImages alloc] init];
-    _view.bridge = [RCTBridge currentBridge];
+    _view.bridge = [RNMBXBridgeManager currentBridge];
 
       // capture weak self reference to prevent retain cycle
       __weak __typeof__(self) weakSelf = self;

--- a/ios/RNMBX/RNMBXLightComponentView.mm
+++ b/ios/RNMBX/RNMBXLightComponentView.mm
@@ -3,6 +3,7 @@
 #import "RNMBXFabricHelpers.h"
 
 #import <React/RCTBridge+Private.h>
+#import "RNMBXBridgeManager.h"
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 
@@ -40,7 +41,7 @@ using namespace facebook::react;
 - (void)prepareView
 {
   _view = [[RNMBXLight alloc] init];
-  _view.bridge = [RCTBridge currentBridge];
+  _view.bridge = [RNMBXBridgeManager currentBridge];
   self.contentView = _view;
 }
 

--- a/ios/RNMBX/RNMBXLineLayerComponentView.mm
+++ b/ios/RNMBX/RNMBXLineLayerComponentView.mm
@@ -5,6 +5,7 @@
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTBridge+Private.h>
+#import "RNMBXBridgeManager.h"
 
 #import <react/renderer/components/rnmapbox_maps_specs/ComponentDescriptors.h>
 #import <react/renderer/components/rnmapbox_maps_specs/EventEmitters.h>
@@ -40,7 +41,7 @@ using namespace facebook::react;
 - (void)prepareView
 {
   _view =  [[RNMBXLineLayer alloc] init];
-  _view.bridge = [RCTBridge currentBridge];
+  _view.bridge = [RNMBXBridgeManager currentBridge];
   self.contentView = _view;
 }
 

--- a/ios/RNMBX/RNMBXModelLayerComponentView.mm
+++ b/ios/RNMBX/RNMBXModelLayerComponentView.mm
@@ -5,6 +5,7 @@
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTBridge+Private.h>
+#import "RNMBXBridgeManager.h"
 
 #import <react/renderer/components/rnmapbox_maps_specs/ComponentDescriptors.h>
 #import <react/renderer/components/rnmapbox_maps_specs/EventEmitters.h>
@@ -40,7 +41,7 @@ using namespace facebook::react;
 - (void)prepareView
 {
   _view =  [[RNMBXModelLayer alloc] init];
-  _view.bridge = [RCTBridge currentBridge];
+  _view.bridge = [RNMBXBridgeManager currentBridge];
   self.contentView = _view;
 }
 

--- a/ios/RNMBX/RNMBXRainComponentView.mm
+++ b/ios/RNMBX/RNMBXRainComponentView.mm
@@ -3,6 +3,7 @@
 #import "RNMBXFabricHelpers.h"
 
 #import <React/RCTBridge+Private.h>
+#import "RNMBXBridgeManager.h"
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 
@@ -40,7 +41,7 @@ using namespace facebook::react;
 - (void)prepareView
 {
     _view =  [[RNMBXRain alloc] init];
-    _view.bridge = [RCTBridge currentBridge];
+    _view.bridge = [RNMBXBridgeManager currentBridge];
 
     self.contentView = _view;
 }

--- a/ios/RNMBX/RNMBXRasterLayerComponentView.mm
+++ b/ios/RNMBX/RNMBXRasterLayerComponentView.mm
@@ -5,6 +5,7 @@
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTBridge+Private.h>
+#import "RNMBXBridgeManager.h"
 
 #import <react/renderer/components/rnmapbox_maps_specs/ComponentDescriptors.h>
 #import <react/renderer/components/rnmapbox_maps_specs/EventEmitters.h>
@@ -40,7 +41,7 @@ using namespace facebook::react;
 - (void)prepareView
 {
   _view =  [[RNMBXRasterLayer alloc] init];
-  _view.bridge = [RCTBridge currentBridge];
+  _view.bridge = [RNMBXBridgeManager currentBridge];
   self.contentView = _view;
 }
 

--- a/ios/RNMBX/RNMBXRasterParticleLayerComponentView.mm
+++ b/ios/RNMBX/RNMBXRasterParticleLayerComponentView.mm
@@ -5,6 +5,7 @@
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTBridge+Private.h>
+#import "RNMBXBridgeManager.h"
 
 #import <react/renderer/components/rnmapbox_maps_specs/ComponentDescriptors.h>
 #import <react/renderer/components/rnmapbox_maps_specs/EventEmitters.h>
@@ -40,7 +41,7 @@ using namespace facebook::react;
 - (void)prepareView
 {
   _view =  [[RNMBXRasterParticleLayer alloc] init];
-  _view.bridge = [RCTBridge currentBridge];
+  _view.bridge = [RNMBXBridgeManager currentBridge];
   self.contentView = _view;
 }
 

--- a/ios/RNMBX/RNMBXSkyLayerComponentView.mm
+++ b/ios/RNMBX/RNMBXSkyLayerComponentView.mm
@@ -5,6 +5,7 @@
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTBridge+Private.h>
+#import "RNMBXBridgeManager.h"
 
 #import <react/renderer/components/rnmapbox_maps_specs/ComponentDescriptors.h>
 #import <react/renderer/components/rnmapbox_maps_specs/EventEmitters.h>
@@ -40,7 +41,7 @@ using namespace facebook::react;
 - (void)prepareView
 {
   _view =  [[RNMBXSkyLayer alloc] init];
-  _view.bridge = [RCTBridge currentBridge];
+  _view.bridge = [RNMBXBridgeManager currentBridge];
   self.contentView = _view;
 }
 

--- a/ios/RNMBX/RNMBXSnowComponentView.mm
+++ b/ios/RNMBX/RNMBXSnowComponentView.mm
@@ -3,6 +3,7 @@
 #import "RNMBXFabricHelpers.h"
 
 #import <React/RCTBridge+Private.h>
+#import "RNMBXBridgeManager.h"
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 
@@ -40,7 +41,7 @@ using namespace facebook::react;
 - (void)prepareView
 {
     _view =  [[RNMBXSnow alloc] init];
-    _view.bridge = [RCTBridge currentBridge];
+    _view.bridge = [RNMBXBridgeManager currentBridge];
 
     self.contentView = _view;
 }

--- a/ios/RNMBX/RNMBXStyle.swift
+++ b/ios/RNMBX/RNMBXStyle.swift
@@ -53,7 +53,7 @@ func fillLayer(layer: inout FillLayer, reactStyle:Dictionary<String, Any>, oldRe
       self.setFillTranslateAnchor(&layer, styleValue:styleValue);
     } else if (prop == "fillPattern") {
       styleValue.setImage(
-        bridge: bridge!,
+        bridge: bridge,
         style: style,
         oldValue: oldReactStyle?[prop],
         setImageOnLayer: { (_) in self.setFillPattern(&layer, styleValue:styleValue) },
@@ -63,7 +63,7 @@ func fillLayer(layer: inout FillLayer, reactStyle:Dictionary<String, Any>, oldRe
       )
     } else if (prop == "fillPatternCrossFade") {
       styleValue.setImage(
-        bridge: bridge!,
+        bridge: bridge,
         style: style,
         oldValue: oldReactStyle?[prop],
         setImageOnLayer: { (_) in self.setFillPatternCrossFade(&layer, styleValue:styleValue) },
@@ -142,7 +142,7 @@ func lineLayer(layer: inout LineLayer, reactStyle:Dictionary<String, Any>, oldRe
       self.setLineDasharray(&layer, styleValue:styleValue);
     } else if (prop == "linePattern") {
       styleValue.setImage(
-        bridge: bridge!,
+        bridge: bridge,
         style: style,
         oldValue: oldReactStyle?[prop],
         setImageOnLayer: { (_) in self.setLinePattern(&layer, styleValue:styleValue) },
@@ -174,7 +174,7 @@ func lineLayer(layer: inout LineLayer, reactStyle:Dictionary<String, Any>, oldRe
       self.setLineElevationGroundScaleTransition(&layer, styleValue:styleValue);
     } else if (prop == "linePatternCrossFade") {
       styleValue.setImage(
-        bridge: bridge!,
+        bridge: bridge,
         style: style,
         oldValue: oldReactStyle?[prop],
         setImageOnLayer: { (_) in self.setLinePatternCrossFade(&layer, styleValue:styleValue) },
@@ -243,7 +243,7 @@ func symbolLayer(layer: inout SymbolLayer, reactStyle:Dictionary<String, Any>, o
       self.setIconTextFitPadding(&layer, styleValue:styleValue);
     } else if (prop == "iconImage") {
       styleValue.setImage(
-        bridge: bridge!,
+        bridge: bridge,
         style: style,
         oldValue: oldReactStyle?[prop],
         setImageOnLayer: { (_) in self.setIconImage(&layer, styleValue:styleValue) },
@@ -379,7 +379,7 @@ func symbolLayer(layer: inout SymbolLayer, reactStyle:Dictionary<String, Any>, o
       self.setTextEmissiveStrengthTransition(&layer, styleValue:styleValue);
     } else if (prop == "iconImageCrossFade") {
       styleValue.setImage(
-        bridge: bridge!,
+        bridge: bridge,
         style: style,
         oldValue: oldReactStyle?[prop],
         setImageOnLayer: { (_) in self.setIconImageCrossFade(&layer, styleValue:styleValue) },
@@ -546,7 +546,7 @@ func fillExtrusionLayer(layer: inout FillExtrusionLayer, reactStyle:Dictionary<S
       self.setFillExtrusionTranslateAnchor(&layer, styleValue:styleValue);
     } else if (prop == "fillExtrusionPattern") {
       styleValue.setImage(
-        bridge: bridge!,
+        bridge: bridge,
         style: style,
         oldValue: oldReactStyle?[prop],
         setImageOnLayer: { (_) in self.setFillExtrusionPattern(&layer, styleValue:styleValue) },
@@ -576,7 +576,7 @@ func fillExtrusionLayer(layer: inout FillExtrusionLayer, reactStyle:Dictionary<S
       self.setFillExtrusionRoundedRoof(&layer, styleValue:styleValue);
     } else if (prop == "fillExtrusionPatternCrossFade") {
       styleValue.setImage(
-        bridge: bridge!,
+        bridge: bridge,
         style: style,
         oldValue: oldReactStyle?[prop],
         setImageOnLayer: { (_) in self.setFillExtrusionPatternCrossFade(&layer, styleValue:styleValue) },
@@ -895,7 +895,7 @@ func backgroundLayer(layer: inout BackgroundLayer, reactStyle:Dictionary<String,
       self.setBackgroundColorTransition(&layer, styleValue:styleValue);
     } else if (prop == "backgroundPattern") {
       styleValue.setImage(
-        bridge: bridge!,
+        bridge: bridge,
         style: style,
         oldValue: oldReactStyle?[prop],
         setImageOnLayer: { (_) in self.setBackgroundPattern(&layer, styleValue:styleValue) },

--- a/ios/RNMBX/RNMBXStyleValue.swift
+++ b/ios/RNMBX/RNMBXStyleValue.swift
@@ -450,7 +450,7 @@ class RNMBXStyleValue {
   }
 
   func setImage(
-    bridge: RCTBridge,
+    bridge: RCTBridge?,
     style: Style,
     oldValue: Any?,
     setImageOnLayer: (_: RNMBXStyleValue) -> Void,
@@ -472,6 +472,12 @@ class RNMBXStyleValue {
             }
           }
         }
+      }
+
+      guard let bridge = bridge else {
+        Logger.log(level: .error, message: "\(name): bridge is nil, cannot fetch image \(optional: imageURI). Use nativeAssetImages instead.")
+        setImageOnLayer(self)
+        return
       }
 
       RNMBXUtils.fetchImage(bridge, url:imageURI, scale:getImageScale(), callback:{ (error, image) in

--- a/ios/RNMBX/RNMBXSymbolLayerComponentView.mm
+++ b/ios/RNMBX/RNMBXSymbolLayerComponentView.mm
@@ -5,6 +5,7 @@
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 #import <React/RCTBridge+Private.h>
+#import "RNMBXBridgeManager.h"
 
 #import <react/renderer/components/rnmapbox_maps_specs/ComponentDescriptors.h>
 #import <react/renderer/components/rnmapbox_maps_specs/EventEmitters.h>
@@ -40,7 +41,7 @@ using namespace facebook::react;
 - (void)prepareView
 {
   _view =  [[RNMBXSymbolLayer alloc] init];
-  _view.bridge = [RCTBridge currentBridge];
+  _view.bridge = [RNMBXBridgeManager currentBridge];
   self.contentView = _view;
 }
 

--- a/ios/RNMBX/RNMBXTerrainComponentView.mm
+++ b/ios/RNMBX/RNMBXTerrainComponentView.mm
@@ -3,6 +3,7 @@
 #import "RNMBXFabricHelpers.h"
 
 #import <React/RCTBridge+Private.h>
+#import "RNMBXBridgeManager.h"
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
 
@@ -40,7 +41,7 @@ using namespace facebook::react;
 - (void)prepareView
 {
   _view =  [[RNMBXTerrain alloc] init];
-  _view.bridge = [RCTBridge currentBridge];
+  _view.bridge = [RNMBXBridgeManager currentBridge];
   self.contentView = _view;
 }
 

--- a/scripts/templates/RNMBXStyle.swift.ejs
+++ b/scripts/templates/RNMBXStyle.swift.ejs
@@ -35,7 +35,7 @@ func <%- setLayerMethodName(layer, 'ios') -%>(layer: inout <%- getLayerType(laye
   <%- ifOrElseIf(i) -%> (prop == "<%= layer.properties[i].name %>") {
   <%_ if (layer.properties[i].image) { _%>
       styleValue.setImage(
-        bridge: bridge!,
+        bridge: bridge,
         style: style,
         oldValue: oldReactStyle?[prop],
         setImageOnLayer: { (_) in self.set<%- iosPropMethodName(layer, pascelCase(layer.properties[i].name)) -%>(&layer, styleValue:styleValue) },


### PR DESCRIPTION
Fixes #4195

On React Native 0.84+ with Fabric/bridgeless mode, `[RCTBridge currentBridge]` returns `nil` because `RCT_REMOVE_LEGACY_ARCH` stubs it out. This causes crashes in two ways:
1. `bridge!` force-unwraps in auto-generated `RNMBXStyle.swift` crash with `EXC_BREAKPOINT`
2. Image loading via `RCTImageLoader` fails since it's accessed through the bridge

### Root cause
TurboModules still receive a working `RCTBridgeProxy` via their `bridge` property (set by `RCTTurboModuleManager`), but ComponentViews used `[RCTBridge currentBridge]` which is nil.

### Changes

**Commit 1: Remove force-unwraps**
- `RNMBXStyle.swift.ejs` template: `bridge!` → `bridge`
- `RNMBXStyleValue.swift`: `setImage` accepts `RCTBridge?`, guards the fetch call
- `RNMBXImages.swift`: guards `fetchImages` with `if let bridge`
- `RNMBXImageQueue.swift`: guards `bridge!.module(...)` with early return

**Commit 2: Bridge proxy resolution**
- New `RNMBXBridgeManager` captures the bridge proxy from `RNMBXImageModule` (a TurboModule)
- `RNMBXBridgeManager.currentBridge` returns `[RCTBridge currentBridge] ?: capturedProxy`
- All 18 ComponentViews now use `[RNMBXBridgeManager currentBridge]`

### Test plan
- Reproduced crash on RN 0.84 bridgeless: `Fatal error` at RNMBXImages.swift:133
- After fix: no crash, images load correctly via bridge proxy
- iOS build succeeds, unit tests pass (110/110)