### PR TITLE
fix(ios): support static frameworks under Expo SDK 57 precompiled pipeline

### DIFF
--- a/ios/RNMBX/rnmapbox_maps-Swift.pre.h
+++ b/ios/RNMBX/rnmapbox_maps-Swift.pre.h
@@ -6,7 +6,7 @@
 @interface MapView : UIView
 @end
 
-#if RNMBX_USE_FRAMEWORKS
+#if __has_include(<rnmapbox_maps/rnmapbox_maps-Swift.h>)
 #import <rnmapbox_maps/rnmapbox_maps-Swift.h>
 #else
 #import <rnmapbox_maps-Swift.h>

--- a/rnmapbox-maps.podspec
+++ b/rnmapbox-maps.podspec
@@ -199,7 +199,19 @@ end
 
 $rnMapboxMapsTargetsToChangeToDynamic = rnMapboxMapsTargetsToChangeToDynamic
 
+def $RNMapboxMaps._expo_precompiled_pipeline?
+  # Expo SDK 56+ precompiled iOS pipeline (prebuilt React core) downgrades every
+  # framework-style pod back to a static library after the podspec is evaluated.
+  # Flipping the Mapbox pods to dynamic here fights that and leaves an inconsistent
+  # graph (MapboxMaps stays dynamic while its deps get forced static). See #4242.
+  ENV['EXPO_USE_PRECOMPILED_MODULES'] == '1'
+end
+
 def $RNMapboxMaps.pre_install(installer)
+  if $RNMapboxMaps._expo_precompiled_pipeline?
+    Pod::UI.puts "[RNMapbox] Expo precompiled modules pipeline detected (EXPO_USE_PRECOMPILED_MODULES=1) — skipping the Mapbox dynamic-framework flip so all Mapbox pods stay consistently static."
+    return
+  end
   installer.aggregate_targets.each do |target|
     target.pod_targets.select { |p| $rnMapboxMapsTargetsToChangeToDynamic.include?(p.name) }.each do |mobile_events_target|
       mobile_events_target.instance_variable_set(:@build_type,Pod::BuildType.dynamic_framework)
@@ -285,9 +297,6 @@ Pod::Spec.new do |s|
         if $RNMapobxMaps._rn_72_or_earlier()
           $RNMapboxMaps._add_compiler_flags(sp, "-DRNMBX_RN_72=1")
         end
-      end
-      if ENV['USE_FRAMEWORKS'] || $RNMapboxMapsUseFrameworks
-        $RNMapboxMaps._add_compiler_flags(sp, "-DRNMBX_USE_FRAMEWORKS=1")
       end
     else
       fail "$RNMapboxMapsImpl should be mapbox but was: $RNMapboxMapsImpl"


### PR DESCRIPTION
## Description

Fixes #4242

On Expo SDK 56+'s precompiled iOS pipeline with `useFrameworks: static`, the library failed to build two ways: `pod install` hit `verify_no_static_framework_transitive_dependencies` (our `pre_install` flips the Mapbox pods to dynamic, but Expo forces most back to static — leaving `MapboxMaps` dynamic with static deps), and compilation hit `'rnmapbox_maps/rnmapbox_maps-Swift.h' file not found` (the `RNMBX_USE_FRAMEWORKS` macro took the framework import path while the pod was actually built static).

Fix: resolve the Swift header with `__has_include` so it follows the pod's real build type (same pattern as `RNMBXFollyConvert.h`; the unused `RNMBX_USE_FRAMEWORKS` flag is removed), and skip the Mapbox dynamic-framework flip when Expo's precompiled pipeline is active (`EXPO_USE_PRECOMPILED_MODULES=1`). Non-Expo builds are unaffected.

Verified on a fresh Expo SDK 57 / RN 0.86 app with `useFrameworks: static` (Xcode 26.6): clean `pod install` and a successful `rnmapbox-maps` compile.

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` <!-- N/A: native podspec + Obj-C header only -->
- [x] Tested on a fresh Expo SDK 57 app (New Architecture / ios)

## Component to reproduce the issue you're fixing

<details>
<summary>Fresh Expo SDK 57 repro (config + component)</summary>

`app.json` (Expo's precompiled pipeline is on by default in SDK 56+):

```json
{
  "expo": {
    "plugins": [
      ["@rnmapbox/maps", { "RNMapboxMapsVersion": "11.20.3" }],
      ["expo-build-properties", { "ios": { "useFrameworks": "static" } }]
    ]
  }
}
```

`App.js`:

```jsx
import Mapbox from '@rnmapbox/maps';
import { StyleSheet } from 'react-native';

const App = () => (
  <Mapbox.MapView style={styles.map}>
    <Mapbox.Camera centerCoordinate={[15.97, 45.81]} zoomLevel={14} />
  </Mapbox.MapView>
);

const styles = StyleSheet.create({ map: { flex: 1 } });

export default App;
```

```bash
npx expo prebuild --clean -p ios
cd ios && pod install   # fails on unpatched build
```

</details>