### PR TITLE
Add PointAnnotationManager component with slot support

### DIFF
--- a/__tests__/interface.test.js
+++ b/__tests__/interface.test.js
@@ -9,6 +9,7 @@ describe('Public Interface', () => {
       'StyleSheet',
       'Light',
       'PointAnnotation',
+      'PointAnnotationManager',
       'MarkerView',
       'Annotation',
       'Callout',

--- a/android/src/main/java/com/rnmapbox/rnmbx/RNMBXPackage.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/RNMBXPackage.kt
@@ -11,6 +11,7 @@ import com.rnmapbox.rnmbx.components.annotation.RNMBXCalloutManager
 import com.rnmapbox.rnmbx.components.annotation.RNMBXMarkerViewContentManager
 import com.rnmapbox.rnmbx.components.annotation.RNMBXMarkerViewManager
 import com.rnmapbox.rnmbx.components.annotation.RNMBXPointAnnotationManager
+import com.rnmapbox.rnmbx.components.annotation.RNMBXPointAnnotationManagerViewManager
 import com.rnmapbox.rnmbx.components.annotation.RNMBXPointAnnotationModule
 import com.rnmapbox.rnmbx.components.camera.RNMBXCameraManager
 import com.rnmapbox.rnmbx.components.camera.RNMBXCameraModule
@@ -135,6 +136,7 @@ class RNMBXPackage : TurboReactPackage() {
         managers.add(RNMBXMarkerViewManager(reactApplicationContext))
         managers.add(RNMBXMarkerViewContentManager(reactApplicationContext))
         managers.add(RNMBXPointAnnotationManager(reactApplicationContext, getViewTagResolver(reactApplicationContext, "RNMBXPointAnnotationManager")))
+        managers.add(RNMBXPointAnnotationManagerViewManager(reactApplicationContext))
         managers.add(RNMBXCalloutManager())
         managers.add(RNMBXNativeUserLocationManager())
         managers.add(RNMBXCustomLocationProviderManager())

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXPointAnnotationManagerView.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXPointAnnotationManagerView.kt
@@ -14,13 +14,17 @@ class RNMBXPointAnnotationManagerView(context: Context) : AbstractMapFeature(con
 
     private fun applySlot() {
         withMapView { mapView ->
-            slot?.let { mapView.pointAnnotations?.manager?.slot = it }
-                ?: run { mapView.pointAnnotations?.manager?.slot = null }
+            mapView.pointAnnotations?.manager?.slot = slot
         }
     }
 
     override fun addToMap(mapView: RNMBXMapView) {
         super.addToMap(mapView)
         applySlot()
+    }
+
+    override fun removeFromMap(mapView: RNMBXMapView, reason: RemovalReason): Boolean {
+        mapView.pointAnnotations?.manager?.slot = null
+        return super.removeFromMap(mapView, reason)
     }
 }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXPointAnnotationManagerView.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXPointAnnotationManagerView.kt
@@ -1,0 +1,26 @@
+package com.rnmapbox.rnmbx.components.annotation
+
+import android.content.Context
+import com.rnmapbox.rnmbx.components.AbstractMapFeature
+import com.rnmapbox.rnmbx.components.RemovalReason
+import com.rnmapbox.rnmbx.components.mapview.RNMBXMapView
+
+class RNMBXPointAnnotationManagerView(context: Context) : AbstractMapFeature(context) {
+    var slot: String? = null
+        set(value) {
+            field = value
+            applySlot()
+        }
+
+    private fun applySlot() {
+        withMapView { mapView ->
+            slot?.let { mapView.pointAnnotations?.manager?.slot = it }
+                ?: run { mapView.pointAnnotations?.manager?.slot = null }
+        }
+    }
+
+    override fun addToMap(mapView: RNMBXMapView) {
+        super.addToMap(mapView)
+        applySlot()
+    }
+}

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXPointAnnotationManagerViewManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXPointAnnotationManagerViewManager.kt
@@ -1,5 +1,6 @@
 package com.rnmapbox.rnmbx.components.annotation
 
+import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.ThemedReactContext
@@ -27,7 +28,7 @@ class RNMBXPointAnnotationManagerViewManager(context: ReactApplicationContext) :
     }
 
     @ReactProp(name = "slot")
-    override fun setSlot(view: RNMBXPointAnnotationManagerView, value: String?) {
-        view.slot = value
+    override fun setSlot(view: RNMBXPointAnnotationManagerView, value: Dynamic) {
+        view.slot = if (value.isNull) null else value.asString()
     }
 }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXPointAnnotationManagerViewManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXPointAnnotationManagerViewManager.kt
@@ -1,0 +1,33 @@
+package com.rnmapbox.rnmbx.components.annotation
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.common.MapBuilder
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.annotations.ReactProp
+import com.facebook.react.viewmanagers.RNMBXPointAnnotationManagerManagerInterface
+import com.rnmapbox.rnmbx.components.AbstractEventEmitter
+
+class RNMBXPointAnnotationManagerViewManager(context: ReactApplicationContext) :
+    AbstractEventEmitter<RNMBXPointAnnotationManagerView>(context),
+    RNMBXPointAnnotationManagerManagerInterface<RNMBXPointAnnotationManagerView> {
+    override fun customEvents(): Map<String, String>? {
+        return MapBuilder.builder<String, String>().build()
+    }
+
+    override fun getName(): String {
+        return REACT_CLASS
+    }
+
+    override fun createViewInstance(context: ThemedReactContext): RNMBXPointAnnotationManagerView {
+        return RNMBXPointAnnotationManagerView(context)
+    }
+
+    companion object {
+        const val REACT_CLASS = "RNMBXPointAnnotationManager"
+    }
+
+    @ReactProp(name = "slot")
+    override fun setSlot(view: RNMBXPointAnnotationManagerView, value: String?) {
+        view.slot = value
+    }
+}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -6537,7 +6537,7 @@
       {
         "name": "slot",
         "required": false,
-        "type": "'bottom' \\| 'middle' \\| 'top' \\| (string & {})",
+        "type": "Slot \\| (string & {})",
         "default": "none",
         "description": "The slot in the style layer stack to position the annotation layer.\nUse with Mapbox Standard style to control layer ordering."
       },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -6529,6 +6529,30 @@
     "relPath": "src/components/PointAnnotation.tsx",
     "name": "PointAnnotation"
   },
+  "PointAnnotationManager": {
+    "description": "Configures the shared PointAnnotation manager for the parent MapView.\nWrap PointAnnotation components as children.",
+    "displayName": "PointAnnotationManager",
+    "methods": [],
+    "props": [
+      {
+        "name": "slot",
+        "required": false,
+        "type": "'bottom' \\| 'middle' \\| 'top' \\| (string & {})",
+        "default": "none",
+        "description": "The slot in the style layer stack to position the annotation layer.\nUse with Mapbox Standard style to control layer ordering."
+      },
+      {
+        "name": "children",
+        "required": false,
+        "type": "ReactNode",
+        "default": "none",
+        "description": "FIX ME NO DESCRIPTION"
+      }
+    ],
+    "fileNameWithExt": "PointAnnotationManager.tsx",
+    "relPath": "src/components/PointAnnotationManager.tsx",
+    "name": "PointAnnotationManager"
+  },
   "Rain": {
     "description": "",
     "displayName": "Rain",

--- a/docs/examples.json
+++ b/docs/examples.json
@@ -674,6 +674,20 @@
       },
       {
         "metadata": {
+          "title": "PointAnnotationManager Slot",
+          "tags": [
+            "PointAnnotationManager",
+            "PointAnnotation",
+            "slot"
+          ],
+          "docs": "\nDemonstrates using PointAnnotationManager to position annotations\nin different slots of the Mapbox Standard style.\n  "
+        },
+        "fullPath": "example/src/examples/Annotations/PointAnnotationManagerSlot.tsx",
+        "relPath": "Annotations/PointAnnotationManagerSlot.tsx",
+        "name": "PointAnnotationManagerSlot"
+      },
+      {
+        "metadata": {
           "title": "Show Point Annotations",
           "tags": [
             "PointAnnotation",

--- a/example/src/examples/Annotations/MarkerViewDisappear.tsx
+++ b/example/src/examples/Annotations/MarkerViewDisappear.tsx
@@ -1,0 +1,89 @@
+import { Camera, MapView, MarkerView } from '@rnmapbox/maps';
+import { useEffect, useState } from 'react';
+import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+
+const POSITIONS = Object.fromEntries([
+  ['id1', [-1.202582, 43.36005] as [number, number]],
+  ['id2', [-1.303701, 43.384357] as [number, number]],
+]);
+
+type Rider = {
+  id: string;
+  name: string;
+  order: number;
+};
+
+const RIDERS: Rider[] = [
+  { id: 'id2', name: 'Favorite Rider', order: 100 },
+  { id: 'id1', name: 'Normal Rider', order: 10 },
+];
+
+export const Test = () => {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [positions, setPositions] = useState<Record<string, [number, number]>>({});
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setPositions(POSITIONS);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const labels = RIDERS.map(rider => ({
+    ...rider,
+    order: rider.id === selectedId ? 10000 : rider.order,
+    selected: rider.id === selectedId,
+  })).sort((a, b) => a.order - b.order);
+
+  return (
+    <View style={StyleSheet.absoluteFill}>
+      <MapView
+        style={{ flex: 1 }}
+        onPress={() => {
+          if (Platform.OS !== 'web') setSelectedId(null);
+        }}>
+        <Camera centerCoordinate={[-1.21, 43.38]} zoomLevel={10} />
+
+        {labels.map(label => {
+          const position = positions[label.id];
+          if (!position) return null;
+
+          return (
+            <MarkerView
+              key={label.id}
+              id={label.id}
+              coordinate={position}
+              anchor={{ x: 0, y: 1 }}
+              allowOverlap={false}
+              isSelected={label.selected}>
+              <Pressable onPress={() => setSelectedId(label.id)}>
+                <View
+                  style={{
+                    borderRadius: 16,
+                    borderWidth: 2,
+                    borderColor: label.selected ? '#fff' : '#4CAF50',
+                    backgroundColor: label.selected ? '#fff' : '#4CAF50',
+                  }}
+                  collapsable={false}>
+                  <Text style={{ fontSize: 16, color: label.selected ? '#4CAF50' : '#fff' }}>
+                    {label.name}
+                  </Text>
+                </View>
+              </Pressable>
+            </MarkerView>
+          );
+        })}
+      </MapView>
+    </View>
+  );
+};
+
+export default Test;
+
+/** @type ExampleWithMetadata['metadata'] */
+const metadata = {
+  title: 'MarkerView Disappear (Issue 4206)',
+  tags: ['MarkerView', 'bug', 'isSelected'],
+  docs: 'Exact reproducer from issue #4206: MarkerViews disappear on Android when width/height is 0 during addViewAnnotation.',
+};
+Test.metadata = metadata;

--- a/example/src/examples/Annotations/PointAnnotationManagerSlot.tsx
+++ b/example/src/examples/Annotations/PointAnnotationManagerSlot.tsx
@@ -8,7 +8,7 @@ import {
 } from '@rnmapbox/maps';
 import { Button } from '@rneui/base';
 
-import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
+import type { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
 
 const styles = StyleSheet.create({
   map: { flex: 1 },

--- a/example/src/examples/Annotations/PointAnnotationManagerSlot.tsx
+++ b/example/src/examples/Annotations/PointAnnotationManagerSlot.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import {
+  Camera,
+  MapView,
+  PointAnnotation,
+  PointAnnotationManager,
+} from '@rnmapbox/maps';
+import { Button } from '@rneui/base';
+
+import { ExampleWithMetadata } from '../common/ExampleMetadata'; // exclude-from-doc
+
+const styles = StyleSheet.create({
+  map: { flex: 1 },
+  pin: {
+    width: 30,
+    height: 30,
+    borderRadius: 15,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  label: { color: 'white', fontWeight: 'bold', fontSize: 12 },
+  buttons: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    padding: 8,
+    gap: 8,
+  },
+});
+
+const COORDS: [number, number][] = [
+  [-74.00597, 40.71427],
+  [-74.0065, 40.7128],
+  [-74.0045, 40.7155],
+];
+
+const PointAnnotationManagerSlot = () => {
+  const [slot, setSlot] = useState<string>('middle');
+
+  return (
+    <>
+      <MapView style={styles.map} styleURL="mapbox://styles/mapbox/standard">
+        <Camera
+          defaultSettings={{
+            centerCoordinate: [-74.00597, 40.71427],
+            zoomLevel: 15,
+            pitch: 45,
+          }}
+        />
+        <PointAnnotationManager slot={slot}>
+          {COORDS.map((coord, i) => (
+            <PointAnnotation key={`pin-${i}`} id={`pin-${i}`} coordinate={coord}>
+              <View style={[styles.pin, { backgroundColor: 'dodgerblue' }]}>
+                <Text style={styles.label}>{i + 1}</Text>
+              </View>
+            </PointAnnotation>
+          ))}
+        </PointAnnotationManager>
+      </MapView>
+      <View style={styles.buttons}>
+        <Button
+          title="bottom"
+          onPress={() => setSlot('bottom')}
+          color={slot === 'bottom' ? 'primary' : 'grey'}
+        />
+        <Button
+          title="middle"
+          onPress={() => setSlot('middle')}
+          color={slot === 'middle' ? 'primary' : 'grey'}
+        />
+        <Button
+          title="top"
+          onPress={() => setSlot('top')}
+          color={slot === 'top' ? 'primary' : 'grey'}
+        />
+      </View>
+    </>
+  );
+};
+
+export default PointAnnotationManagerSlot;
+
+const metadata: ExampleWithMetadata['metadata'] = {
+  title: 'PointAnnotationManager Slot',
+  tags: ['PointAnnotationManager', 'PointAnnotation', 'slot'],
+  docs: `
+Demonstrates using PointAnnotationManager to position annotations
+in different slots of the Mapbox Standard style.
+  `,
+};
+PointAnnotationManagerSlot.metadata = metadata;

--- a/example/src/examples/Annotations/index.js
+++ b/example/src/examples/Annotations/index.js
@@ -2,6 +2,7 @@ export { default as CustomCallout } from './CustomCallout';
 export { default as Heatmap } from './Heatmap';
 export { default as MarkerView } from './MarkerView';
 export { default as PointAnnotationAnchors } from './PointAnnotationAnchors';
+export { default as PointAnnotationManagerSlot } from './PointAnnotationManagerSlot';
 export { default as ShowPointAnnotation } from './ShowPointAnnotation';
 
 export const metadata = {

--- a/ios/RNMBX/RNMBXPointAnnotationManagerComponentView.h
+++ b/ios/RNMBX/RNMBXPointAnnotationManagerComponentView.h
@@ -1,0 +1,15 @@
+#ifdef __cplusplus
+
+#import <UIKit/UIKit.h>
+
+#import <React/RCTUIManager.h>
+#import <React/RCTViewComponentView.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RNMBXPointAnnotationManagerComponentView : RCTViewComponentView
+
+@end
+
+NS_ASSUME_NONNULL_END
+#endif // __cplusplus

--- a/ios/RNMBX/RNMBXPointAnnotationManagerComponentView.mm
+++ b/ios/RNMBX/RNMBXPointAnnotationManagerComponentView.mm
@@ -1,6 +1,7 @@
 
 #import "RNMBXPointAnnotationManagerComponentView.h"
 #import "RNMBXFabricHelpers.h"
+#import "RNMBXFabricPropConvert.h"
 
 #import <React/RCTConversions.h>
 #import <React/RCTFabricComponentsPlugins.h>
@@ -51,7 +52,8 @@ using namespace facebook::react;
 
 - (void)updateProps:(const Props::Shared &)props
            oldProps:(const Props::Shared &)oldProps {
-  const auto &newProps = static_cast<const RNMBXPointAnnotationManagerProps &>(*props);
+  const auto &oldViewProps = static_cast<const RNMBXPointAnnotationManagerProps &>(*_props);
+  const auto &newViewProps = static_cast<const RNMBXPointAnnotationManagerProps &>(*props);
 
   RNMBX_OPTIONAL_PROP_NSString(slot)
 

--- a/ios/RNMBX/RNMBXPointAnnotationManagerComponentView.mm
+++ b/ios/RNMBX/RNMBXPointAnnotationManagerComponentView.mm
@@ -1,0 +1,70 @@
+
+#import "RNMBXPointAnnotationManagerComponentView.h"
+#import "RNMBXFabricHelpers.h"
+
+#import <React/RCTConversions.h>
+#import <React/RCTFabricComponentsPlugins.h>
+
+#import <react/renderer/components/rnmapbox_maps_specs/ComponentDescriptors.h>
+#import <react/renderer/components/rnmapbox_maps_specs/EventEmitters.h>
+#import <react/renderer/components/rnmapbox_maps_specs/Props.h>
+#import <react/renderer/components/rnmapbox_maps_specs/RCTComponentViewHelpers.h>
+
+#import "rnmapbox_maps-Swift.pre.h"
+
+using namespace facebook::react;
+
+@interface RNMBXPointAnnotationManagerComponentView () <RCTRNMBXPointAnnotationManagerViewProtocol>
+@end
+
+@implementation RNMBXPointAnnotationManagerComponentView {
+  RNMBXPointAnnotationManagerView *_view;
+}
+
+// Needed because of this: https://github.com/facebook/react-native/pull/37274
++ (void)load {
+  [super load];
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  if (self = [super initWithFrame:frame]) {
+    static const auto defaultProps =
+        std::make_shared<const RNMBXPointAnnotationManagerProps>();
+    _props = defaultProps;
+    [self prepareView];
+  }
+
+  return self;
+}
+
+- (void)prepareView {
+  _view = [[RNMBXPointAnnotationManagerView alloc] init];
+  self.contentView = _view;
+}
+
+#pragma mark - RCTComponentViewProtocol
+
++ (ComponentDescriptorProvider)componentDescriptorProvider {
+  return concreteComponentDescriptorProvider<
+      RNMBXPointAnnotationManagerComponentDescriptor>();
+}
+
+- (void)updateProps:(const Props::Shared &)props
+           oldProps:(const Props::Shared &)oldProps {
+  const auto &newProps = static_cast<const RNMBXPointAnnotationManagerProps &>(*props);
+
+  RNMBX_OPTIONAL_PROP_NSString(slot)
+
+  [super updateProps:props oldProps:oldProps];
+}
+
+- (void)prepareForRecycle {
+  [super prepareForRecycle];
+  [self prepareView];
+}
+
+@end
+
+Class<RCTComponentViewProtocol> RNMBXPointAnnotationManagerCls(void) {
+  return RNMBXPointAnnotationManagerComponentView.class;
+}

--- a/ios/RNMBX/RNMBXPointAnnotationManagerComponentView.swift
+++ b/ios/RNMBX/RNMBXPointAnnotationManagerComponentView.swift
@@ -10,12 +10,15 @@ open class RNMBXPointAnnotationManagerView: RNMBXMapComponentBase {
 
   private func applySlot() {
     withRNMBXMapView { map in
+      let oldSlot = map.pointAnnotationManager.manager.slot
       map.pointAnnotationManager.manager.slot = self.slot
+      print("[RNMBXPointAnnotationManager] slot changed: \(oldSlot ?? "nil") -> \(self.slot ?? "nil")")
     }
   }
 
   public override func addToMap(_ map: RNMBXMapView, style: Style) {
     super.addToMap(map, style: style)
+    print("[RNMBXPointAnnotationManager] addToMap, slot=\(self.slot ?? "nil")")
     applySlot()
   }
 }

--- a/ios/RNMBX/RNMBXPointAnnotationManagerComponentView.swift
+++ b/ios/RNMBX/RNMBXPointAnnotationManagerComponentView.swift
@@ -10,15 +10,12 @@ open class RNMBXPointAnnotationManagerView: RNMBXMapComponentBase {
 
   private func applySlot() {
     withRNMBXMapView { map in
-      let oldSlot = map.pointAnnotationManager.manager.slot
       map.pointAnnotationManager.manager.slot = self.slot
-      print("[RNMBXPointAnnotationManager] slot changed: \(oldSlot ?? "nil") -> \(self.slot ?? "nil")")
     }
   }
 
   public override func addToMap(_ map: RNMBXMapView, style: Style) {
     super.addToMap(map, style: style)
-    print("[RNMBXPointAnnotationManager] addToMap, slot=\(self.slot ?? "nil")")
     applySlot()
   }
 }

--- a/ios/RNMBX/RNMBXPointAnnotationManagerComponentView.swift
+++ b/ios/RNMBX/RNMBXPointAnnotationManagerComponentView.swift
@@ -19,7 +19,7 @@ open class RNMBXPointAnnotationManagerView: RNMBXMapComponentBase {
     applySlot()
   }
 
-  public override func removeFromMap(_ map: RNMBXMapView, reason: RNMBXMapComponentBase.RemovalReason) -> Bool {
+  public override func removeFromMap(_ map: RNMBXMapView, reason: RemovalReason) -> Bool {
     map.pointAnnotationManager.manager.slot = nil
     return super.removeFromMap(map, reason: reason)
   }

--- a/ios/RNMBX/RNMBXPointAnnotationManagerComponentView.swift
+++ b/ios/RNMBX/RNMBXPointAnnotationManagerComponentView.swift
@@ -18,4 +18,9 @@ open class RNMBXPointAnnotationManagerView: RNMBXMapComponentBase {
     super.addToMap(map, style: style)
     applySlot()
   }
+
+  public override func removeFromMap(_ map: RNMBXMapView, reason: RNMBXMapComponentBase.RemovalReason) -> Bool {
+    map.pointAnnotationManager.manager.slot = nil
+    return super.removeFromMap(map, reason: reason)
+  }
 }

--- a/ios/RNMBX/RNMBXPointAnnotationManagerComponentView.swift
+++ b/ios/RNMBX/RNMBXPointAnnotationManagerComponentView.swift
@@ -1,0 +1,25 @@
+import MapboxMaps
+
+@objc(RNMBXPointAnnotationManagerView)
+open class RNMBXPointAnnotationManagerView: RNMBXMapComponentBase {
+  @objc public var slot: String? = nil {
+    didSet {
+      applySlot()
+    }
+  }
+
+  private func applySlot() {
+    withRNMBXMapView { map in
+      if let slot = self.slot {
+        map.pointAnnotationManager.manager.slot = Slot(rawValue: slot)
+      } else {
+        map.pointAnnotationManager.manager.slot = nil
+      }
+    }
+  }
+
+  public override func addToMap(_ map: RNMBXMapView, style: Style) {
+    super.addToMap(map, style: style)
+    applySlot()
+  }
+}

--- a/ios/RNMBX/RNMBXPointAnnotationManagerComponentView.swift
+++ b/ios/RNMBX/RNMBXPointAnnotationManagerComponentView.swift
@@ -10,11 +10,7 @@ open class RNMBXPointAnnotationManagerView: RNMBXMapComponentBase {
 
   private func applySlot() {
     withRNMBXMapView { map in
-      if let slot = self.slot {
-        map.pointAnnotationManager.manager.slot = Slot(rawValue: slot)
-      } else {
-        map.pointAnnotationManager.manager.slot = nil
-      }
+      map.pointAnnotationManager.manager.slot = self.slot
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -259,6 +259,9 @@
         "RNMBXNativeUserLocation": {
           "className": "RNMBXNativeUserLocationComponentView"
         },
+        "RNMBXPointAnnotationManager": {
+          "className": "RNMBXPointAnnotationManagerComponentView"
+        },
         "RNMBXPointAnnotation": {
           "className": "RNMBXPointAnnotationComponentView"
         },
@@ -328,6 +331,7 @@
         "RNMBXModelLayer": "RNMBXModelLayerComponentView",
         "RNMBXModels": "RNMBXModelsComponentView",
         "RNMBXNativeUserLocation": "RNMBXNativeUserLocationComponentView",
+        "RNMBXPointAnnotationManager": "RNMBXPointAnnotationManagerComponentView",
         "RNMBXPointAnnotation": "RNMBXPointAnnotationComponentView",
         "RNMBXRain": "RNMBXRainComponentView",
         "RNMBXRasterArraySource": "RNMBXRasterArraySourceComponentView",

--- a/src/Mapbox.native.ts
+++ b/src/Mapbox.native.ts
@@ -18,6 +18,7 @@ export {
 } from './components/MapView';
 export { default as Light } from './components/Light';
 export { default as PointAnnotation } from './components/PointAnnotation';
+export { default as PointAnnotationManager } from './components/PointAnnotationManager';
 export { default as Annotation } from './components/Annotation';
 export { default as Callout } from './components/Callout';
 export { default as StyleImport } from './components/StyleImport';

--- a/src/components/PointAnnotationManager.tsx
+++ b/src/components/PointAnnotationManager.tsx
@@ -20,9 +20,10 @@ type Props = {
  */
 const PointAnnotationManager = (props: Props) => {
   return (
-    <NativePointAnnotationManager slot={props.slot as Slot | undefined}>
+    <>
+      <NativePointAnnotationManager slot={props.slot as Slot | undefined} />
       {props.children}
-    </NativePointAnnotationManager>
+    </>
   );
 };
 

--- a/src/components/PointAnnotationManager.tsx
+++ b/src/components/PointAnnotationManager.tsx
@@ -1,0 +1,29 @@
+import { type ReactNode } from 'react';
+
+import NativePointAnnotationManager from '../specs/RNMBXPointAnnotationManagerNativeComponent';
+
+type Slot = 'bottom' | 'middle' | 'top';
+
+type Props = {
+  /**
+   * The slot in the style layer stack to position the annotation layer.
+   * Use with Mapbox Standard style to control layer ordering.
+   */
+  slot?: Slot | (string & {});
+
+  children?: ReactNode;
+};
+
+/**
+ * Configures the shared PointAnnotation manager for the parent MapView.
+ * Wrap PointAnnotation components as children.
+ */
+const PointAnnotationManager = (props: Props) => {
+  return (
+    <NativePointAnnotationManager slot={props.slot as Slot | undefined}>
+      {props.children}
+    </NativePointAnnotationManager>
+  );
+};
+
+export default PointAnnotationManager;

--- a/src/specs/RNMBXPointAnnotationManagerNativeComponent.ts
+++ b/src/specs/RNMBXPointAnnotationManagerNativeComponent.ts
@@ -1,0 +1,18 @@
+import type { HostComponent, ViewProps } from 'react-native';
+import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+
+import type { UnsafeMixed } from './codegenUtils';
+
+// see https://github.com/rnmapbox/maps/wiki/FabricOptionalProp
+type OptionalProp<T> = UnsafeMixed<T>;
+
+type Slot = 'bottom' | 'middle' | 'top';
+
+export interface NativeProps extends ViewProps {
+  slot?: OptionalProp<Slot>;
+}
+
+// @ts-ignore-error - Codegen requires single cast but TypeScript prefers double cast
+export default codegenNativeComponent<NativeProps>(
+  'RNMBXPointAnnotationManager',
+) as HostComponent<NativeProps>;


### PR DESCRIPTION
New `PointAnnotationManager` component that configures the shared point annotation manager. Supports `slot` prop for positioning annotations in the Standard style layer stack.

Usage:
```tsx
<MapView styleURL="mapbox://styles/mapbox/standard">
  <PointAnnotationManager slot="middle">
    <PointAnnotation coordinate={[lng, lat]} id="pin1">
      ...
    </PointAnnotation>
  </PointAnnotationManager>
</MapView>
```