### PR TITLE
Update style-spec to Mapbox Maps SDK 11.23.1

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/RNMBXStyleFactory.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/RNMBXStyleFactory.kt
@@ -413,6 +413,12 @@ object RNMBXStyleFactory {
                 setTextOcclusionOpacityTransition(layer, styleValue)
               "iconColorSaturation" ->
                 setIconColorSaturation(layer, styleValue)
+              "iconColorContrast" ->
+                setIconColorContrast(layer, styleValue)
+              "iconColorBrightnessMin" ->
+                setIconColorBrightnessMin(layer, styleValue)
+              "iconColorBrightnessMax" ->
+                setIconColorBrightnessMax(layer, styleValue)
               "symbolZOffset" ->
                 setSymbolZOffset(layer, styleValue)
                 "symbolZOffsetTransition" ->
@@ -645,6 +651,8 @@ object RNMBXStyleFactory {
                 setFillExtrusionLineWidth(layer, styleValue)
                 "fillExtrusionLineWidthTransition" ->
                 setFillExtrusionLineWidthTransition(layer, styleValue)
+              "fillExtrusionCastShadows" ->
+                setFillExtrusionCastShadows(layer, styleValue)
           }
         } catch (e: MapboxStyleException) {
           Logger.e(LOG_TAG, "Failed to update: $styleKey ${e.message}")
@@ -791,6 +799,10 @@ object RNMBXStyleFactory {
                 setHillshadeAccentColor(layer, styleValue)
                 "hillshadeAccentColorTransition" ->
                 setHillshadeAccentColorTransition(layer, styleValue)
+              "hillshadeEmissiveStrength" ->
+                setHillshadeEmissiveStrength(layer, styleValue)
+                "hillshadeEmissiveStrengthTransition" ->
+                setHillshadeEmissiveStrengthTransition(layer, styleValue)
           }
         } catch (e: MapboxStyleException) {
           Logger.e(LOG_TAG, "Failed to update: $styleKey ${e.message}")
@@ -3195,6 +3207,60 @@ object RNMBXStyleFactory {
       }
     }
 
+    fun setIconColorContrast(layer: SymbolLayer, styleValue: RNMBXStyleValue ) {
+      if (styleValue.isExpression()) {
+        val expression = styleValue.getExpression()
+        if (expression != null) {
+          layer.iconColorContrast(expression)
+        } else {
+          Logger.e("RNMBXSymbol", "Expression for iconColorContrast is null")
+        }
+      } else {
+          val value = styleValue.getDouble(VALUE_KEY)
+          if (value != null) {
+            layer.iconColorContrast(value)
+          } else {
+            Logger.e("RNMBXSymbol", "value for iconColorContrast is null")
+          }
+      }
+    }
+
+    fun setIconColorBrightnessMin(layer: SymbolLayer, styleValue: RNMBXStyleValue ) {
+      if (styleValue.isExpression()) {
+        val expression = styleValue.getExpression()
+        if (expression != null) {
+          layer.iconColorBrightnessMin(expression)
+        } else {
+          Logger.e("RNMBXSymbol", "Expression for iconColorBrightnessMin is null")
+        }
+      } else {
+          val value = styleValue.getDouble(VALUE_KEY)
+          if (value != null) {
+            layer.iconColorBrightnessMin(value)
+          } else {
+            Logger.e("RNMBXSymbol", "value for iconColorBrightnessMin is null")
+          }
+      }
+    }
+
+    fun setIconColorBrightnessMax(layer: SymbolLayer, styleValue: RNMBXStyleValue ) {
+      if (styleValue.isExpression()) {
+        val expression = styleValue.getExpression()
+        if (expression != null) {
+          layer.iconColorBrightnessMax(expression)
+        } else {
+          Logger.e("RNMBXSymbol", "Expression for iconColorBrightnessMax is null")
+        }
+      } else {
+          val value = styleValue.getDouble(VALUE_KEY)
+          if (value != null) {
+            layer.iconColorBrightnessMax(value)
+          } else {
+            Logger.e("RNMBXSymbol", "value for iconColorBrightnessMax is null")
+          }
+      }
+    }
+
     fun setSymbolZOffset(layer: SymbolLayer, styleValue: RNMBXStyleValue ) {
       if (styleValue.isExpression()) {
         val expression = styleValue.getExpression()
@@ -4270,6 +4336,24 @@ object RNMBXStyleFactory {
       }
     }
 
+    fun setFillExtrusionCastShadows(layer: FillExtrusionLayer, styleValue: RNMBXStyleValue ) {
+      if (styleValue.isExpression()) {
+        val expression = styleValue.getExpression()
+        if (expression != null) {
+          layer.fillExtrusionCastShadows(expression)
+        } else {
+          Logger.e("RNMBXFillExtrusion", "Expression for fillExtrusionCastShadows is null")
+        }
+      } else {
+          val value = styleValue.getBoolean(VALUE_KEY)
+          if (value != null) {
+            layer.fillExtrusionCastShadows(value)
+          } else {
+            Logger.e("RNMBXFillExtrusion", "value for fillExtrusionCastShadows is null")
+          }
+      }
+    }
+
     fun setVisibility(layer: RasterLayer, styleValue: RNMBXStyleValue ) {
         layer.visibility(Visibility.valueOf(styleValue.getEnumName()));
     }
@@ -4878,6 +4962,32 @@ object RNMBXStyleFactory {
       val transition = styleValue.transition
       if (transition != null) {
         layer.hillshadeAccentColorTransition(transition);
+      }
+    }
+
+    fun setHillshadeEmissiveStrength(layer: HillshadeLayer, styleValue: RNMBXStyleValue ) {
+      if (styleValue.isExpression()) {
+        val expression = styleValue.getExpression()
+        if (expression != null) {
+          layer.hillshadeEmissiveStrength(expression)
+        } else {
+          Logger.e("RNMBXHillshade", "Expression for hillshadeEmissiveStrength is null")
+        }
+      } else {
+          val value = styleValue.getDouble(VALUE_KEY)
+          if (value != null) {
+            layer.hillshadeEmissiveStrength(value)
+          } else {
+            Logger.e("RNMBXHillshade", "value for hillshadeEmissiveStrength is null")
+          }
+      }
+    }
+
+
+    fun setHillshadeEmissiveStrengthTransition(layer: HillshadeLayer, styleValue: RNMBXStyleValue) {
+      val transition = styleValue.transition
+      if (transition != null) {
+        layer.hillshadeEmissiveStrengthTransition(transition);
       }
     }
 

--- a/docs/FillExtrusionLayer.md
+++ b/docs/FillExtrusionLayer.md
@@ -155,6 +155,7 @@ Customizable style attributes
 * <a href="#fillextrusioncutofffaderange">fillExtrusionCutoffFadeRange</a><br/>
 * <a href="#fillextrusionemissivestrength">fillExtrusionEmissiveStrength</a><br/>
 * <a href="#fillextrusionlinewidth">fillExtrusionLineWidth</a><br/>
+* <a href="#fillextrusioncastshadows">fillExtrusionCastShadows</a><br/>
 
 ___
 
@@ -1211,5 +1212,22 @@ The transition affecting any changes to this layer’s fillExtrusionLineWidth pr
 
 #### Default Value
 `{duration: 300, delay: 0}`
+
+
+___
+
+### fillExtrusionCastShadows
+Name: `fillExtrusionCastShadows`
+
+Mapbox spec: [fill-extrusion-cast-shadows](https://docs.mapbox.com/style-spec/reference/layers/#paint-fill-extrusion-fill-extrusion-cast-shadows)
+
+#### Description
+Enable/Disable shadow casting for this layer
+
+#### Type
+`boolean`
+#### Default Value
+`true`
+
 
 

--- a/docs/HillshadeLayer.md
+++ b/docs/HillshadeLayer.md
@@ -144,6 +144,7 @@ Customizable style attributes
 * <a href="#hillshadeshadowcolor">hillshadeShadowColor</a><br/>
 * <a href="#hillshadehighlightcolor">hillshadeHighlightColor</a><br/>
 * <a href="#hillshadeaccentcolor">hillshadeAccentColor</a><br/>
+* <a href="#hillshadeemissivestrength">hillshadeEmissiveStrength</a><br/>
 
 ___
 
@@ -369,6 +370,54 @@ Name: `hillshadeAccentColorTransition`
 #### Description
 
 The transition affecting any changes to this layer’s hillshadeAccentColor property.
+
+#### Type
+
+`{ duration, delay }`
+
+#### Units
+`milliseconds`
+
+#### Default Value
+`{duration: 300, delay: 0}`
+
+
+___
+
+### hillshadeEmissiveStrength
+Name: `hillshadeEmissiveStrength`
+
+Mapbox spec: [hillshade-emissive-strength](https://docs.mapbox.com/style-spec/reference/layers/#paint-hillshade-hillshade-emissive-strength)
+
+#### Description
+Controls the intensity of light emitted on the source features.
+
+#### Type
+`number`
+#### Default Value
+`0`
+
+#### Units
+`intensity`
+
+#### Minimum
+`0`
+
+
+#### Requires
+`lights`
+
+#### Expression
+
+Parameters: `zoom, measure-light`
+___
+
+### hillshadeEmissiveStrengthTransition
+Name: `hillshadeEmissiveStrengthTransition`
+
+#### Description
+
+The transition affecting any changes to this layer’s hillshadeEmissiveStrength property.
 
 #### Type
 

--- a/docs/LineLayer.md
+++ b/docs/LineLayer.md
@@ -972,7 +972,7 @@ Controls the intensity of light emitted on the source features.
 
 #### Expression
 
-Parameters: `zoom, measure-light`
+Parameters: `zoom, measure-light, line-progress`
 ___
 
 ### lineEmissiveStrengthTransition

--- a/docs/SymbolLayer.md
+++ b/docs/SymbolLayer.md
@@ -211,6 +211,9 @@ This is now deprecated, use Image component instead.
 * <a href="#texttranslate">textTranslate</a><br/>
 * <a href="#texttranslateanchor">textTranslateAnchor</a><br/>
 * <a href="#iconcolorsaturation">iconColorSaturation</a><br/>
+* <a href="#iconcolorcontrast">iconColorContrast</a><br/>
+* <a href="#iconcolorbrightnessmin">iconColorBrightnessMin</a><br/>
+* <a href="#iconcolorbrightnessmax">iconColorBrightnessMax</a><br/>
 * <a href="#symbolzoffset">symbolZOffset</a><br/>
 
 ___
@@ -2179,6 +2182,84 @@ Increase or reduce the saturation of the symbol icon.
 
 #### Minimum
 `-1`
+
+
+#### Maximum
+`1`
+
+#### Expression
+
+Parameters: ``
+
+___
+
+### iconColorContrast
+Name: `iconColorContrast`
+
+Mapbox spec: [icon-color-contrast](https://docs.mapbox.com/style-spec/reference/layers/#paint-symbol-icon-color-contrast)
+
+#### Description
+Increase or reduce the contrast of the symbol icon.
+
+#### Type
+`number`
+#### Default Value
+`0`
+
+#### Minimum
+`-1`
+
+
+#### Maximum
+`1`
+
+#### Expression
+
+Parameters: ``
+
+___
+
+### iconColorBrightnessMin
+Name: `iconColorBrightnessMin`
+
+Mapbox spec: [icon-color-brightness-min](https://docs.mapbox.com/style-spec/reference/layers/#paint-symbol-icon-color-brightness-min)
+
+#### Description
+Increase or reduce the brightness of the symbols. The value is the minimum brightness.
+
+#### Type
+`number`
+#### Default Value
+`0`
+
+#### Minimum
+`0`
+
+
+#### Maximum
+`1`
+
+#### Expression
+
+Parameters: ``
+
+___
+
+### iconColorBrightnessMax
+Name: `iconColorBrightnessMax`
+
+Mapbox spec: [icon-color-brightness-max](https://docs.mapbox.com/style-spec/reference/layers/#paint-symbol-icon-color-brightness-max)
+
+#### Description
+Increase or reduce the brightness of the symbols. The value is the maximum brightness.
+
+#### Type
+`number`
+#### Default Value
+`1`
+
+#### Minimum
+`0`
 
 
 #### Maximum

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2370,6 +2370,22 @@
           "name": "fill-extrusion-line-width",
           "namespace": "paint"
         }
+      },
+      {
+        "name": "fillExtrusionCastShadows",
+        "type": "boolean",
+        "values": [],
+        "default": true,
+        "description": "Enable/Disable shadow casting for this layer",
+        "requires": [],
+        "disabledBy": [],
+        "allowedFunctionTypes": [],
+        "transition": false,
+        "mbx": {
+          "fullName": "paint-fill-extrusion-fill-extrusion-cast-shadows",
+          "name": "fill-extrusion-cast-shadows",
+          "namespace": "paint"
+        }
       }
     ]
   },
@@ -3307,6 +3323,33 @@
         "mbx": {
           "fullName": "paint-hillshade-hillshade-accent-color",
           "name": "hillshade-accent-color",
+          "namespace": "paint"
+        }
+      },
+      {
+        "name": "hillshadeEmissiveStrength",
+        "type": "number",
+        "values": [],
+        "minimum": 0,
+        "units": "intensity",
+        "default": 0,
+        "description": "Controls the intensity of light emitted on the source features.",
+        "requires": [
+          "lights"
+        ],
+        "disabledBy": [],
+        "allowedFunctionTypes": [],
+        "expression": {
+          "interpolated": true,
+          "parameters": [
+            "zoom",
+            "measure-light"
+          ]
+        },
+        "transition": true,
+        "mbx": {
+          "fullName": "paint-hillshade-hillshade-emissive-strength",
+          "name": "hillshade-emissive-strength",
           "namespace": "paint"
         }
       }
@@ -4397,7 +4440,8 @@
           "interpolated": true,
           "parameters": [
             "zoom",
-            "measure-light"
+            "measure-light",
+            "line-progress"
           ]
         },
         "transition": true,
@@ -10048,6 +10092,69 @@
         "mbx": {
           "fullName": "paint-symbol-icon-color-saturation",
           "name": "icon-color-saturation",
+          "namespace": "paint"
+        }
+      },
+      {
+        "name": "iconColorContrast",
+        "type": "number",
+        "values": [],
+        "minimum": -1,
+        "maximum": 1,
+        "default": 0,
+        "description": "Increase or reduce the contrast of the symbol icon.",
+        "requires": [],
+        "disabledBy": [],
+        "allowedFunctionTypes": [],
+        "expression": {
+          "interpolated": false
+        },
+        "transition": false,
+        "mbx": {
+          "fullName": "paint-symbol-icon-color-contrast",
+          "name": "icon-color-contrast",
+          "namespace": "paint"
+        }
+      },
+      {
+        "name": "iconColorBrightnessMin",
+        "type": "number",
+        "values": [],
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0,
+        "description": "Increase or reduce the brightness of the symbols. The value is the minimum brightness.",
+        "requires": [],
+        "disabledBy": [],
+        "allowedFunctionTypes": [],
+        "expression": {
+          "interpolated": false
+        },
+        "transition": false,
+        "mbx": {
+          "fullName": "paint-symbol-icon-color-brightness-min",
+          "name": "icon-color-brightness-min",
+          "namespace": "paint"
+        }
+      },
+      {
+        "name": "iconColorBrightnessMax",
+        "type": "number",
+        "values": [],
+        "minimum": 0,
+        "maximum": 1,
+        "default": 1,
+        "description": "Increase or reduce the brightness of the symbols. The value is the maximum brightness.",
+        "requires": [],
+        "disabledBy": [],
+        "allowedFunctionTypes": [],
+        "expression": {
+          "interpolated": false
+        },
+        "transition": false,
+        "mbx": {
+          "fullName": "paint-symbol-icon-color-brightness-max",
+          "name": "icon-color-brightness-max",
           "namespace": "paint"
         }
       },

--- a/ios/RNMBX/RNMBXStyle.swift
+++ b/ios/RNMBX/RNMBXStyle.swift
@@ -393,6 +393,12 @@ func symbolLayer(layer: inout SymbolLayer, reactStyle:Dictionary<String, Any>, o
       self.setTextOcclusionOpacityTransition(&layer, styleValue:styleValue);
     } else if (prop == "iconColorSaturation") {
       self.setIconColorSaturation(&layer, styleValue:styleValue);
+    } else if (prop == "iconColorContrast") {
+      self.setIconColorContrast(&layer, styleValue:styleValue);
+    } else if (prop == "iconColorBrightnessMin") {
+      self.setIconColorBrightnessMin(&layer, styleValue:styleValue);
+    } else if (prop == "iconColorBrightnessMax") {
+      self.setIconColorBrightnessMax(&layer, styleValue:styleValue);
     } else if (prop == "symbolZOffset") {
       self.setSymbolZOffset(&layer, styleValue:styleValue);
     } else if (prop == "symbolZOffsetTransition") {
@@ -634,6 +640,8 @@ func fillExtrusionLayer(layer: inout FillExtrusionLayer, reactStyle:Dictionary<S
       self.setFillExtrusionLineWidth(&layer, styleValue:styleValue);
     } else if (prop == "fillExtrusionLineWidthTransition") {
       self.setFillExtrusionLineWidthTransition(&layer, styleValue:styleValue);
+    } else if (prop == "fillExtrusionCastShadows") {
+      self.setFillExtrusionCastShadows(&layer, styleValue:styleValue);
     } else {
       Logger.log(level:.error, message: "Unexpected property \(prop) for layer: fill-extrusion")
     }
@@ -789,6 +797,10 @@ func hillshadeLayer(layer: inout HillshadeLayer, reactStyle:Dictionary<String, A
       self.setHillshadeAccentColor(&layer, styleValue:styleValue);
     } else if (prop == "hillshadeAccentColorTransition") {
       self.setHillshadeAccentColorTransition(&layer, styleValue:styleValue);
+    } else if (prop == "hillshadeEmissiveStrength") {
+      self.setHillshadeEmissiveStrength(&layer, styleValue:styleValue);
+    } else if (prop == "hillshadeEmissiveStrengthTransition") {
+      self.setHillshadeEmissiveStrengthTransition(&layer, styleValue:styleValue);
     } else {
       Logger.log(level:.error, message: "Unexpected property \(prop) for layer: hillshade")
     }
@@ -2288,6 +2300,33 @@ func setIconColorSaturation(_ layer: inout SymbolLayer, styleValue: RNMBXStyleVa
       
 }
 
+func setIconColorContrast(_ layer: inout SymbolLayer, styleValue: RNMBXStyleValue)
+{
+      
+        
+          layer.iconColorContrast = styleValue.mglStyleValueNumber();
+        
+      
+}
+
+func setIconColorBrightnessMin(_ layer: inout SymbolLayer, styleValue: RNMBXStyleValue)
+{
+      
+        
+          layer.iconColorBrightnessMin = styleValue.mglStyleValueNumber();
+        
+      
+}
+
+func setIconColorBrightnessMax(_ layer: inout SymbolLayer, styleValue: RNMBXStyleValue)
+{
+      
+        
+          layer.iconColorBrightnessMax = styleValue.mglStyleValueNumber();
+        
+      
+}
+
 func setSymbolZOffset(_ layer: inout SymbolLayer, styleValue: RNMBXStyleValue)
 {
       
@@ -2887,6 +2926,15 @@ func setFillExtrusionLineWidthTransition(_ layer: inout FillExtrusionLayer, styl
     layer.fillExtrusionLineWidthTransition = styleValue.getTransition();
 }
 
+func setFillExtrusionCastShadows(_ layer: inout FillExtrusionLayer, styleValue: RNMBXStyleValue)
+{
+      
+        
+          layer.fillExtrusionCastShadows = styleValue.mglStyleValueBoolean();
+        
+      
+}
+
 
 
 func setRasterStyleLayerVisibility(_ layer: inout RasterLayer, styleValue: RNMBXStyleValue)
@@ -3229,6 +3277,20 @@ func setHillshadeAccentColor(_ layer: inout HillshadeLayer, styleValue: RNMBXSty
 func setHillshadeAccentColorTransition(_ layer: inout HillshadeLayer, styleValue: RNMBXStyleValue)
 {
     layer.hillshadeAccentColorTransition = styleValue.getTransition();
+}
+
+func setHillshadeEmissiveStrength(_ layer: inout HillshadeLayer, styleValue: RNMBXStyleValue)
+{
+      
+        
+          layer.hillshadeEmissiveStrength = styleValue.mglStyleValueNumber();
+        
+      
+}
+
+func setHillshadeEmissiveStrengthTransition(_ layer: inout HillshadeLayer, styleValue: RNMBXStyleValue)
+{
+    layer.hillshadeEmissiveStrengthTransition = styleValue.getTransition();
 }
 
 

--- a/package.json
+++ b/package.json
@@ -75,8 +75,8 @@
   },
   "homepage": "https://github.com/rnmapbox/maps#readme",
   "mapbox": {
-    "ios": "~> 11.20.1",
-    "android": "11.20.1"
+    "ios": "~> 11.23.1",
+    "android": "11.23.1"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/scripts/autogenHelpers/generateCodeWithEjs.mjs
+++ b/scripts/autogenHelpers/generateCodeWithEjs.mjs
@@ -319,18 +319,9 @@ function isTranslate(attrName) {
 }
 
 const UnsupportedProperties = [
-  'hillshade-emissive-strength', // should be supported in v11 according to specs but it's not on ios 11.0.0.rc2
-
-  'icon-color-contrast', // should be supported in v11 11.15.2 but it's not on android
-
-  'icon-color-brightness-min', // should be supported in v11 11.15.0 but it's not on android
-  'icon-color-brightness-max', // should be supported in v11 11.15.0 but it's not on android
-
-  'fill-extrusion-cast-shadows', // should be supported in v11 11.8.0 but it's not on android
-
   'raster-particle-elevation', // should be supported in v11 11.7.0 but it's not yet implemented in SDK
 
-  'raster-elevation-reference', // spec says ios 11.19.0 but not present in SDK 11.20.1
+  'raster-elevation-reference', // spec says ios 11.19.0 but not present in SDK 11.23.1
 ];
 
 // Properties marked as private in the style-spec but supported by native SDKs

--- a/src/utils/MapboxStyles.ts
+++ b/src/utils/MapboxStyles.ts
@@ -809,7 +809,10 @@ export interface LineLayerStyleProps {
    *
    * @requires lights
    */
-  lineEmissiveStrength?: Value<number, ['zoom', 'measure-light']>;
+  lineEmissiveStrength?: Value<
+    number,
+    ['zoom', 'measure-light', 'line-progress']
+  >;
 
   /**
    * The transition affecting any changes to this layer’s lineEmissiveStrength property.
@@ -1363,6 +1366,18 @@ export interface SymbolLayerStyleProps {
    */
   iconColorSaturation?: Value<number>;
   /**
+   * Increase or reduce the contrast of the symbol icon.
+   */
+  iconColorContrast?: Value<number>;
+  /**
+   * Increase or reduce the brightness of the symbols. The value is the minimum brightness.
+   */
+  iconColorBrightnessMin?: Value<number>;
+  /**
+   * Increase or reduce the brightness of the symbols. The value is the maximum brightness.
+   */
+  iconColorBrightnessMax?: Value<number>;
+  /**
    * Specifies an uniform elevation from the ground, in meters.
    */
   symbolZOffset?: Value<number, ['zoom', 'feature']>;
@@ -1826,6 +1841,10 @@ export interface FillExtrusionLayerStyleProps {
    * The transition affecting any changes to this layer’s fillExtrusionLineWidth property.
    */
   fillExtrusionLineWidthTransition?: Transition;
+  /**
+   * Enable/Disable shadow casting for this layer
+   */
+  fillExtrusionCastShadows?: boolean;
 }
 export interface RasterLayerStyleProps {
   /**
@@ -2047,6 +2066,17 @@ export interface HillshadeLayerStyleProps {
    * The transition affecting any changes to this layer’s hillshadeAccentColor property.
    */
   hillshadeAccentColorTransition?: Transition;
+  /**
+   * Controls the intensity of light emitted on the source features.
+   *
+   * @requires lights
+   */
+  hillshadeEmissiveStrength?: Value<number, ['zoom', 'measure-light']>;
+
+  /**
+   * The transition affecting any changes to this layer’s hillshadeEmissiveStrength property.
+   */
+  hillshadeEmissiveStrengthTransition?: Transition;
 }
 export interface ModelLayerStyleProps {
   /**

--- a/src/utils/styleMap.ts
+++ b/src/utils/styleMap.ts
@@ -163,6 +163,9 @@ const styleMap = {
   textOcclusionOpacity: StyleTypes.Constant,
   textOcclusionOpacityTransition: StyleTypes.Transition,
   iconColorSaturation: StyleTypes.Constant,
+  iconColorContrast: StyleTypes.Constant,
+  iconColorBrightnessMin: StyleTypes.Constant,
+  iconColorBrightnessMax: StyleTypes.Constant,
   symbolZOffset: StyleTypes.Constant,
   symbolZOffsetTransition: StyleTypes.Transition,
 
@@ -245,6 +248,7 @@ const styleMap = {
   fillExtrusionEmissiveStrengthTransition: StyleTypes.Transition,
   fillExtrusionLineWidth: StyleTypes.Constant,
   fillExtrusionLineWidthTransition: StyleTypes.Transition,
+  fillExtrusionCastShadows: StyleTypes.Constant,
 
   rasterOpacity: StyleTypes.Constant,
   rasterOpacityTransition: StyleTypes.Transition,
@@ -291,6 +295,8 @@ const styleMap = {
   hillshadeHighlightColorTransition: StyleTypes.Transition,
   hillshadeAccentColor: StyleTypes.Color,
   hillshadeAccentColorTransition: StyleTypes.Transition,
+  hillshadeEmissiveStrength: StyleTypes.Constant,
+  hillshadeEmissiveStrengthTransition: StyleTypes.Transition,
 
   modelAllowDensityReduction: StyleTypes.Constant,
   modelId: StyleTypes.Constant,

--- a/style-spec/v8.json
+++ b/style-spec/v8.json
@@ -2207,6 +2207,22 @@
         "interpolated": false
       },
       "property-type": "constant"
+    },
+    "source-max-zoom": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 24,
+      "private": true,
+      "experimental": true,
+      "doc": "The maximum zoom level at which to load and parse source tiles for this layer. When set, tiles are never loaded or re-parsed above this zoom level. At higher zoom levels, the renderer reuses tiles from this zoom level without creating overscaled variants. This reduces the number of tiles parsed and prevents tile-border artifacts for layers like fill-extrusion.",
+      "sdk-support": {
+        "basic functionality": {
+          "js": "3.21.0",
+          "android": "11.21.0",
+          "ios": "11.21.0"
+        }
+      },
+      "property-type": "constant"
     }
   },
   "layout_building": {
@@ -2222,7 +2238,7 @@
       },
       "default": "visible",
       "doc": "Whether this layer is displayed.",
-      "private": true,      
+      "private": true,
       "sdk-support": {
         "basic functionality": {
           "js": "3.16.0",
@@ -7908,6 +7924,30 @@
       },
       "property-type": "data-constant"
     },
+    "fill-extrusion-front-cutoff": {
+      "type": "array",
+      "private": true,
+      "experimental": true,
+      "value": "number",
+      "property-type": "data-constant",
+      "transition": false,
+      "expression": {
+        "interpolated": true,
+        "parameters": ["zoom"]
+      },
+      "length": 3,
+      "default": [0.0, 0.0, 1.0],
+      "minimum": [0.0, 0.0, 0.0],
+      "maximum": [1.0, 1.0, 1.0],
+      "doc": "An array for configuring the fade-out effect for the front cutoff of content on pitched map views. It contains three values: start, range and final opacity. The start parameter defines the point at which the fade-out effect begins, with smaller values causing the effect to start earlier. The range parameter specifies how long the fade-out effect will last. A value of 0.0 for range makes content disappear immediately without a fade-out effect. The final opacity determines content opacity at the end of the fade-out effect. A value of 1.0 for final opacity means that the cutoff is completely disabled. Note: The property has no effect on the map if terrain or globe projection is enabled.",
+      "sdk-support": {
+        "basic functionality": {
+          "js": "3.21.0",
+          "android": "11.21.0",
+          "ios": "11.21.0"
+        }
+      }
+    },
     "fill-extrusion-emissive-strength": {
       "type": "number",
       "default": 0,
@@ -8222,7 +8262,7 @@
     },
     "building-cutoff-fade-range": {
       "type": "number",
-      "private": true,      
+      "private": true,
       "default": 0.0,
       "minimum": 0.0,
       "maximum": 1.0,
@@ -8239,6 +8279,30 @@
         }
       },
       "property-type": "data-constant"
+    },
+    "building-front-cutoff": {
+      "type": "array",
+      "private": true,
+      "experimental": true,
+      "value": "number",
+      "property-type": "data-constant",
+      "transition": false,
+      "expression": {
+        "interpolated": true,
+        "parameters": ["zoom"]
+      },
+      "length": 3,
+      "default": [0.0, 0.0, 1.0],
+      "minimum": [0.0, 0.0, 0.0],
+      "maximum": [1.0, 1.0, 1.0],
+      "doc": "An array for configuring the fade-out effect for the front cutoff of content on pitched map views. It contains three values: start, range and final opacity. The start parameter defines the point at which the fade-out effect begins, with smaller values causing the effect to start earlier. The range parameter specifies how long the fade-out effect will last. A value of 0.0 for range makes content disappear immediately without a fade-out effect. The final opacity determines content opacity at the end of the fade-out effect. A value of 1.0 for final opacity means that the cutoff is completely disabled. Note: The property has no effect on the map if terrain or globe projection is enabled.",
+      "sdk-support": {
+        "basic functionality": {
+          "js": "3.21.0",
+          "android": "11.21.0",
+          "ios": "11.21.0"
+        }
+      }
     },
     "building-flood-light-color": {
       "property-type": "data-constant",
@@ -8810,7 +8874,8 @@
         "interpolated": true,
         "parameters": [
           "zoom",
-          "measure-light"
+          "measure-light",
+          "line-progress"
         ]
       },
       "property-type": "data-driven"
@@ -8893,6 +8958,50 @@
         ]
       },
       "transition": true,
+      "property-type": "data-constant"
+    },
+    "line-blend-mode": {
+      "type": "enum",
+      "values": {
+        "default": { "doc": "Normal non-blended rendering mode." },
+        "multiply": { "doc": "Line features are composited using multiply blending." },
+        "additive": { "doc": "Line features are composited using additive density accumulation with tone mapping." }
+      },
+      "doc": "Controls the blend mode used for rendering line features.",
+      "default": "default",
+      "experimental": true,
+      "private": true,
+      "sdk-support": {
+        "basic functionality": {
+          "js": "3.21.0"
+        }
+      },
+      "expression": {
+        "interpolated": false,
+        "parameters": [
+          "zoom"
+        ]
+      },
+      "property-type": "data-constant"
+    },
+    "line-blend-additive-clamp": {
+      "type": "number",
+      "default": 0,
+      "minimum": 0,
+      "doc": "Controls the brightness of lines in additive blend mode. When set to 0 (the default), brightness is adjusted automatically based on the density of lines visible on screen. Increase this value if the lines appear too bright, or decrease it if they appear too faint.",
+      "experimental": true,
+      "private": true,
+      "sdk-support": {
+        "basic functionality": {
+          "js": "3.21.0"
+        }
+      },
+      "expression": {
+        "interpolated": true,
+        "parameters": [
+          "zoom"
+        ]
+      },
       "property-type": "data-constant"
     }
   },
@@ -9418,6 +9527,7 @@
           "measure-light"
         ]
       },
+      "appearance": true,
       "property-type": "data-driven"
     },
     "icon-occlusion-opacity": {
@@ -9451,6 +9561,7 @@
           "measure-light"
         ]
       },
+      "appearance": true,
       "property-type": "data-driven"
     },
     "icon-emissive-strength": {
@@ -9483,6 +9594,7 @@
           "feature-state"
         ]
       },
+      "appearance": true,
       "property-type": "data-driven"
     },
     "text-emissive-strength": {
@@ -9515,6 +9627,7 @@
           "feature-state"
         ]
       },
+      "appearance": true,
       "property-type": "data-driven"
     },
     "icon-color": {
@@ -9547,6 +9660,7 @@
           "measure-light"
         ]
       },
+      "appearance": true,
       "property-type": "data-driven"
     },
     "icon-halo-color": {
@@ -9579,6 +9693,7 @@
           "measure-light"
         ]
       },
+      "appearance": true,
       "property-type": "data-driven"
     },
     "icon-halo-width": {
@@ -9612,6 +9727,7 @@
           "measure-light"
         ]
       },
+      "appearance": true,
       "property-type": "data-driven"
     },
     "icon-halo-blur": {
@@ -9645,6 +9761,7 @@
           "measure-light"
         ]
       },
+      "appearance": true,
       "property-type": "data-driven"
     },
     "icon-translate": {
@@ -9656,6 +9773,7 @@
         0
       ],
       "transition": true,
+      "appearance": true,
       "units": "pixels",
       "doc": "Distance that the icon's anchor is moved from its original placement. Positive values indicate right and down, while negative values indicate left and up.",
       "requires": [
@@ -9763,6 +9881,7 @@
           "measure-light"
         ]
       },
+      "appearance": true,
       "property-type": "data-driven"
     },
     "text-occlusion-opacity": {
@@ -9796,6 +9915,7 @@
           "measure-light"
         ]
       },
+      "appearance": true,
       "property-type": "data-driven"
     },
     "text-color": {
@@ -9829,6 +9949,7 @@
           "measure-light"
         ]
       },
+      "appearance": true,
       "property-type": "data-driven"
     },
     "text-halo-color": {
@@ -9861,6 +9982,7 @@
           "measure-light"
         ]
       },
+      "appearance": true,
       "property-type": "data-driven"
     },
     "text-halo-width": {
@@ -9894,6 +10016,7 @@
           "measure-light"
         ]
       },
+      "appearance": true,
       "property-type": "data-driven"
     },
     "text-halo-blur": {
@@ -9927,6 +10050,7 @@
           "measure-light"
         ]
       },
+      "appearance": true,
       "property-type": "data-driven"
     },
     "text-translate": {
@@ -9938,6 +10062,7 @@
         0
       ],
       "transition": true,
+      "appearance": true,
       "units": "pixels",
       "doc": "Distance that the text's anchor is moved from its original placement. Positive values indicate right and down, while negative values indicate left and up.",
       "requires": [
@@ -10072,6 +10197,7 @@
       "minimum": 0,
       "transition": true,
       "experimental": true,
+      "appearance": true,
       "sdk-support": {
         "basic functionality": {
           "js": "3.7.0",
@@ -11290,6 +11416,27 @@
       },
       "transition": true
     },
+    "model-lightmap-intensity": {
+      "type": "number",
+      "default": 0.0,
+      "minimum": 0,
+      "doc": "Controls the intensity of the model lightmap contribution. Values less than or equal to 0.001 are treated as off.",
+      "private": true,
+      "experimental": true,
+      "expression": {
+        "interpolated": true,
+        "parameters": ["zoom"]
+      },
+      "sdk-support": {
+          "basic functionality": {
+          "js": "3.25.0",
+          "android": "11.25.0",
+          "ios": "11.25.0"
+        }
+      },
+      "property-type": "data-constant",
+      "transition": true
+    },
     "model-type": {
       "type": "enum",
       "values": {
@@ -11474,7 +11621,7 @@
       "default": [0.0, 0.0, 1.0],
       "minimum": [0.0, 0.0, 0.0],
       "maximum": [1.0, 1.0, 1.0],
-      "doc": "An array for configuring the fade-out effect for the front cutoff of content on pitched map views. It contains three values: start, range and final opacity. The start parameter defines the point at which the fade-out effect begins, with smaller values causing the effect to start earlier. The range parameter specifies how long the fade-out effect will last. A value of 0.0 for range makes content disappear immediately without a fade-out effect. The final opacity determines content opacity at the end of the fade-out effect. A value of 1.0 for final opacity means that the cutoff is completely disabled.",
+      "doc": "An array for configuring the fade-out effect for the front cutoff of content on pitched map views. It contains three values: start, range and final opacity. The start parameter defines the point at which the fade-out effect begins, with smaller values causing the effect to start earlier. The range parameter specifies how long the fade-out effect will last. A value of 0.0 for range makes content disappear immediately without a fade-out effect. The final opacity determines content opacity at the end of the fade-out effect. A value of 1.0 for final opacity means that the cutoff is completely disabled. Note: The property has no effect on the map if terrain or globe projection is enabled.",
       "sdk-support": {
         "basic functionality": {
           "js": "3.5.0"
@@ -11506,6 +11653,24 @@
           "js": "3.17.0",
           "android": "11.10.0",
           "ios": "11.10.0"
+        }
+      }
+    },
+    "model-ignore-line-cutout": {
+      "type": "boolean",
+      "doc": "When set to true, the layer is not going to be affected by the line cutout effect.",
+      "default": false,
+      "transition": false,
+      "expression": {
+        "interpolated": false
+      },
+      "property-type": "data-constant",
+      "experimental": true,
+      "private": true,
+      "sdk-support": {
+        "basic functionality": {
+          "android": "11.21.0",
+          "ios": "11.21.0"
         }
       }
     }


### PR DESCRIPTION
Bump iOS/Android SDK references to 11.23.1 and update v8.json style spec with newly supported layer properties: `fillExtrusionCastShadows`, `iconColorContrast`, `iconColorBrightnessMin`, `iconColorBrightnessMax`, `hillshadeEmissiveStrength`, and line-progress support for `lineEmissiveStrength`.