### PR TITLE
fix(offline): serialize tileRegionPacks access on main thread, keep OfflineManager alive until tasks complete

### DIFF
--- a/ios/RNMBX/Offline/RNMBXOfflineModule.swift
+++ b/ios/RNMBX/Offline/RNMBXOfflineModule.swift
@@ -195,55 +195,63 @@ class RNMBXOfflineModule: RCTEventEmitter {
   func getPackStatus(_ name: String,
                      resolver: @escaping RCTPromiseResolveBlock,
                      rejecter: @escaping RCTPromiseRejectBlock) {
-    guard tileRegionPacks[name] != nil else {
-      rejecter("RNMBXOfflineModule.getPackStatus", "pack \(name) not found", nil)
-      return
-    }
-    
-    tileStore.tileRegion(forId: name) { result in
-      switch result {
-      case .success(let region):
-        self.tileStore.tileRegionMetadata(forId: name) { result in
-          switch result {
-          case .success(let metadata):
-            let pack = TileRegionPack(
-              name: name,
-              progress: self.toProgress(region: region),
-              metadata: logged("RNMBXOfflineModule.getPackStatus") { metadata as? [String:Any] } ?? [:]
-            )
-            self.tileRegionPacks[name] = pack
-            resolver(self._makeRegionStatusPayload(pack: pack))
-          case .failure(let error):
-            Logger.log(level:.error, message: "Unable to fetch metadata for \(name)")
-            rejecter("RNMBXOfflineModule.getPackStatus", error.localizedDescription, error)
+    DispatchQueue.main.async {
+      guard self.tileRegionPacks[name] != nil else {
+        rejecter("RNMBXOfflineModule.getPackStatus", "pack \(name) not found", nil)
+        return
+      }
+
+      self.tileStore.tileRegion(forId: name) { result in
+        switch result {
+        case .success(let region):
+          self.tileStore.tileRegionMetadata(forId: name) { result in
+            DispatchQueue.main.async {
+              switch result {
+              case .success(let metadata):
+                let pack = TileRegionPack(
+                  name: name,
+                  progress: self.toProgress(region: region),
+                  metadata: logged("RNMBXOfflineModule.getPackStatus") { metadata as? [String:Any] } ?? [:]
+                )
+                self.tileRegionPacks[name] = pack
+                resolver(self._makeRegionStatusPayload(pack: pack))
+              case .failure(let error):
+                Logger.log(level:.error, message: "Unable to fetch metadata for \(name)")
+                rejecter("RNMBXOfflineModule.getPackStatus", error.localizedDescription, error)
+              }
+            }
           }
+        case .failure(let error):
+          Logger.log(level:.error, message: "Unable to fetch region for \(name)")
+          rejecter("RNMBXOfflineModule.getPackStatus", error.localizedDescription, error)
         }
-      case .failure(let error):
-        Logger.log(level:.error, message: "Unable to fetch region for \(name)")
-        rejecter("RNMBXOfflineModule.getPackStatus", error.localizedDescription, error)
       }
     }
   }
   
   @objc
-  func resumePackDownload(_ name: String, resolver: RCTPromiseResolveBlock, rejecter: RCTPromiseRejectBlock)
+  func resumePackDownload(_ name: String, resolver: @escaping RCTPromiseResolveBlock, rejecter: @escaping RCTPromiseRejectBlock)
   {
-    if let pack = tileRegionPacks[name] {
-      startLoading(pack: pack)
-      resolver(nil)
-    } else {
-      rejecter("resumePackDownload", "Unknown offline pack: \(name)", nil)
+    DispatchQueue.main.async {
+      if let pack = self.tileRegionPacks[name] {
+        self.startLoading(pack: pack)
+        resolver(nil)
+      } else {
+        rejecter("resumePackDownload", "Unknown offline pack: \(name)", nil)
+      }
     }
   }
   
   @objc
-  func pausePackDownload(_ name: String, resolver: RCTPromiseResolveBlock, rejecter: RCTPromiseRejectBlock)
+  func pausePackDownload(_ name: String, resolver: @escaping RCTPromiseResolveBlock, rejecter: @escaping RCTPromiseRejectBlock)
   {
-    if let pack = tileRegionPacks[name] {
-      pack.cancelables.forEach { $0.cancel() }
-      resolver(nil)
-    } else {
-      rejecter("pausePackDownload", "Unknown offline region: \(name)", nil)
+    DispatchQueue.main.async {
+      if let pack = self.tileRegionPacks[name] {
+        pack.cancelables.forEach { $0.cancel() }
+        resolver(nil)
+      } else {
+        rejecter("pausePackDownload", "Unknown offline region: \(name)", nil)
+      }
     }
   }
   
@@ -255,20 +263,22 @@ class RNMBXOfflineModule: RCTEventEmitter {
   
   @objc
   func deletePack(_ name: String,
-                  resolver: RCTPromiseResolveBlock,
-                  rejecter: RCTPromiseRejectBlock)
+                  resolver: @escaping RCTPromiseResolveBlock,
+                  rejecter: @escaping RCTPromiseRejectBlock)
   {
-    guard let pack = tileRegionPacks[name] else {
-      return resolver(nil)
+    DispatchQueue.main.async {
+      guard let pack = self.tileRegionPacks[name] else {
+        return resolver(nil)
+      }
+
+      guard pack.state != .invalid else {
+        return rejecter("deletePack", "Pack: \(name) has already been deleted", nil)
+      }
+
+      self.tileStore.removeTileRegion(forId: name)
+      self.tileRegionPacks[name]!.state = .invalid
+      resolver(nil)
     }
-    
-    guard pack.state != .invalid else {
-      return rejecter("deletePack", "Pack: \(name) has already been deleted", nil)
-    }
-    
-    tileStore.removeTileRegion(forId: name)
-    tileRegionPacks[name]!.state = .invalid
-    resolver(nil)
   }
   
   @objc
@@ -358,7 +368,11 @@ class RNMBXOfflineModule: RCTEventEmitter {
     let threadedOfflineManager = OfflineManager()
     taskGroup.enter()
     let stylePackTask = threadedOfflineManager.loadStylePack(for: styleURI, loadOptions: stylePackLoadOptions) { progress in
-      self.tileRegionPacks[id]!.state = .active
+      // progress callbacks arrive on SDK background threads; tileRegionPacks
+      // is main-thread state (see #4252)
+      DispatchQueue.main.async {
+        self.tileRegionPacks[id]!.state = .active
+      }
     } completion: { result in
       DispatchQueue.main.async {
         defer {
@@ -396,10 +410,14 @@ class RNMBXOfflineModule: RCTEventEmitter {
     taskGroup.enter()
     let task = self.tileStore.loadTileRegion(forId: id, loadOptions: loadOptions!, progress: {
       progress in
-      lastProgress = progress
-      self.tileRegionPacks[id]!.progress = progress
-      self.tileRegionPacks[id]!.state = .active
-      self.offlinePackProgressDidChange(progress: progress, metadata: metadata, state: .active)
+      // delivered on the "MB TileStore RW" thread; mutating tileRegionPacks
+      // here races the main thread and corrupts the dictionary (#4252)
+      DispatchQueue.main.async {
+        lastProgress = progress
+        self.tileRegionPacks[id]!.progress = progress
+        self.tileRegionPacks[id]!.state = .active
+        self.offlinePackProgressDidChange(progress: progress, metadata: metadata, state: .active)
+      }
     }) { result in
         DispatchQueue.main.async {
             defer {
@@ -427,6 +445,9 @@ class RNMBXOfflineModule: RCTEventEmitter {
     taskGroup.notify(queue: .main) {
       self.tileRegionPacks[id]!.cancelables = []
       self.tileRegionPacks[id]!.state = downloadError ? .inactive : .complete
+      // the style pack load and the tileset descriptor are tied to this
+      // manager; it must outlive the in-flight work (#4252)
+      withExtendedLifetime(threadedOfflineManager) {}
     }
 
     self.tileRegionPacks[id]!.cancelables = [task, stylePackTask]
@@ -442,13 +463,17 @@ class RNMBXOfflineModule: RCTEventEmitter {
       taskGroup.enter()
       taskGroup.enter()
       tileStore.tileRegionGeometry(forId: region.id) { (result) in
-        geomteryResults[region.id] = (result, region)
-        taskGroup.leave()
+        DispatchQueue.main.async {
+          geomteryResults[region.id] = (result, region)
+          taskGroup.leave()
+        }
       }
-      
+
       tileStore.tileRegionMetadata(forId: region.id) { (result) in
-        metadataResults[region.id] = result
-        taskGroup.leave()
+        DispatchQueue.main.async {
+          metadataResults[region.id] = result
+          taskGroup.leave()
+        }
       }
     }
     


### PR DESCRIPTION
## Description

Fixes #4252

The SIGABRT reported in #4252 ("object deallocated with non-zero retain count", in a closure in `startLoading`) turned out to be a data race on `tileRegionPacks`: the `loadStylePack`/`loadTileRegion` progress callbacks are delivered on Mapbox SDK background threads (`com.mapbox.common.MB TileStore RW`) and mutated the dictionary concurrently with the main thread. Crash reports from the reproducer below show both threads inside the `tileRegionPacks` setter/subscript at the moment of the abort (also seen as malloc "pointer being freed was not allocated"). The progress closures now hop to the main queue, as the completion handlers already did. The RCT entry points that touch the same state (`getPackStatus`, `resumePackDownload`, `pausePackDownload`, `deletePack` — these run on the module's background method queue) and `convertRegionsToJSON`'s TileStore callbacks are serialized on main as well.

The issue's original finding is also addressed: the function-local `OfflineManager` was deallocated ~0ms after `startLoading` returned (instrumentation showed deinit before the style pack completion in 910/914 packs), so `taskGroup.notify` now holds it via `withExtendedLifetime` until both tasks complete.

Verification with the reproducer below on the iOS simulator: unfixed build crashed 3 times within minutes (by ~1,400 packs); fixed build ran 10,341 packs in ~9 minutes with no crash, and the manager outlived its tasks in 3,402/3,402 observed packs.

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [x] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [x] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Component to reproduce the issue you're fixing

<details>
<summary>Hammer reproducer — put into <code>example/src/examples/BugReportExample.js</code>, open "Bug Report Template", press Start; the unfixed build aborts within a few minutes</summary>

```jsx
import React from 'react';
import { Button, SafeAreaView, ScrollView, Text, View } from 'react-native';
import { MapView, Camera, offlineManager } from '@rnmapbox/maps';

// Reproducer for https://github.com/rnmapbox/maps/issues/4252
// Hammers createPack so the SDK's background-thread progress callbacks race
// main-thread access to tileRegionPacks. A nonexistent style makes
// loadStylePack fail fast, which tightens the timing.

const styles = {
  mapView: { flex: 1 },
  panel: { padding: 10, gap: 4 },
  counters: { fontFamily: 'Menlo', fontSize: 12 },
};

const BOUNDS = [
  [14.6, 35.8],
  [14.4, 35.9],
];

class BugReportExample extends React.Component {
  state = {
    running: false,
    created: 0,
    completed: 0,
    errors: 0,
    progressEvents: 0,
    lastError: null,
  };

  packSeq = 0;

  componentWillUnmount() {
    this.stop();
  }

  start = () => {
    this.setState({ running: true }, () => {
      this.timer = setInterval(this.tick, 250);
    });
  };

  stop = () => {
    clearInterval(this.timer);
    this.timer = null;
    this.setState({ running: false });
  };

  tick = () => {
    // burst of packs per tick; alternate a real style (fast-completes once
    // cached) with a nonexistent one (fails early)
    for (let i = 0; i < 5; i++) {
      const seq = this.packSeq++;
      const name = `repro-4252-${seq}`;
      const styleURL =
        seq % 2 === 0
          ? 'mapbox://styles/mapbox/streets-v12'
          : 'mapbox://styles/mapbox/nonexistent-repro-4252';
      offlineManager
        .createPack(
          {
            name,
            styleURL,
            bounds: BOUNDS,
            minZoom: 10,
            maxZoom: 10,
          },
          (pack, status) => {
            if (status.percentage === 100) {
              this.setState((s) => ({ completed: s.completed + 1 }));
            } else {
              this.setState((s) => ({ progressEvents: s.progressEvents + 1 }));
            }
          },
          (pack, err) => {
            this.setState((s) => ({
              errors: s.errors + 1,
              lastError: String(err?.message ?? err),
            }));
          },
        )
        .then(() => {
          this.setState((s) => ({ created: s.created + 1 }));
          setTimeout(() => {
            offlineManager.deletePack(name).catch(() => {});
          }, 3000);
        })
        .catch((e) => {
          this.setState((s) => ({
            errors: s.errors + 1,
            lastError: String(e?.message ?? e),
          }));
        });
    }
  };

  render() {
    const { running, created, completed, errors, progressEvents, lastError } =
      this.state;
    return (
      <SafeAreaView style={{ flex: 1 }}>
        <View style={styles.panel}>
          <Button
            title={running ? 'Stop' : 'Start hammering createPack'}
            onPress={running ? this.stop : this.start}
          />
          <Text style={styles.counters} testID="counters">
            created={created} completed={completed} errors={errors}{' '}
            progress={progressEvents}
          </Text>
          {lastError ? (
            <ScrollView style={{ maxHeight: 60 }}>
              <Text style={styles.counters}>lastError: {lastError}</Text>
            </ScrollView>
          ) : null}
        </View>
        <MapView style={styles.mapView}>
          <Camera
            defaultSettings={{ centerCoordinate: [14.5, 35.85], zoomLevel: 9 }}
          />
        </MapView>
      </SafeAreaView>
    );
  }
}

export default BugReportExample;
```

</details>

<details>
<summary>Crash stacks from the unfixed build (3 aborts within ~7 min)</summary>

Main thread aborting while the TileStore thread is in the same dictionary:

```
Thread 0 (main), SIGABRT:
  swift_deallocClassInstance.cold.1   ("deallocated with non-zero retain count")
  RNMBXOfflineModule.tileRegionPacks.setter
  closure #1 in RNMBXOfflineModule.startLoading(pack:)   <- loadStylePack progress
  thunk for MBMStylePackLoadProgress

Thread 15 "com.mapbox.common.MB TileStore RW" (concurrent):
  Dictionary.subscript.modify / _NativeDictionary.copy()
  closure #3 in RNMBXOfflineModule.startLoading(pack:)   <- loadTileRegion progress
  thunk for MBXTileRegionLoadProgress
```

And the TileStore thread itself aborting on the corrupted heap:

```
Thread 15 "com.mapbox.common.MB TileStore RW", SIGABRT:
  ___BUG_IN_CLIENT_OF_LIBMALLOC_POINTER_BEING_FREED_WAS_NOT_ALLOCATED
  _swift_release_dealloc
  RNMBXOfflineModule.tileRegionPacks.setter
  closure #3 in RNMBXOfflineModule.startLoading(pack:)
```

</details>
