### PR TITLE
chore: remove redundant comments from MarkerView zero-dimension guard

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerView.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerView.kt
@@ -129,8 +129,6 @@ class RNMBXMarkerView(context: Context?, private val mManager: RNMBXMarkerViewMa
         }
         
         if (view.width == 0 || view.height == 0) {
-            // Fixes https://github.com/rnmapbox/maps/issues/4206
-            // Wait for the next layout via onLayoutChange
             return
         }
         


### PR DESCRIPTION
Follow-up to #4212. Removes two inline comments from the zero-dimension early-return guard: the issue link belongs in the PR/commit, and the second comment just narrates what the surrounding code already shows.