### PR TITLE
fix(MarkerView): forward pointerEvents prop to native view

### DIFF
--- a/.github/workflows/ios-actions.yml
+++ b/.github/workflows/ios-actions.yml
@@ -109,6 +109,7 @@ jobs:
       - name: Install Detox Dependencies
         run: |
           brew tap wix/brew
+          brew trust wix/brew
           brew install applesimutils
           brew install xcbeautify
 

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerView.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerView.kt
@@ -11,6 +11,7 @@ import com.mapbox.geojson.Point
 import com.mapbox.maps.ViewAnnotationAnchor
 import com.mapbox.maps.ViewAnnotationOptions
 import com.mapbox.maps.viewannotation.viewAnnotationOptions
+import com.facebook.react.uimanager.PointerEvents
 import com.rnmapbox.rnmbx.components.AbstractMapFeature
 import com.rnmapbox.rnmbx.components.RemovalReason
 import com.rnmapbox.rnmbx.components.mapview.RNMBXMapView
@@ -33,6 +34,7 @@ class RNMBXMarkerView(context: Context?, private val mManager: RNMBXMarkerViewMa
     private var mAllowOverlap = false
     private var mAllowOverlapWithPuck = false
     private var mIsSelected = false
+    private var mPointerEvents: PointerEvents = PointerEvents.AUTO
 
     fun setCoordinate(point: Point?) {
         mCoordinate = point
@@ -63,8 +65,15 @@ class RNMBXMarkerView(context: Context?, private val mManager: RNMBXMarkerViewMa
 
     // region View methods
 
+    override fun setPointerEvents(pointerEvents: PointerEvents) {
+        super.setPointerEvents(pointerEvents)
+        mPointerEvents = pointerEvents
+        (mView as? RNMBXMarkerViewContent)?.setExternalPointerEvents(pointerEvents)
+    }
+
     override fun addView(childView: View, childPosition: Int) {
         mView = childView
+        (mView as? RNMBXMarkerViewContent)?.setExternalPointerEvents(mPointerEvents)
         // Note: Do not call this method on `super`. The view is added manually.
     }
 

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerView.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerView.kt
@@ -65,15 +65,14 @@ class RNMBXMarkerView(context: Context?, private val mManager: RNMBXMarkerViewMa
 
     // region View methods
 
-    override fun setPointerEvents(pointerEvents: PointerEvents) {
-        super.setPointerEvents(pointerEvents)
+    fun setContentPointerEvents(pointerEvents: PointerEvents) {
         mPointerEvents = pointerEvents
         (mView as? RNMBXMarkerViewContent)?.setExternalPointerEvents(pointerEvents)
     }
 
     override fun addView(childView: View, childPosition: Int) {
         mView = childView
-        (mView as? RNMBXMarkerViewContent)?.setExternalPointerEvents(mPointerEvents)
+        (childView as? RNMBXMarkerViewContent)?.setExternalPointerEvents(mPointerEvents)
         // Note: Do not call this method on `super`. The view is added manually.
     }
 

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewContent.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewContent.kt
@@ -6,12 +6,18 @@ import android.view.View.MeasureSpec
 import android.view.ViewGroup
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactContext
+import com.facebook.react.uimanager.PointerEvents
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.views.view.ReactViewGroup
 import com.rnmapbox.rnmbx.components.camera.BaseEvent
 
 class RNMBXMarkerViewContent(context: Context): ReactViewGroup(context) {
     var inAdd: Boolean = false
+    private var externalPointerEvents: PointerEvents = PointerEvents.AUTO
+
+    fun setExternalPointerEvents(pointerEvents: PointerEvents) {
+        externalPointerEvents = pointerEvents
+    }
 
     // Track last reported translation to avoid feedback loop:
     // Mapbox sets setTranslationX(512) → we fire event → JS sets transform:[{translateX:512}]
@@ -29,6 +35,9 @@ class RNMBXMarkerViewContent(context: Context): ReactViewGroup(context) {
     }
 
     override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+        if (externalPointerEvents == PointerEvents.NONE) {
+            return false
+        }
         // On ACTION_DOWN, tell the parent MapView not to intercept subsequent MOVE/UP
         // events for pan/zoom recognition — that would send CANCEL to child Pressables
         // and suppress onPress. Android resets the disallow flag on each new DOWN, so

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewManager.kt
@@ -8,8 +8,11 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.rnmapbox.rnmbx.components.AbstractEventEmitter
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.common.MapBuilder
+import com.facebook.react.uimanager.PointerEvents
+import com.facebook.react.uimanager.ReactStylesDiffMap
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewManagerDelegate
+import com.facebook.react.uimanager.ViewProps
 import com.facebook.react.viewmanagers.RNMBXMarkerViewManagerDelegate
 import com.facebook.react.viewmanagers.RNMBXMarkerViewManagerInterface
 import com.mapbox.maps.ScreenCoordinate
@@ -70,6 +73,17 @@ class RNMBXMarkerViewManager(reactApplicationContext: ReactApplicationContext) :
     @ReactProp(name = "isSelected")
     override fun setIsSelected(markerView: RNMBXMarkerView, isSelected: Dynamic) {
         markerView.setIsSelected(isSelected.asBoolean())
+    }
+
+    override fun updateProperties(viewToUpdate: RNMBXMarkerView, props: ReactStylesDiffMap) {
+        super.updateProperties(viewToUpdate, props)
+        // The codegen delegate does not forward the standard `pointerEvents` ViewProp — it falls
+        // to BaseViewManagerDelegate which ignores it. Intercept it here so the marker content
+        // view (which lives in a separate Mapbox view hierarchy) can honour it.
+        if (props.hasKey(ViewProps.POINTER_EVENTS)) {
+            val pe = PointerEvents.parsePointerEvents(props.getString(ViewProps.POINTER_EVENTS))
+            viewToUpdate.setContentPointerEvents(pe)
+        }
     }
 
     override fun createViewInstance(reactContext: ThemedReactContext): RNMBXMarkerView {

--- a/docs/examples.json
+++ b/docs/examples.json
@@ -652,9 +652,10 @@
             "PointAnnotation",
             "MarkerView",
             "Slider",
-            "Interactive"
+            "Interactive",
+            "pointerEvents"
           ],
-          "docs": "\nShows marker view and point annotations, including an interactive marker with\nsliders, switch, counter, text input, and pressable button to verify complex\ntouch interactions inside a MarkerView.\n"
+          "docs": "\nShows marker view and point annotations, including an interactive marker with\nsliders, switch, counter, text input, and pressable button to verify complex\ntouch interactions inside a MarkerView. Toggle pointerEvents=\"none\" to make\nthe marker transparent to all touch events, passing them through to the map.\n"
         },
         "fullPath": "example/src/examples/Annotations/MarkerView.tsx",
         "relPath": "Annotations/MarkerView.tsx",

--- a/example/src/examples/Annotations/MarkerView.tsx
+++ b/example/src/examples/Annotations/MarkerView.tsx
@@ -274,11 +274,19 @@ const ShowMarkerView = () => {
     React.useState<GeoJSON.Position[]>(INITIAL_COORDINATES);
   const [allowOverlapWithPuck, setAllowOverlapWithPuck] =
     React.useState<boolean>(false);
+  const [pointerEventsNone, setPointerEventsNone] =
+    React.useState<boolean>(false);
+
+  const [mapMoveCount, setMapMoveCount] = React.useState(0);
 
   const onPressMap = (e: GeoJSON.Feature) => {
     const geometry = e.geometry as GeoJSON.Point;
     setPointList((pl) => [...pl, geometry.coordinates]);
   };
+
+  const onRegionDidChange = React.useCallback(() => {
+    setMapMoveCount((c) => c + 1);
+  }, []);
 
   return (
     <>
@@ -290,7 +298,15 @@ const ShowMarkerView = () => {
         }
         onPress={() => setAllowOverlapWithPuck((prev) => !prev)}
       />
-      <Mapbox.MapView onPress={onPressMap} style={styles.matchParent}>
+      <Button
+        title={
+          pointerEventsNone
+            ? 'pointerEvents="none" – tap/drag passes to map'
+            : 'pointerEvents="auto" – marker handles touches'
+        }
+        onPress={() => setPointerEventsNone((prev) => !prev)}
+      />
+      <Mapbox.MapView onPress={onPressMap} onRegionDidChange={onRegionDidChange} style={styles.matchParent}>
         <Mapbox.Camera
           defaultSettings={{
             zoomLevel: 16,
@@ -305,6 +321,7 @@ const ShowMarkerView = () => {
         <Mapbox.MarkerView
           coordinate={pointList[0]!}
           allowOverlapWithPuck={allowOverlapWithPuck}
+          pointerEvents={pointerEventsNone ? 'none' : 'auto'}
         >
           <AnnotationContent title={'this is a marker view'} />
         </Mapbox.MarkerView>
@@ -331,6 +348,7 @@ const ShowMarkerView = () => {
       </Mapbox.MapView>
 
       <Bubble>
+        <Text>Map moved: {mapMoveCount} times</Text>
         <Text>Tap on map to add a point annotation</Text>
       </Bubble>
     </>
@@ -344,11 +362,12 @@ export default ShowMarkerView;
 /** @type ExampleWithMetadata['metadata'] */
 const metadata = {
   title: 'Marker View',
-  tags: ['PointAnnotation', 'MarkerView', 'Slider', 'Interactive'],
+  tags: ['PointAnnotation', 'MarkerView', 'Slider', 'Interactive', 'pointerEvents'],
   docs: `
 Shows marker view and point annotations, including an interactive marker with
 sliders, switch, counter, text input, and pressable button to verify complex
-touch interactions inside a MarkerView.
+touch interactions inside a MarkerView. Toggle pointerEvents="none" to make
+the marker transparent to all touch events, passing them through to the map.
 `,
 };
 ShowMarkerView.metadata = metadata;

--- a/src/components/MarkerView.tsx
+++ b/src/components/MarkerView.tsx
@@ -72,6 +72,7 @@ const MarkerView = ({
   isSelected = false,
   coordinate,
   style,
+  pointerEvents,
   children,
 }: Props) => {
   // Android new-arch (Fabric) fix: UIManager.measure reads from the Fabric shadow
@@ -98,9 +99,14 @@ const MarkerView = ({
   // we don't trigger a re-render for no-op native position re-applications.
   const lastTranslateRef = useRef<{ x: number; y: number } | null>(null);
 
-  const handleTouchEnd = useCallback((e: { stopPropagation: () => void }) => {
-    e.stopPropagation();
-  }, []);
+  const handleTouchEnd = useCallback(
+    (e: { stopPropagation: () => void }) => {
+      if (pointerEvents !== 'none' && pointerEvents !== 'box-none') {
+        e.stopPropagation();
+      }
+    },
+    [pointerEvents],
+  );
 
   const handleAnnotationPosition = useCallback(
     (e: NativeSyntheticEvent<{ x: number; y: number }>) => {
@@ -150,6 +156,7 @@ const MarkerView = ({
       allowOverlap={allowOverlap}
       allowOverlapWithPuck={allowOverlapWithPuck}
       isSelected={isSelected}
+      pointerEvents={pointerEvents}
       onTouchEnd={handleTouchEnd}
     >
       <RNMBXMakerViewContentComponent


### PR DESCRIPTION
Fixes #4219.

`MarkerView` accepted `pointerEvents` via `ViewProps` but never forwarded it to native, so `pointerEvents="none"` had no effect — the marker kept intercepting touches regardless.

**iOS:** Destructure `pointerEvents` from props and pass it to the native `RNMBXMarkerView`. Skip `stopPropagation` in `onTouchEnd` when `pointerEvents` is `"none"` or `"box-none"` for consistent JS event handling.

**Android:** `RNMBXMarkerViewContent` is added directly to Mapbox's `ViewAnnotationManager` (outside RN's view hierarchy), so Fabric's normal `pointerEvents` propagation doesn't reach it. Override `setPointerEvents` in `RNMBXMarkerView` to propagate the value, and in `RNMBXMarkerViewContent.dispatchTouchEvent` return `false` early when `pointerEvents=NONE` (also skipping the `requestDisallowInterceptTouchEvent` call that would otherwise keep the map from receiving touches).

Also updates the Marker View example to add a toggle for `pointerEvents` so the behavior can be verified interactively.

<details>
<summary>Repro</summary>

```tsx
// Before: pointerEvents="none" silently ignored — marker blocks all map touches
<Mapbox.MarkerView coordinate={coord} pointerEvents="none">
  <MyView />
</Mapbox.MarkerView>
```

With this fix, `pointerEvents="none"` makes the marker transparent to all touch events, passing them through to the map below.
</details>