### PR TITLE
fix(ci): handle concurrent update-docs runs

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -61,13 +61,26 @@ jobs:
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git stash --include-untracked
-          git pull --rebase origin main
-          git stash pop || true
-          git log -1
           git add .
+          git log -1
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
           git commit -m "Update docs from maps  rnmapbox/maps@${GITHUB_SHA::7}"
-          git push origin main
+          PUSHED=false
+          for i in 1 2 3; do
+            if git pull --rebase -X ours origin main && git push origin main; then
+              PUSHED=true
+              break
+            fi
+            echo "Attempt $i failed, retrying in $((i * 10))s..."
+            sleep $((i * 10))
+          done
+          if [ "$PUSHED" != "true" ]; then
+            echo "All push attempts failed"
+            exit 1
+          fi
         working-directory: maps-docs
         env:
           GITHUB_SHA: ${{ github.sha }}


### PR DESCRIPTION
When two pushes to `main` trigger `update-docs` concurrently, the second run's `git stash pop` fails: the first run already pushed the same binary files (PNGs) to `maps-docs`, so git can't restore untracked files from the stash on top of them. `|| true` hid the error but left the repo in a broken state, causing the commit to find nothing to commit → exit 1.

Fix: drop the stash entirely. Instead, commit the generated files first, then `git pull --rebase -X ours origin main` (which replays our commit on top of the latest remote, taking our freshly generated version for any binary conflicts), then push. A 3-attempt retry loop handles the residual race where another run pushes between our pull and push.

<details>
<summary>Reproducer</summary>

Two pushes to `main` in quick succession (e.g. a merge + version bump) each spend ~3min generating docs, then race to push to `maps-docs`. Example failing run: https://github.com/rnmapbox/maps/actions/runs/28312708283/job/83880193652

</details>