### PR TITLE
Fix layout issue where MarkerViews disappear

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerView.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerView.kt
@@ -119,7 +119,13 @@ class RNMBXMarkerView(context: Context?, private val mManager: RNMBXMarkerViewMa
             mMapView?.offscreenAnnotationViewContainer?.addView(view)
             mMapView?.offscreenAnnotationViewContainer?.removeView(view)
         }
-
+        
+        if (view.width == 0 || view.height == 0) {
+            // Fixes https://github.com/rnmapbox/maps/issues/4206
+            // Wait for the next layout via onLayoutChange
+            return
+        }
+        
         val options = getOptions()
 
         val content = view as? RNMBXMarkerViewContent;


### PR DESCRIPTION
When `width = 0` and `height = 0`,  sometimes `View` has no dimension yet. Wait for the next layout before `addViewAnnotation`

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes #4206

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [x] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)
