### PR TITLE
fix(android): implement getDelegate() on ViewManagers missing it

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewContentManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewContentManager.kt
@@ -2,13 +2,19 @@ package com.rnmapbox.rnmbx.components.annotation
 
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXMarkerViewContentManagerDelegate
 import com.facebook.react.viewmanagers.RNMBXMarkerViewContentManagerInterface
 import com.rnmapbox.rnmbx.components.AbstractEventEmitter
 
 
 class RNMBXMarkerViewContentManager(reactApplicationContext: ReactApplicationContext) :
     AbstractEventEmitter<RNMBXMarkerViewContent>(reactApplicationContext),
-    RNMBXMarkerViewContentManagerInterface<RNMBXMarkerView> {
+    RNMBXMarkerViewContentManagerInterface<RNMBXMarkerViewContent> {
+
+    private val delegate = RNMBXMarkerViewContentManagerDelegate<RNMBXMarkerViewContent, RNMBXMarkerViewContentManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXMarkerViewContent> = delegate
 
     override fun getName(): String {
         return REACT_CLASS

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXCameraManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXCameraManager.kt
@@ -15,11 +15,17 @@ import com.rnmapbox.rnmbx.utils.extensions.asDoubleOrNull
 import com.rnmapbox.rnmbx.utils.extensions.asStringOrNull
 import com.rnmapbox.rnmbx.rncompat.dynamic.*
 import com.rnmapbox.rnmbx.utils.Logger
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXCameraManagerDelegate
 
 class RNMBXCameraManager(private val mContext: ReactApplicationContext, val viewTagResolver: ViewTagResolver) :
     AbstractEventEmitter<RNMBXCamera>(
         mContext
     ), RNMBXCameraManagerInterface<RNMBXCamera> {
+
+    private val delegate = RNMBXCameraManagerDelegate<RNMBXCamera, RNMBXCameraManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXCamera> = delegate
     override fun customEvents(): Map<String, String>? {
         return HashMap()
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXVIewportManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/camera/RNMBXVIewportManager.kt
@@ -13,10 +13,16 @@ import com.rnmapbox.rnmbx.components.AbstractEventEmitter
 import com.rnmapbox.rnmbx.events.constants.EventKeys
 import com.rnmapbox.rnmbx.events.constants.eventMapOf
 import com.rnmapbox.rnmbx.utils.ViewTagResolver
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXViewportManagerDelegate
 
 class RNMBXViewportManager(private val mContext: ReactApplicationContext, val viewTagResolver: ViewTagResolver) : AbstractEventEmitter<RNMBXViewport>(
         mContext
     ), RNMBXViewportManagerInterface<RNMBXViewport> {
+
+    private val delegate = RNMBXViewportManagerDelegate<RNMBXViewport, RNMBXViewportManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXViewport> = delegate
 
     override fun getName(): String {
         return REACT_CLASS

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/images/RNMBXImageManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/images/RNMBXImageManager.kt
@@ -9,10 +9,16 @@ import com.facebook.react.viewmanagers.RNMBXImageManagerInterface
 import com.rnmapbox.rnmbx.components.AbstractEventEmitter
 import com.rnmapbox.rnmbx.components.styles.sources.RNMBXShapeSource
 import com.rnmapbox.rnmbx.utils.ViewTagResolver
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXImageManagerDelegate
 
 class RNMBXImageManager(private val mContext: ReactApplicationContext, val viewTagResolver: ViewTagResolver) : AbstractEventEmitter<RNMBXImage>(
 mContext
 ), RNMBXImageManagerInterface<RNMBXImage> {
+
+    private val delegate = RNMBXImageManagerDelegate<RNMBXImage, RNMBXImageManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXImage> = delegate
     override fun getName(): String {
         return "RNMBXImage"
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/images/RNMBXImagesManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/images/RNMBXImagesManager.kt
@@ -20,11 +20,17 @@ import com.rnmapbox.rnmbx.utils.ResourceUtils
 import com.rnmapbox.rnmbx.utils.extensions.forEach
 import com.rnmapbox.rnmbx.utils.extensions.getIfDouble
 import java.util.*
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXImagesManagerDelegate
 
 class RNMBXImagesManager(private val mContext: ReactApplicationContext) :
     AbstractEventEmitter<RNMBXImages>(
         mContext
     ), RNMBXImagesManagerInterface<RNMBXImages> {
+
+    private val delegate = RNMBXImagesManagerDelegate<RNMBXImages, RNMBXImagesManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXImages> = delegate
     override fun getName(): String {
         return "RNMBXImages"
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/location/RNMBXCustomLocationProviderManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/location/RNMBXCustomLocationProviderManager.kt
@@ -8,10 +8,16 @@ import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNMBXCustomLocationProviderManagerInterface
 import com.rnmapbox.rnmbx.rncompat.dynamic.*
 import com.rnmapbox.rnmbx.utils.Logger
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXCustomLocationProviderManagerDelegate
 
 
 class RNMBXCustomLocationProviderManager : ViewGroupManager<RNMBXCustomLocationProvider>(),
     RNMBXCustomLocationProviderManagerInterface<RNMBXCustomLocationProvider> {
+
+    private val delegate = RNMBXCustomLocationProviderManagerDelegate<RNMBXCustomLocationProvider, RNMBXCustomLocationProviderManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXCustomLocationProvider> = delegate
     override fun getName(): String {
         return  REACT_CLASS
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/location/RNMBXNativeUserLocationManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/location/RNMBXNativeUserLocationManager.kt
@@ -20,9 +20,15 @@ import com.rnmapbox.rnmbx.utils.extensions.toJsonArray
 import java.io.StringWriter
 import javax.annotation.Nonnull
 import com.rnmapbox.rnmbx.v11compat.location.*
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXNativeUserLocationManagerDelegate
 
 class RNMBXNativeUserLocationManager : ViewGroupManager<RNMBXNativeUserLocation>(),
     RNMBXNativeUserLocationManagerInterface<RNMBXNativeUserLocation> {
+
+    private val delegate = RNMBXNativeUserLocationManagerDelegate<RNMBXNativeUserLocation, RNMBXNativeUserLocationManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXNativeUserLocation> = delegate
     @Nonnull
     override fun getName(): String {
         return REACT_CLASS

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/RNMBXStyleImportManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/RNMBXStyleImportManager.kt
@@ -15,10 +15,16 @@ import com.rnmapbox.rnmbx.rncompat.dynamic.*
 import com.rnmapbox.rnmbx.utils.Logger
 import com.rnmapbox.rnmbx.utils.extensions.toValueHashMap
 import org.json.JSONObject
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXStyleImportManagerDelegate
 
 class RNMBXStyleImportManager(context: ReactApplicationContext) :
     AbstractEventEmitter<RNMBXStyleImport>(context),
     RNMBXStyleImportManagerInterface<RNMBXStyleImport> {
+
+    private val delegate = RNMBXStyleImportManagerDelegate<RNMBXStyleImport, RNMBXStyleImportManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXStyleImport> = delegate
     override fun customEvents(): Map<String, String>? {
         return MapBuilder.builder<String, String>().build()
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXBackgroundLayerManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXBackgroundLayerManager.kt
@@ -5,9 +5,15 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNMBXBackgroundLayerManagerInterface
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXBackgroundLayerManagerDelegate
 
 class RNMBXBackgroundLayerManager : ViewGroupManager<RNMBXBackgroundLayer>(),
     RNMBXBackgroundLayerManagerInterface<RNMBXBackgroundLayer> {
+
+    private val delegate = RNMBXBackgroundLayerManagerDelegate<RNMBXBackgroundLayer, RNMBXBackgroundLayerManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXBackgroundLayer> = delegate
     override fun getName(): String {
         return REACT_CLASS
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXCircleLayerManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXCircleLayerManager.kt
@@ -5,9 +5,15 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNMBXCircleLayerManagerInterface
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXCircleLayerManagerDelegate
 
 class RNMBXCircleLayerManager : ViewGroupManager<RNMBXCircleLayer>(),
     RNMBXCircleLayerManagerInterface<RNMBXCircleLayer> {
+
+    private val delegate = RNMBXCircleLayerManagerDelegate<RNMBXCircleLayer, RNMBXCircleLayerManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXCircleLayer> = delegate
 
     override fun getName(): String {
         return REACT_CLASS

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXFillExtrusionLayerManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXFillExtrusionLayerManager.kt
@@ -5,9 +5,15 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNMBXFillExtrusionLayerManagerInterface
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXFillExtrusionLayerManagerDelegate
 
 class RNMBXFillExtrusionLayerManager : ViewGroupManager<RNMBXFillExtrusionLayer>(),
     RNMBXFillExtrusionLayerManagerInterface<RNMBXFillExtrusionLayer> {
+
+    private val delegate = RNMBXFillExtrusionLayerManagerDelegate<RNMBXFillExtrusionLayer, RNMBXFillExtrusionLayerManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXFillExtrusionLayer> = delegate
     override fun getName(): String {
         return REACT_CLASS
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXFillLayerManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXFillLayerManager.kt
@@ -5,9 +5,15 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNMBXFillLayerManagerInterface
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXFillLayerManagerDelegate
 
 class RNMBXFillLayerManager : ViewGroupManager<RNMBXFillLayer>(),
     RNMBXFillLayerManagerInterface<RNMBXFillLayer> {
+
+    private val delegate = RNMBXFillLayerManagerDelegate<RNMBXFillLayer, RNMBXFillLayerManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXFillLayer> = delegate
     override fun getName(): String {
         return REACT_CLASS
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXHeatmapLayerManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXHeatmapLayerManager.kt
@@ -5,9 +5,15 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNMBXHeatmapLayerManagerInterface
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXHeatmapLayerManagerDelegate
 
 class RNMBXHeatmapLayerManager : ViewGroupManager<RNMBXHeatmapLayer>(),
     RNMBXHeatmapLayerManagerInterface<RNMBXHeatmapLayer> {
+
+    private val delegate = RNMBXHeatmapLayerManagerDelegate<RNMBXHeatmapLayer, RNMBXHeatmapLayerManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXHeatmapLayer> = delegate
     override fun getName(): String {
         return REACT_CLASS
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXHillshadeLayerManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXHillshadeLayerManager.kt
@@ -5,9 +5,15 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNMBXHillshadeLayerManagerInterface
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXHillshadeLayerManagerDelegate
 
 class RNMBXHillshadeLayerManager : ViewGroupManager<RNMBXHillshadeLayer>(),
     RNMBXHillshadeLayerManagerInterface<RNMBXHillshadeLayer> {
+
+    private val delegate = RNMBXHillshadeLayerManagerDelegate<RNMBXHillshadeLayer, RNMBXHillshadeLayerManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXHillshadeLayer> = delegate
     override fun getName(): String {
         return REACT_CLASS
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXLineLayerManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXLineLayerManager.kt
@@ -5,9 +5,15 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNMBXLineLayerManagerInterface
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXLineLayerManagerDelegate
 
 class RNMBXLineLayerManager : ViewGroupManager<RNMBXLineLayer>(),
     RNMBXLineLayerManagerInterface<RNMBXLineLayer> {
+
+    private val delegate = RNMBXLineLayerManagerDelegate<RNMBXLineLayer, RNMBXLineLayerManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXLineLayer> = delegate
     override fun getName(): String {
         return REACT_CLASS
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXModelLayerManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXModelLayerManager.kt
@@ -6,10 +6,16 @@ import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNMBXModelLayerManagerInterface
 import com.rnmapbox.rnmbx.utils.Logger
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXModelLayerManagerDelegate
 
 
 class RNMBXModelLayerManager : ViewGroupManager<RNMBXModelLayer>(),
     RNMBXModelLayerManagerInterface<RNMBXModelLayer> {
+
+    private val delegate = RNMBXModelLayerManagerDelegate<RNMBXModelLayer, RNMBXModelLayerManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXModelLayer> = delegate
     override fun getName(): String {
         return REACT_CLASS
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXRasterLayerManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXRasterLayerManager.kt
@@ -5,9 +5,15 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNMBXRasterLayerManagerInterface
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXRasterLayerManagerDelegate
 
 class RNMBXRasterLayerManager : ViewGroupManager<RNMBXRasterLayer>(),
     RNMBXRasterLayerManagerInterface<RNMBXRasterLayer> {
+
+    private val delegate = RNMBXRasterLayerManagerDelegate<RNMBXRasterLayer, RNMBXRasterLayerManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXRasterLayer> = delegate
     override fun getName(): String {
         return REACT_CLASS
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXSkyLayerManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXSkyLayerManager.kt
@@ -5,9 +5,15 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNMBXSkyLayerManagerInterface
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXSkyLayerManagerDelegate
 
 class RNMBXSkyLayerManager : ViewGroupManager<RNMBXSkyLayer>(),
     RNMBXSkyLayerManagerInterface<RNMBXSkyLayer> {
+
+    private val delegate = RNMBXSkyLayerManagerDelegate<RNMBXSkyLayer, RNMBXSkyLayerManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXSkyLayer> = delegate
     override fun getName(): String {
         return REACT_CLASS
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXSymbolLayerManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/layers/RNMBXSymbolLayerManager.kt
@@ -5,9 +5,15 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNMBXSymbolLayerManagerInterface
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXSymbolLayerManagerDelegate
 
 class RNMBXSymbolLayerManager : ViewGroupManager<RNMBXSymbolLayer>(),
     RNMBXSymbolLayerManagerInterface<RNMBXSymbolLayer> {
+
+    private val delegate = RNMBXSymbolLayerManagerDelegate<RNMBXSymbolLayer, RNMBXSymbolLayerManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXSymbolLayer> = delegate
     override fun getName(): String {
         return REACT_CLASS
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/light/RNMBXLightManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/light/RNMBXLightManager.kt
@@ -6,9 +6,15 @@ import com.rnmapbox.rnmbx.utils.extensions.asMapOrNull
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNMBXLightManagerInterface
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXLightManagerDelegate
 
 class RNMBXLightManager : ViewGroupManager<RNMBXLight>(),
     RNMBXLightManagerInterface<RNMBXLight> {
+
+    private val delegate = RNMBXLightManagerDelegate<RNMBXLight, RNMBXLightManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXLight> = delegate
     override fun getName(): String {
         return REACT_CLASS
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/model/RNMBXModelsManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/model/RNMBXModelsManager.kt
@@ -11,9 +11,15 @@ import com.facebook.react.viewmanagers.RNMBXModelsManagerInterface
 import com.rnmapbox.rnmbx.components.styles.terrain.RNMBXTerrainManager
 import com.rnmapbox.rnmbx.utils.Logger
 import com.rnmapbox.rnmbx.utils.extensions.forEach
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXModelsManagerDelegate
 
 class RNMBXModelsManager(private val mContext: ReactApplicationContext) : ViewGroupManager<RNMBXModels>(),
     RNMBXModelsManagerInterface<RNMBXModels> {
+
+    private val delegate = RNMBXModelsManagerDelegate<RNMBXModels, RNMBXModelsManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXModels> = delegate
     override fun getName(): String {
         return REACT_CLASS
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXImageSourceManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXImageSourceManager.kt
@@ -7,9 +7,15 @@ import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNMBXImageSourceManagerInterface
 import com.rnmapbox.rnmbx.utils.GeoJSONUtils.toLatLngQuad
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXImageSourceManagerDelegate
 
 class RNMBXImageSourceManager : ViewGroupManager<RNMBXImageSource>(),
     RNMBXImageSourceManagerInterface<RNMBXImageSource> {
+
+    private val delegate = RNMBXImageSourceManagerDelegate<RNMBXImageSource, RNMBXImageSourceManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXImageSource> = delegate
     override fun getName(): String {
         return REACT_CLASS
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXRasterDemSourceManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXRasterDemSourceManager.kt
@@ -7,6 +7,8 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNMBXRasterDemSourceManagerInterface
 import com.rnmapbox.rnmbx.utils.Logger
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXRasterDemSourceManagerDelegate
 
 // import com.rnmapbox.rnmbx.components.annotation.RNMBXCallout;
 // import com.rnmapbox.rnmbx.utils.ResourceUtils;
@@ -14,6 +16,10 @@ class RNMBXRasterDemSourceManager(private val mContext: ReactApplicationContext)
     RNMBXTileSourceManager<RNMBXRasterDemSource>(
         mContext
     ), RNMBXRasterDemSourceManagerInterface<RNMBXRasterDemSource> {
+
+    private val delegate = RNMBXRasterDemSourceManagerDelegate<RNMBXRasterDemSource, RNMBXRasterDemSourceManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXRasterDemSource> = delegate
     override fun customEvents(): Map<String, String>? {
         return MapBuilder.builder<String, String>()
             .build()

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXRasterSourceManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXRasterSourceManager.kt
@@ -10,10 +10,16 @@ import com.rnmapbox.rnmbx.events.constants.eventMapOf
 import javax.annotation.Nonnull
 import com.facebook.react.bridge.ReadableType
 import com.rnmapbox.rnmbx.utils.Logger
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXRasterSourceManagerDelegate
 
 class RNMBXRasterSourceManager(reactApplicationContext: ReactApplicationContext) :
     RNMBXTileSourceManager<RNMBXRasterSource>(reactApplicationContext),
     RNMBXRasterSourceManagerInterface<RNMBXRasterSource> {
+
+    private val delegate = RNMBXRasterSourceManagerDelegate<RNMBXRasterSource, RNMBXRasterSourceManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXRasterSource> = delegate
     @Nonnull
     override fun getName(): String {
         return REACT_CLASS

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXShapeSourceManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXShapeSourceManager.kt
@@ -20,12 +20,18 @@ import java.net.MalformedURLException
 import java.net.URL
 import java.util.ArrayList
 import java.util.HashMap
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXShapeSourceManagerDelegate
 
 
 class RNMBXShapeSourceManager(private val mContext: ReactApplicationContext, val viewTagResolver: ViewTagResolver, val shapeAnimatorManager: ShapeAnimatorManager) :
     AbstractEventEmitter<RNMBXShapeSource>(
         mContext
     ), RNMBXShapeSourceManagerInterface<RNMBXShapeSource> {
+
+    private val delegate = RNMBXShapeSourceManagerDelegate<RNMBXShapeSource, RNMBXShapeSourceManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXShapeSource> = delegate
     override fun getName(): String {
         return REACT_CLASS
     }

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXVectorSourceManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/sources/RNMBXVectorSourceManager.kt
@@ -10,10 +10,16 @@ import com.rnmapbox.rnmbx.events.constants.EventKeys
 import com.rnmapbox.rnmbx.events.constants.eventMapOf
 import com.rnmapbox.rnmbx.utils.Logger
 import javax.annotation.Nonnull
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXVectorSourceManagerDelegate
 
 class RNMBXVectorSourceManager(reactApplicationContext: ReactApplicationContext) :
     RNMBXTileSourceManager<RNMBXVectorSource>(reactApplicationContext),
     RNMBXVectorSourceManagerInterface<RNMBXVectorSource> {
+
+    private val delegate = RNMBXVectorSourceManagerDelegate<RNMBXVectorSource, RNMBXVectorSourceManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXVectorSource> = delegate
     @Nonnull
     override fun getName(): String {
         return REACT_CLASS

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/styles/terrain/RNMBXTerrainManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/styles/terrain/RNMBXTerrainManager.kt
@@ -6,9 +6,15 @@ import com.rnmapbox.rnmbx.utils.extensions.asMapOrNull
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNMBXTerrainManagerInterface
+import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.viewmanagers.RNMBXTerrainManagerDelegate
 
 class RNMBXTerrainManager : ViewGroupManager<RNMBXTerrain>(),
     RNMBXTerrainManagerInterface<RNMBXTerrain> {
+
+    private val delegate = RNMBXTerrainManagerDelegate<RNMBXTerrain, RNMBXTerrainManager>(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXTerrain> = delegate
     override fun getName(): String {
         return REACT_CLASS
     }


### PR DESCRIPTION
Fixes #4194.

27 ViewManagers implement the codegen-generated `*ManagerInterface` but didn't override `getDelegate()` to return the corresponding `*ManagerDelegate`. Since RN 0.79 ([facebook/react-native#49414](https://github.com/facebook/react-native/pull/49414)), this logs a `ReactNoCrashSoftException` on every component mount and falls back to reflection-based property setting via `ViewManagerPropertyUpdater`.

The fix is pure boilerplate — each manager gets a delegate field and a `getDelegate()` override, exactly like the managers that already had it (`RNMBXMapViewManager`, `RNMBXCameraGestureObserverManager`, etc.).

Also fixes a pre-existing type error in `RNMBXMarkerViewContentManager`: it implemented `...Interface<RNMBXMarkerView>` but its view type is `RNMBXMarkerViewContent`. The interface has no props so `T` is never used in any method — zero runtime effect, but the mismatch prevented wiring up the delegate.

**Verified on Android 14 emulator / RN 0.84:**
- Before: `E ViewManager: ReactNoCrashSoftException: ViewManager using codegen must override getDelegate method (name: RNMBXCamera/RNMBXShapeSource/RNMBXCircleLayer/...)` on every mount
- After: no SoftExceptions

Whether this is the root cause of the freeze reported in #4194 on Android 16 is unconfirmed — the SoftExceptions are real and worth fixing regardless.