### PR TITLE
fix(PointAnnotation): fix nested children not rendering on New Architecture (Fabric)

### DIFF
--- a/example/src/examples/Annotations/PointAnnotationAnchors.js
+++ b/example/src/examples/Annotations/PointAnnotationAnchors.js
@@ -81,7 +81,7 @@ const PointAnnotationAnchors = (props) => {
           coordinate={p.coordinate}
           anchor={p.anchor}
         >
-          <View style={styles.small} collapsable={false}>
+          <View style={styles.small}>
             <Text style={[styles.text, { color: 'white' }]}>
               x={p.anchor.x.toPrecision(2)}, y={p.anchor.y.toPrecision(2)}
             </Text>
@@ -103,7 +103,7 @@ const PointAnnotationAnchors = (props) => {
             coordinate={p.coordinate}
             anchor={p.anchor}
           >
-            <View style={[styles.large, p.containerStyle]} collapsable={false}>
+            <View style={[styles.large, p.containerStyle]}>
               <View
                 style={{
                   height: ANNOTATION_SIZE * 2,

--- a/src/components/PointAnnotation.tsx
+++ b/src/components/PointAnnotation.tsx
@@ -236,15 +236,11 @@ class PointAnnotation extends NativeBridgeComponent(
       onMapboxPointAnnotationDragEnd: this._onDragEnd,
       coordinate: this._getCoordinate(),
     };
-    const childArray = React.Children.toArray(this.props.children);
-    const calloutIndex = childArray.findIndex(
-      (child) => React.isValidElement(child) && child.type === Callout,
+    const children = React.Children.toArray(this.props.children);
+    const callout = children.find(
+      (c) => React.isValidElement(c) && c.type === Callout,
     );
-    const callout = calloutIndex !== -1 ? childArray[calloutIndex] : null;
-    const content =
-      calloutIndex !== -1
-        ? childArray.filter((_, i) => i !== calloutIndex)
-        : childArray;
+    const content = children.filter((c) => c !== callout);
 
     return (
       // @ts-expect-error just codegen stuff

--- a/src/components/PointAnnotation.tsx
+++ b/src/components/PointAnnotation.tsx
@@ -1,5 +1,5 @@
 import React, { type SyntheticEvent, type Component } from 'react';
-import { StyleSheet, type ViewProps } from 'react-native';
+import { StyleSheet, View, type ViewProps } from 'react-native';
 import {
   type Feature,
   type GeoJsonProperties,
@@ -16,6 +16,7 @@ import RNMBXPointAnnotationNativeComponent from '../specs/RNMBXPointAnnotationNa
 import NativeRNMBXPointAnnotationModule from '../specs/NativeRNMBXPointAnnotationModule';
 
 import NativeBridgeComponent, { type RNMBEvent } from './NativeBridgeComponent';
+import Callout from './Callout';
 
 export const NATIVE_MODULE_NAME = 'RNMBXPointAnnotation';
 
@@ -235,10 +236,21 @@ class PointAnnotation extends NativeBridgeComponent(
       onMapboxPointAnnotationDragEnd: this._onDragEnd,
       coordinate: this._getCoordinate(),
     };
+    const childArray = React.Children.toArray(this.props.children);
+    const calloutIndex = childArray.findIndex(
+      (child) => React.isValidElement(child) && child.type === Callout,
+    );
+    const callout = calloutIndex !== -1 ? childArray[calloutIndex] : null;
+    const content =
+      calloutIndex !== -1
+        ? childArray.filter((_, i) => i !== calloutIndex)
+        : childArray;
+
     return (
       // @ts-expect-error just codegen stuff
       <RNMBXPointAnnotationNativeComponent {...props}>
-        {this.props.children}
+        <View collapsable={false}>{content}</View>
+        {callout}
       </RNMBXPointAnnotationNativeComponent>
     );
   }


### PR DESCRIPTION
Fixes #3682

In React Native's New Architecture (Fabric), a View inside PointAnnotation can get its children lifted up to become direct siblings in the native child list. This triggers the "supports max 1 subview other than a callout" error and causes the bitmap snapshot to only capture the empty outer View — nested content (e.g. Text labels) disappears.

**Root cause:** Fabric's view flattening optimization removes collapsable Views from the native hierarchy and reparents their children to the nearest non-flattened ancestor — in this case, PointAnnotation itself.

**Fix:** Wrap content children in a `View collapsable={false}` inside `PointAnnotation.tsx`. The native layer always sees exactly one content child regardless of how deeply the user nests views. Callout children are kept as direct native siblings (the native side identifies them by type).

Also removes the manual `collapsable={false}` workaround that was added to the `PointAnnotationAnchors` example — the library now handles this internally.

<details>
<summary>Reproducer (before fix)</summary>

```jsx
<Mapbox.PointAnnotation id="test" coordinate={[0, 0]}>
  <View style={{ backgroundColor: 'blue', width: 50, height: 50 }}>
    <Text>label</Text>
  </View>
</Mapbox.PointAnnotation>
```

On RN 0.76+ with New Architecture: only the blue box renders, Text is missing, and the console logs `PointAnnotation supports max 1 subview other than a callout`.
</details>