### PR TITLE
Add minZoomLevel prop to ShapeSource

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXShapeSource.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXShapeSource.kt
@@ -34,6 +34,7 @@ class RNMBXShapeSource(context: Context, private val mManager: RNMBXShapeSourceM
     private var mClusterMaxZoom: Long? = null
     private var mClusterProperties: HashMap<String, Any>? = null
     private var mMaxZoom: Long? = null
+    private var mMinZoom: Long? = null
     private var mBuffer: Long? = null
     private var mTolerance: Double? = null
     private var mLineMetrics: Boolean? = null
@@ -158,6 +159,10 @@ class RNMBXShapeSource(context: Context, private val mManager: RNMBXShapeSourceM
         mMaxZoom = maxZoom
     }
 
+    fun setMinZoom(minZoom: Long) {
+        mMinZoom = minZoom
+    }
+
     fun setBuffer(buffer: Long) {
         mBuffer = buffer
     }
@@ -189,6 +194,9 @@ class RNMBXShapeSource(context: Context, private val mManager: RNMBXShapeSourceM
         }
         if (mMaxZoom != null) {
             builder.maxzoom(mMaxZoom!!)
+        }
+        if (mMinZoom != null) {
+            builder.minzoom(mMinZoom!!)
         }
         if (mBuffer != null) {
             builder.buffer(mBuffer!!)

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXShapeSourceManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXShapeSourceManager.kt
@@ -154,6 +154,11 @@ class RNMBXShapeSourceManager(private val mContext: ReactApplicationContext, val
         source.setMaxZoom(maxZoom.asInt().toLong())
     }
 
+    @ReactProp(name = "minZoomLevel")
+    override fun setMinZoomLevel(source: RNMBXShapeSource, minZoom: Dynamic) {
+        source.setMinZoom(minZoom.asInt().toLong())
+    }
+
     @ReactProp(name = "buffer")
     override fun setBuffer(source: RNMBXShapeSource, buffer: Dynamic) {
         source.setBuffer(buffer.asInt().toLong())

--- a/docs/ShapeSource.md
+++ b/docs/ShapeSource.md
@@ -115,6 +115,16 @@ The default value is 18.
 
 
   
+### minZoomLevel
+
+```tsx
+number
+```
+Specifies the minimum zoom level at which to create vector tiles.
+The default value is 0.
+
+
+  
 ### buffer
 
 ```tsx

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -7680,6 +7680,13 @@
         "description": "Specifies the maximum zoom level at which to create vector tiles.\nA greater value produces greater detail at high zoom levels.\nThe default value is 18."
       },
       {
+        "name": "minZoomLevel",
+        "required": false,
+        "type": "number",
+        "default": "none",
+        "description": "Specifies the minimum zoom level at which to create vector tiles.\nThe default value is 0."
+      },
+      {
         "name": "buffer",
         "required": false,
         "type": "number",

--- a/ios/RNMBX/RNMBXShapeSource.swift
+++ b/ios/RNMBX/RNMBXShapeSource.swift
@@ -85,6 +85,7 @@ public class RNMBXShapeSource : RNMBXSource {
   @objc public var clusterProperties : [String: [Any]]?;
 
   @objc public var maxZoomLevel : NSNumber?
+  @objc public var minZoomLevel : NSNumber?
   @objc public var buffer : NSNumber?
   @objc public var tolerance : NSNumber?
   @objc public var lineMetrics : Bool = false
@@ -134,6 +135,10 @@ public class RNMBXShapeSource : RNMBXSource {
 
     if let maxZoomLevel = maxZoomLevel {
       result.maxzoom = maxZoomLevel.doubleValue
+    }
+
+    if let minZoomLevel = minZoomLevel {
+      result.minzoom = minZoomLevel.doubleValue
     }
 
     if let buffer = buffer {

--- a/ios/RNMBX/RNMBXShapeSourceComponentView.mm
+++ b/ios/RNMBX/RNMBXShapeSourceComponentView.mm
@@ -102,6 +102,7 @@ using namespace facebook::react;
   RNMBX_OPTIONAL_PROP_NSNumber(clusterMaxZoomLevel)
   RNMBX_OPTIONAL_PROP_NSDictionary(clusterProperties)
   RNMBX_OPTIONAL_PROP_NSNumber(maxZoomLevel)
+  RNMBX_OPTIONAL_PROP_NSNumber(minZoomLevel)
   RNMBX_OPTIONAL_PROP_NSNumber(buffer)
   RNMBX_OPTIONAL_PROP_NSNumber(tolerance)
   RNMBX_OPTIONAL_PROP_BOOL(lineMetrics)

--- a/src/components/ShapeSource.tsx
+++ b/src/components/ShapeSource.tsx
@@ -94,6 +94,12 @@ export type Props = {
   maxZoomLevel?: number;
 
   /**
+   * Specifies the minimum zoom level at which to create vector tiles.
+   * The default value is 0.
+   */
+  minZoomLevel?: number;
+
+  /**
    * Specifies the size of the tile buffer on each side.
    * A value of 0 produces no buffer. A value of 512 produces a buffer as wide as the tile itself.
    * Larger values produce fewer rendering artifacts near tile edges and slower performance.
@@ -312,6 +318,7 @@ export class ShapeSource extends NativeBridgeComponent(
       clusterMaxZoomLevel: this.props.clusterMaxZoomLevel,
       clusterProperties: this.props.clusterProperties,
       maxZoomLevel: this.props.maxZoomLevel,
+      minZoomLevel: this.props.minZoomLevel,
       buffer: this.props.buffer,
       tolerance: this.props.tolerance,
       lineMetrics: this.props.lineMetrics,

--- a/src/specs/RNMBXShapeSourceNativeComponent.ts
+++ b/src/specs/RNMBXShapeSourceNativeComponent.ts
@@ -21,6 +21,7 @@ export interface NativeProps extends ViewProps {
   clusterMaxZoomLevel: UnsafeMixed<Double>;
   clusterProperties: UnsafeMixed<any>;
   maxZoomLevel: UnsafeMixed<Double>;
+  minZoomLevel: UnsafeMixed<Double>;
   buffer: UnsafeMixed<Double>;
   tolerance: UnsafeMixed<Double>;
   lineMetrics: UnsafeMixed<boolean>;


### PR DESCRIPTION
Exposes GeoJsonSource.minZoom (available since SDK v11.17) as a `minZoomLevel` prop on ShapeSource, following the existing `maxZoomLevel` pattern.