### PR TITLE
fix(PointAnnotationManager): override getDelegate on Android view manager

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXPointAnnotationManagerView.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXPointAnnotationManagerView.kt
@@ -125,12 +125,16 @@ class RNMBXPointAnnotationManagerView(context: Context) : AbstractMapFeature(con
     private fun applyProps() {
         val manager = coordinator?.manager ?: return
         manager.slot = slot
-        manager.iconAllowOverlap = iconAllowOverlap
-        manager.iconIgnorePlacement = iconIgnorePlacement
-        manager.iconOptional = iconOptional
-        manager.textAllowOverlap = textAllowOverlap
-        manager.textIgnorePlacement = textIgnorePlacement
-        manager.textOptional = textOptional
+        // Only write when the prop is set. The annotation plugin defaults
+        // iconAllowOverlap/iconIgnorePlacement to true so annotations always show;
+        // writing null here would clobber that back to the style default (false) and
+        // cull colliding pins.
+        iconAllowOverlap?.let { manager.iconAllowOverlap = it }
+        iconIgnorePlacement?.let { manager.iconIgnorePlacement = it }
+        iconOptional?.let { manager.iconOptional = it }
+        textAllowOverlap?.let { manager.textAllowOverlap = it }
+        textIgnorePlacement?.let { manager.textIgnorePlacement = it }
+        textOptional?.let { manager.textOptional = it }
     }
 
     companion object {

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXPointAnnotationManagerViewManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXPointAnnotationManagerViewManager.kt
@@ -6,13 +6,22 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableType
 import com.facebook.react.common.MapBuilder
 import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.annotations.ReactProp
+import com.facebook.react.viewmanagers.RNMBXPointAnnotationManagerManagerDelegate
 import com.facebook.react.viewmanagers.RNMBXPointAnnotationManagerManagerInterface
 import com.rnmapbox.rnmbx.components.AbstractEventEmitter
 
 class RNMBXPointAnnotationManagerViewManager(context: ReactApplicationContext) :
     AbstractEventEmitter<RNMBXPointAnnotationManagerView>(context),
     RNMBXPointAnnotationManagerManagerInterface<RNMBXPointAnnotationManagerView> {
+    private val mDelegate: ViewManagerDelegate<RNMBXPointAnnotationManagerView> =
+        RNMBXPointAnnotationManagerManagerDelegate(this)
+
+    override fun getDelegate(): ViewManagerDelegate<RNMBXPointAnnotationManagerView> {
+        return mDelegate
+    }
+
     override fun customEvents(): Map<String, String>? {
         return MapBuilder.builder<String, String>().build()
     }


### PR DESCRIPTION
## Description

Fixes an Android regression introduced by #4240. The new `RNMBXPointAnnotationManagerViewManager` never overrode `getDelegate()`, so under Fabric its props (`slot`, `iconAllowOverlap`, `textAllowOverlap`, …) were never applied and React Native logged a soft exception:

```
ReactNoCrashSoftException: ViewManager using codegen must override getDelegate method (name: RNMBXPointAnnotationManager).
```

As a result, `PointAnnotationManager`s rendered blank on Android — the `PointAnnotationManager Multiple` example showed no pins. This adds the codegen delegate, matching the other view managers (`RNMBXCalloutManager`, `RNMBXMarkerViewManager`). iOS was unaffected (props are applied via `updateProps` in the component view).

Verified on an emulator (New Architecture): with the fix the soft exception is gone and the `top`-slot pins render in front of the Standard style's 3D buildings while the `bottom`-slot pins are occluded behind them, matching iOS.

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder <!-- n/a: no generated code changes -->
- [x] I have tested the new feature on `/example` app.
  - [x] In New Architecture mode/ios
  - [x] In New Architecture mode/android
- [x] I added/updated a sample - if a new feature was implemented (`/example`) <!-- existing `PointAnnotationManager Multiple` example reproduces it -->

## Component to reproduce the issue you're fixing

<details>
<summary>Two managers in different slots — renders blank on Android without this fix</summary>

```tsx
<MapView styleURL="mapbox://styles/mapbox/standard">
  <Camera defaultSettings={{ centerCoordinate: [-74.0115, 40.711], zoomLevel: 15.7, pitch: 62 }} />
  <PointAnnotationManager slot="bottom" iconAllowOverlap>
    <PointAnnotation id="b" coordinate={[-74.0145, 40.7085]}>
      <View style={{ width: 26, height: 26, borderRadius: 13, backgroundColor: 'crimson' }} />
    </PointAnnotation>
  </PointAnnotationManager>
  <PointAnnotationManager slot="top" iconAllowOverlap>
    <PointAnnotation id="t" coordinate={[-74.014, 40.7085]}>
      <View style={{ width: 26, height: 26, borderRadius: 13, backgroundColor: 'royalblue' }} />
    </PointAnnotation>
  </PointAnnotationManager>
</MapView>
```

Or run `Annotations › PointAnnotationManager Multiple` in the example app.
</details>
