### PR TITLE
fix: replace {at}link JSDoc that breaks MDX doc generator

### DIFF
--- a/docs/StyleImport.md
+++ b/docs/StyleImport.md
@@ -68,7 +68,7 @@ type Config = {
 _required_
 config is a dictionary of configuration options for the style import.
 
-When using the Mapbox Standard style with `id="basemap"`, use {@link StandardStyleConfig}
+When using the Mapbox Standard style with `id="basemap"`, use `StandardStyleConfig`
 keys for autocomplete. Arbitrary keys are also accepted for forward compatibility.
 
 See https://github.com/mapbox/mapbox-maps-ios/blob/main/Sources/MapboxMaps/Documentation.docc/Migrate%20to%20v11.md#21-the-mapbox-standard-style

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -8352,7 +8352,7 @@
           ]
         },
         "default": "none",
-        "description": "config is a dictionary of configuration options for the style import.\n\nWhen using the Mapbox Standard style with `id=\"basemap\"`, use {@link StandardStyleConfig}\nkeys for autocomplete. Arbitrary keys are also accepted for forward compatibility.\n\nSee https://github.com/mapbox/mapbox-maps-ios/blob/main/Sources/MapboxMaps/Documentation.docc/Migrate%20to%20v11.md#21-the-mapbox-standard-style"
+        "description": "config is a dictionary of configuration options for the style import.\n\nWhen using the Mapbox Standard style with `id=\"basemap\"`, use `StandardStyleConfig`\nkeys for autocomplete. Arbitrary keys are also accepted for forward compatibility.\n\nSee https://github.com/mapbox/mapbox-maps-ios/blob/main/Sources/MapboxMaps/Documentation.docc/Migrate%20to%20v11.md#21-the-mapbox-standard-style"
       }
     ],
     "fileNameWithExt": "StyleImport.tsx",

--- a/src/components/StyleImport.tsx
+++ b/src/components/StyleImport.tsx
@@ -77,7 +77,7 @@ type Props = {
   /**
    * config is a dictionary of configuration options for the style import.
    *
-   * When using the Mapbox Standard style with `id="basemap"`, use {@link StandardStyleConfig}
+   * When using the Mapbox Standard style with `id="basemap"`, use `StandardStyleConfig`
    * keys for autocomplete. Arbitrary keys are also accepted for forward compatibility.
    *
    * See https://github.com/mapbox/mapbox-maps-ios/blob/main/Sources/MapboxMaps/Documentation.docc/Migrate%20to%20v11.md#21-the-mapbox-standard-style


### PR DESCRIPTION
PR #4210 added `{@link StandardStyleConfig}` in a JSDoc comment in `StyleImport.tsx`. The doc generator parses comments as MDX, and acorn chokes on `@` inside `{}` (treats it as a JSX expression). Replaced with a backtick reference.