### PR TITLE
fix(Viewport): allow transitionTo without an explicit transition on iOS

### DIFF
--- a/ios/RNMBX/RNMBXViewport.swift
+++ b/ios/RNMBX/RNMBXViewport.swift
@@ -274,11 +274,8 @@ open class RNMBXViewport : UIView, RNMBXMapAndMapViewComponent, ViewportStatusOb
       Logger.log(level:.error, message: "no viewport")
       return nil
     }
-    guard let kind = from["kind"] as? String else {
-      Logger.log(level:.error, message: "no kind found in state")
-      return nil
-    }
-    
+    let kind = from["kind"] as? String ?? "default"
+
     switch (kind) {
     case "immediate":
       return viewport.makeImmediateViewportTransition()
@@ -290,7 +287,7 @@ open class RNMBXViewport : UIView, RNMBXMapAndMapViewComponent, ViewportStatusOb
       return viewport.makeDefaultViewportTransition(
         options: options
       )
-        
+
     default:
       Logger.log(level:.error, message: "unexpected transition kind: \(kind)")
       return nil


### PR DESCRIPTION
## Description

Fixes #4226

`Viewport.transitionTo(state, transition?)` types the transition as optional, and Android already handles a missing transition (falls back to Mapbox's default). On iOS, though, `toTransition` guarded on the transition's `kind` and returned `nil` when it was absent, so `transitionTo` aborted with a non-descriptive `Mapbox [error] no kind found in state` and never ran the transition.

This defaults to the `default` transition when no `kind` is provided, matching Android and the TypeScript types.

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [x] I have tested the new feature on `/example` app.
  - [x] In V11 mode/ios
  - [x] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

Verified on the iOS example (New Arch, Mapbox v11). Before the fix, calling `transitionTo({ kind: 'followPuck' })` with no transition logged:

```
Mapbox [error] no kind found in state
Mapbox [error] unable to parse transition in RNMBXViewport.transitionTo
```

After the fix the transition runs and resolves (`transitionTo completed: true`); the camera transitions to follow the puck.

## Component to reproduce the issue you're fixing

<details>
<summary>Reproducer</summary>

```jsx
import React, { useEffect, useRef } from 'react';
import { MapView, Viewport } from '@rnmapbox/maps';

function BugReport() {
  const viewportRef = useRef<Viewport>(null);

  useEffect(() => {
    // transition is optional per the TS types; on iOS this previously
    // failed with "no kind found in state" instead of using the default.
    viewportRef.current?.transitionTo({ kind: 'followPuck' });
  }, []);

  return (
    <MapView style={{ flex: 1 }}>
      <Viewport ref={viewportRef} />
    </MapView>
  );
}
```

</details>
