### PR TITLE
fix: correct OfflineProgressStatus TypeScript type and TileRegionPackState typo

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/modules/RNMBXOfflineModule.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/modules/RNMBXOfflineModule.kt
@@ -43,7 +43,7 @@ enum class TileRegionPackState(val rawValue: String) {
     INACTIVE("inactive"),
     ACTIVE("active"),
     COMPLETE("complete"),
-    UNKNOWN("unkown")
+    UNKNOWN("unknown")
 }
 class TileRegionPack(var name: String, var state: TileRegionPackState = TileRegionPackState.UNKNOWN, var progress: TileRegionLoadProgress? = null, var metadata: JSONObject) {
     var cancelable: Cancelable? = null

--- a/src/RNMBXModule.ts
+++ b/src/RNMBXModule.ts
@@ -10,10 +10,10 @@ interface RNMBXModule {
     SatelliteStreet: URL;
   };
   OfflinePackDownloadState: {
-    Inactive: string | number;
-    Active: string | number;
-    Complete: string | number;
-    Unknown?: string | number;
+    Inactive: string;
+    Active: string;
+    Complete: string;
+    Unknown?: string;
   };
   LineJoin: {
     Bevel: string | number;

--- a/src/modules/offline/offlineManager.ts
+++ b/src/modules/offline/offlineManager.ts
@@ -22,16 +22,23 @@ export const OfflineModuleEventEmitter = new NativeEventEmitter(
   MapboxOfflineManager,
 );
 
-export type OfflineProgressStatus = {
-  name: string;
-  state: number;
-  percentage: number;
-  completedResourceSize: number;
-  completedTileCount: number;
-  completedResourceCount: number;
-  requiredResourceCount: number;
-  completedTileSize: number;
-};
+export type OfflineProgressStatus =
+  | {
+      name: string;
+      state: 'invalid' | 'inactive' | 'active' | 'complete' | 'unknown';
+      percentage: number;
+      completedResourceCount: number;
+      completedResourceSize: number;
+      erroredResourceCount: number;
+      loadedResourceSize: number;
+      loadedResourceCount: number;
+      requiredResourceCount: number;
+    }
+  | {
+      name: string;
+      state: 'invalid' | 'inactive' | 'active' | 'complete' | 'unknown';
+      percentage: null;
+    };
 
 export type OfflinePackError = {
   name: string;


### PR DESCRIPTION
## Description

Corrects the `OfflineProgressStatus` TypeScript type, which had several inaccuracies compared to what the native modules (Android/iOS) actually emit:

- `state` was typed as `number` but is always a string, so it was changed to a strict union: `'invalid' | 'inactive' | 'active' | 'complete' | 'unknown'`
- Removed phantom fields `completedTileCount` and `completedTileSize` that were never emitted by native code
- Added missing fields that native always emits: `erroredResourceCount`, `loadedResourceSize`, `loadedResourceCount`
- Converted to a discriminated union on `percentage` to accurately model the two distinct payload shapes: one with full progress data and one emitted when a pack exists but has not yet started loading (percentage is `null` and resource counts are absent)
- Narrowed `OfflinePackDownloadState` values in `RNMBXModule.ts` from `string | number` to `string`, consistent with what native actually sends
- Fixed a typo in `TileRegionPackState.UNKNOWN` on Android: `"unkown"` to `"unknown"`

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [x] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

N/A type-only changes with one runtime string correction on Android.

## Component to reproduce the issue you're fixing

  ```jsx
// state was typed as number but native always emits a string
offlineManager.subscribe(pack, (pack, status) => {
    console.log(typeof status.state); // was typed as number, actually "active" | "complete" | etc.
    console.log(status.completedTileCount); // phantom field was always undefined at runtime
});
```
