### PR TITLE
fix(android): use getReactTag() for react-native >= 0.87 compatibility

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapViewManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapViewManager.kt
@@ -433,7 +433,7 @@ open class RNMBXMapViewManager(context: ReactApplicationContext, val viewTagReso
          * onDropViewInstance.
          */
         private fun diposeNativeMapView() {
-            val mapView = mViewManager.getByReactTag(reactTag)
+            val mapView = mViewManager.getByReactTag(getReactTag())
             if (mapView != null) {
                 UiThreadUtil.runOnUiThread {
                     try {


### PR DESCRIPTION
## Description

Use the explicit `getReactTag()` accessor instead of the `reactTag` Kotlin synthetic property in `MapShadowNode`, which breaks compilation on React Native >= 0.87. Backward compatible with earlier RN versions.

Mirrors the equivalent fix in maplibre-react-native: https://github.com/maplibre/maplibre-react-native/pull/1583

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
