### PR TITLE
chore: upgrade packages to match peer dependency contract

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -43,7 +43,7 @@
     "react-native-safe-area-context": "^5.6.1",
     "react-native-screens": "^4.15.2",
     "react-native-vector-icons": "^10.3.0",
-    "react-native-worklets": "^0.8.3"
+    "react-native-worklets": "^0.11.0"
   },
   "optionalDependencies": {
     "@expo/metro-runtime": "~6.1.2",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "ejs-lint": "^2.0.1",
     "eslint": "^9.35.0",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-jest": "^27.9.0",
+    "eslint-plugin-jest": "^28.0.0",
     "eslint-plugin-prettier": "^5.5.4",
     "expo": "^54.0.10",
     "expo-module-scripts": "^5.0.7",


### PR DESCRIPTION
## Description

Chore to address peer dependency warnings when doing a fresh repo install. This aligns `eslint-plugin-jest` and `react-native-worklets` against `eslint` and `react-native-reanimated` versions respectively.

Quick scoping out of the above package changelogs suggest its probably a safe upgrade

- `react-native-worklets` ^0.11.0 satisfies reanimated's 0.10.x - 0.11.x range
- `eslint-plugin-jest` ^28.0.0 satisfies `eslint` ^7||^8||^9

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [x] I have tested the new feature on `/example` app.
  - [x] In V11 mode/ios
  - [x] In New Architecture mode/ios
  - [x] In V11 mode/android
  - [x] In New Architecture mode/android
