### PR TITLE
fix(android): MarkerView no longer blocks map pan/pinch (new arch)

### DIFF
--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerView.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerView.kt
@@ -35,6 +35,7 @@ class RNMBXMarkerView(context: Context?, private val mManager: RNMBXMarkerViewMa
     private var mAllowOverlapWithPuck = false
     private var mIsSelected = false
     private var mPointerEvents: PointerEvents = PointerEvents.AUTO
+    private var mStopGesturePropagation = false
 
     fun setCoordinate(point: Point?) {
         mCoordinate = point
@@ -70,9 +71,15 @@ class RNMBXMarkerView(context: Context?, private val mManager: RNMBXMarkerViewMa
         (mView as? RNMBXMarkerViewContent)?.setExternalPointerEvents(pointerEvents)
     }
 
+    fun setStopGesturePropagation(stop: Boolean) {
+        mStopGesturePropagation = stop
+        (mView as? RNMBXMarkerViewContent)?.setStopGesturePropagation(stop)
+    }
+
     override fun addView(childView: View, childPosition: Int) {
         mView = childView
         (childView as? RNMBXMarkerViewContent)?.setExternalPointerEvents(mPointerEvents)
+        (childView as? RNMBXMarkerViewContent)?.setStopGesturePropagation(mStopGesturePropagation)
         // Note: Do not call this method on `super`. The view is added manually.
     }
 
@@ -176,6 +183,34 @@ class RNMBXMarkerView(context: Context?, private val mManager: RNMBXMarkerViewMa
             }
             didAddToMap = false
         }
+    }
+
+    // endregion
+
+    // region Hit testing
+
+    /**
+     * Whether the given absolute screen coordinate (physical pixels, as from
+     * `View.getLocationOnScreen`) falls within this marker's on-screen content view. Used by the
+     * map's tap handling to stop a tap on a marker from selecting features/pins underneath it.
+     * Returns false for `pointerEvents="none"`/`"box-none"` markers, whose container is meant to
+     * be transparent to touches (taps on box-none children never reach the map anyway).
+     */
+    fun containsScreenPoint(screenX: Float, screenY: Float): Boolean {
+        if (!didAddToMap ||
+            mPointerEvents == PointerEvents.NONE ||
+            mPointerEvents == PointerEvents.BOX_NONE
+        ) {
+            return false
+        }
+        val view = mView ?: return false
+        if (view.visibility != View.VISIBLE || view.width == 0 || view.height == 0) {
+            return false
+        }
+        val loc = IntArray(2)
+        view.getLocationOnScreen(loc)
+        return screenX >= loc[0] && screenX <= loc[0] + view.width &&
+            screenY >= loc[1] && screenY <= loc[1] + view.height
     }
 
     // endregion

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewContent.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewContent.kt
@@ -2,6 +2,7 @@ package com.rnmapbox.rnmbx.components.annotation
 
 import android.content.Context
 import android.view.MotionEvent
+import android.view.View
 import android.view.View.MeasureSpec
 import android.view.ViewGroup
 import com.facebook.react.bridge.Arguments
@@ -14,9 +15,14 @@ import com.rnmapbox.rnmbx.components.camera.BaseEvent
 class RNMBXMarkerViewContent(context: Context): ReactViewGroup(context) {
     var inAdd: Boolean = false
     private var externalPointerEvents: PointerEvents = PointerEvents.AUTO
+    private var stopGesturePropagation: Boolean = false
 
     fun setExternalPointerEvents(pointerEvents: PointerEvents) {
         externalPointerEvents = pointerEvents
+    }
+
+    fun setStopGesturePropagation(stop: Boolean) {
+        stopGesturePropagation = stop
     }
 
     // Track last reported translation to avoid feedback loop:
@@ -38,15 +44,59 @@ class RNMBXMarkerViewContent(context: Context): ReactViewGroup(context) {
         if (externalPointerEvents == PointerEvents.NONE) {
             return false
         }
-        // On ACTION_DOWN, tell the parent MapView not to intercept subsequent MOVE/UP
-        // events for pan/zoom recognition — that would send CANCEL to child Pressables
-        // and suppress onPress. Android resets the disallow flag on each new DOWN, so
-        // calling this once per gesture is sufficient. See maplibre-react-native#1289.
-        if (ev.actionMasked == MotionEvent.ACTION_DOWN) {
+        // Decide, at the start of each gesture, who owns it:
+        //
+        // - If the touch lands on a scrollable descendant (ScrollView, FlatList, ViewPager, …),
+        //   ask the map not to intercept so the child keeps the whole gesture and can scroll.
+        //   The map is an ancestor, so its onInterceptTouchEvent runs before the child's — without
+        //   this the map would steal the drag on its own touch slop before the child could claim it.
+        // - Otherwise we leave interception alone. Taps still reach child Pressables (Mapbox uses
+        //   its own touch slop, so a tap is not intercepted), while a pan/pinch that merely starts
+        //   on the marker reaches the map — instead of the marker being a dead zone (issue #4255).
+        //
+        // Note: scrollable detection cannot help children that handle drags purely in JS
+        // (PanResponder, e.g. some sliders); they never claim the native gesture, so the map takes
+        // over once the drag passes its slop. For those, set `stopGesturePropagation` on the
+        // MarkerView to keep every gesture inside the marker. Android resets the disallow flag on
+        // each new ACTION_DOWN.
+        if (ev.actionMasked == MotionEvent.ACTION_DOWN &&
+            (stopGesturePropagation || touchStartsOnScrollableChild(ev.rawX, ev.rawY))
+        ) {
             parent?.requestDisallowInterceptTouchEvent(true)
         }
         return super.dispatchTouchEvent(ev)
     }
+
+    private fun touchStartsOnScrollableChild(rawX: Float, rawY: Float): Boolean =
+        anyScrollableContains(this, rawX, rawY)
+
+    private fun anyScrollableContains(view: View, rawX: Float, rawY: Float): Boolean {
+        if (view.visibility != View.VISIBLE) {
+            return false
+        }
+        val loc = IntArray(2)
+        view.getLocationOnScreen(loc)
+        val inside = rawX >= loc[0] && rawX <= loc[0] + view.width &&
+            rawY >= loc[1] && rawY <= loc[1] + view.height
+        if (!inside) {
+            return false
+        }
+        if (view !== this && view.isScrollable()) {
+            return true
+        }
+        if (view is ViewGroup) {
+            for (i in 0 until view.childCount) {
+                if (anyScrollableContains(view.getChildAt(i), rawX, rawY)) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    private fun View.isScrollable(): Boolean =
+        canScrollHorizontally(1) || canScrollHorizontally(-1) ||
+            canScrollVertically(1) || canScrollVertically(-1)
 
     override fun setTranslationX(translationX: Float) {
         super.setTranslationX(translationX)

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewManager.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/annotation/RNMBXMarkerViewManager.kt
@@ -75,6 +75,11 @@ class RNMBXMarkerViewManager(reactApplicationContext: ReactApplicationContext) :
         markerView.setIsSelected(isSelected.asBoolean())
     }
 
+    @ReactProp(name = "stopGesturePropagation")
+    override fun setStopGesturePropagation(markerView: RNMBXMarkerView, value: Dynamic) {
+        markerView.setStopGesturePropagation(!value.isNull && value.asBoolean())
+    }
+
     override fun updateProperties(viewToUpdate: RNMBXMarkerView, props: ReactStylesDiffMap) {
         super.updateProperties(viewToUpdate, props)
         // The codegen delegate does not forward the standard `pointerEvents` ViewProp — it falls

--- a/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapView.kt
+++ b/android/src/main/java/com/rnmapbox/rnmbx/components/mapview/RNMBXMapView.kt
@@ -725,6 +725,12 @@ open class RNMBXMapView(private val mContext: Context, var mManager: RNMBXMapVie
             }
         }
         val screenPointPx = mMap?.pixelForCoordinate(point)
+        // A tap that reaches the map but lands within a MarkerView (e.g. on a non-interactive
+        // part of it) should be absorbed by the marker, not fall through to touchable sources
+        // (symbol/shape layers) or pins underneath it. See #4255 discussion.
+        if (screenPointPx != null && isPointOnMarkerView(screenPointPx)) {
+            return true
+        }
         val touchableSources = allTouchableSources
         val hits = HashMap<String?, List<Feature?>?>()
         if (screenPointPx != null) {
@@ -750,6 +756,23 @@ open class RNMBXMapView(private val mContext: Context, var mManager: RNMBXMapVie
             })
         }
         return false
+    }
+
+    /**
+     * Whether the given map-surface coordinate (physical pixels, from `pixelForCoordinate`) lands
+     * within any `MarkerView` currently on the map. Converts to absolute screen coordinates so it
+     * can be compared against each marker view's `getLocationOnScreen` bounds.
+     */
+    private fun isPointOnMarkerView(screenPointPx: ScreenCoordinate): Boolean {
+        val markerViews = mFeatures.mapNotNull { it.feature as? RNMBXMarkerView }
+        if (markerViews.isEmpty()) {
+            return false
+        }
+        val mapLoc = IntArray(2)
+        mapView.getLocationOnScreen(mapLoc)
+        val absX = mapLoc[0] + screenPointPx.x.toFloat()
+        val absY = mapLoc[1] + screenPointPx.y.toFloat()
+        return markerViews.any { it.containsScreenPoint(absX, absY) }
     }
 
     override fun onMapLongClick(point: Point): Boolean {

--- a/docs/MarkerView.md
+++ b/docs/MarkerView.md
@@ -80,6 +80,24 @@ FIX ME NO DESCRIPTION
   _defaults to:_ `false`
 
   
+### stopGesturePropagation
+
+```tsx
+boolean
+```
+Keep pan/pinch/drag gestures that start on this marker inside the marker instead of
+letting them reach the map. Enable this for markers whose children handle their own
+drags in JavaScript (e.g. a PanResponder-based slider), which otherwise race the map's
+pan/zoom recogniser and can be taken over by the map. By default the marker is smart:
+taps and native scrollables are kept, but a pan/pinch that merely starts on the marker
+moves the map. Defaults to false.
+
+@platform android — on iOS the map's gesture recognisers already coexist with marker
+content, so this has no effect.
+
+  _defaults to:_ `false`
+
+  
 ### children
 
 ```tsx

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -5818,6 +5818,13 @@
         "description": "FIX ME NO DESCRIPTION"
       },
       {
+        "name": "stopGesturePropagation",
+        "required": false,
+        "type": "boolean",
+        "default": "false",
+        "description": "Keep pan/pinch/drag gestures that start on this marker inside the marker instead of\nletting them reach the map. Enable this for markers whose children handle their own\ndrags in JavaScript (e.g. a PanResponder-based slider), which otherwise race the map's\npan/zoom recogniser and can be taken over by the map. By default the marker is smart:\ntaps and native scrollables are kept, but a pan/pinch that merely starts on the marker\nmoves the map. Defaults to false.\n\n@platform android — on iOS the map's gesture recognisers already coexist with marker\ncontent, so this has no effect."
+      },
+      {
         "name": "children",
         "required": true,
         "type": "ReactReactElement",

--- a/example/src/examples/Annotations/MarkerView.tsx
+++ b/example/src/examples/Annotations/MarkerView.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Button,
   Pressable,
+  ScrollView,
   StyleSheet,
   Switch,
   Text,
@@ -278,6 +279,9 @@ const ShowMarkerView = () => {
     React.useState<boolean>(false);
 
   const [mapMoveCount, setMapMoveCount] = React.useState(0);
+  const [featurePressCount, setFeaturePressCount] = React.useState(0);
+  const [scrollCount, setScrollCount] = React.useState(0);
+  const [stopGesture, setStopGesture] = React.useState(false);
 
   const onPressMap = (e: GeoJSON.Feature) => {
     const geometry = e.geometry as GeoJSON.Point;
@@ -287,6 +291,22 @@ const ShowMarkerView = () => {
   const onRegionDidChange = React.useCallback(() => {
     setMapMoveCount((c) => c + 1);
   }, []);
+
+  // A tappable circle sitting directly under the first MarkerView, to demonstrate that a tap on
+  // the marker does not fall through and select the feature beneath it (#4255).
+  const underMarkerShape = React.useMemo<GeoJSON.FeatureCollection>(
+    () => ({
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: { type: 'Point', coordinates: pointList[0]! },
+        },
+      ],
+    }),
+    [pointList],
+  );
 
   return (
     <>
@@ -306,7 +326,19 @@ const ShowMarkerView = () => {
         }
         onPress={() => setPointerEventsNone((prev) => !prev)}
       />
-      <Mapbox.MapView onPress={onPressMap} onRegionDidChange={onRegionDidChange} style={styles.matchParent}>
+      <Button
+        title={
+          stopGesture
+            ? 'stopGesturePropagation ON – slider marker keeps gestures'
+            : 'stopGesturePropagation OFF – slider drag may pan map'
+        }
+        onPress={() => setStopGesture((prev) => !prev)}
+      />
+      <Mapbox.MapView
+        onPress={onPressMap}
+        onRegionDidChange={onRegionDidChange}
+        style={styles.matchParent}
+      >
         <Mapbox.Camera
           defaultSettings={{
             zoomLevel: 16,
@@ -318,6 +350,17 @@ const ShowMarkerView = () => {
           <AnnotationContent title={'this is a point annotation'} />
         </Mapbox.PointAnnotation>
 
+        <Mapbox.ShapeSource
+          id="under-marker-src"
+          shape={underMarkerShape}
+          onPress={() => setFeaturePressCount((c) => c + 1)}
+        >
+          <Mapbox.CircleLayer
+            id="under-marker-circle"
+            style={{ circleRadius: 44, circleColor: 'rgba(255,0,0,0.35)' }}
+          />
+        </Mapbox.ShapeSource>
+
         <Mapbox.MarkerView
           coordinate={pointList[0]!}
           allowOverlapWithPuck={allowOverlapWithPuck}
@@ -327,9 +370,54 @@ const ShowMarkerView = () => {
         </Mapbox.MarkerView>
 
         <Mapbox.MarkerView
+          coordinate={pointList[1]!}
+          anchor={{ x: 0.5, y: 1.3 }}
+          allowOverlap
+        >
+          <View
+            collapsable={false}
+            style={{
+              width: 180,
+              height: 54,
+              backgroundColor: 'white',
+              borderRadius: 8,
+              borderWidth: 1,
+              borderColor: '#333',
+            }}
+          >
+            <ScrollView
+              horizontal
+              onScroll={() => setScrollCount((c) => c + 1)}
+              scrollEventThrottle={16}
+              showsHorizontalScrollIndicator
+            >
+              {Array.from({ length: 12 }).map((_, i) => (
+                <View
+                  key={i}
+                  style={{
+                    width: 50,
+                    height: 50,
+                    margin: 2,
+                    borderRadius: 6,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    backgroundColor: `hsl(${i * 30}, 70%, 60%)`,
+                  }}
+                >
+                  <Text style={{ color: 'white', fontWeight: 'bold' }}>
+                    {i}
+                  </Text>
+                </View>
+              ))}
+            </ScrollView>
+          </View>
+        </Mapbox.MarkerView>
+
+        <Mapbox.MarkerView
           coordinate={INITIAL_COORDINATES[2]!}
           allowOverlap
           allowOverlapWithPuck={allowOverlapWithPuck}
+          stopGesturePropagation={stopGesture}
         >
           <InteractiveMarkerContent />
         </Mapbox.MarkerView>
@@ -349,6 +437,8 @@ const ShowMarkerView = () => {
 
       <Bubble>
         <Text>Map moved: {mapMoveCount} times</Text>
+        <Text>Feature (under marker) pressed: {featurePressCount} times</Text>
+        <Text>ScrollView scrolled: {scrollCount} events</Text>
         <Text>Tap on map to add a point annotation</Text>
       </Bubble>
     </>
@@ -362,7 +452,13 @@ export default ShowMarkerView;
 /** @type ExampleWithMetadata['metadata'] */
 const metadata = {
   title: 'Marker View',
-  tags: ['PointAnnotation', 'MarkerView', 'Slider', 'Interactive', 'pointerEvents'],
+  tags: [
+    'PointAnnotation',
+    'MarkerView',
+    'Slider',
+    'Interactive',
+    'pointerEvents',
+  ],
   docs: `
 Shows marker view and point annotations, including an interactive marker with
 sliders, switch, counter, text input, and pressable button to verify complex

--- a/src/components/MarkerView.tsx
+++ b/src/components/MarkerView.tsx
@@ -45,6 +45,19 @@ type Props = ViewProps & {
   isSelected?: boolean;
 
   /**
+   * Keep pan/pinch/drag gestures that start on this marker inside the marker instead of
+   * letting them reach the map. Enable this for markers whose children handle their own
+   * drags in JavaScript (e.g. a PanResponder-based slider), which otherwise race the map's
+   * pan/zoom recogniser and can be taken over by the map. By default the marker is smart:
+   * taps and native scrollables are kept, but a pan/pinch that merely starts on the marker
+   * moves the map. Defaults to false.
+   *
+   * @platform android — on iOS the map's gesture recognisers already coexist with marker
+   * content, so this has no effect.
+   */
+  stopGesturePropagation?: boolean;
+
+  /**
    * One or more valid React Native views. You can use Pressable, TouchableOpacity,
    * etc. directly as children — onPress and touch feedback work correctly.
    */
@@ -73,6 +86,7 @@ const MarkerView = ({
   coordinate,
   style,
   pointerEvents,
+  stopGesturePropagation = false,
   children,
 }: Props) => {
   // Android new-arch (Fabric) fix: UIManager.measure reads from the Fabric shadow
@@ -157,6 +171,7 @@ const MarkerView = ({
       allowOverlapWithPuck={allowOverlapWithPuck}
       isSelected={isSelected}
       pointerEvents={pointerEvents}
+      stopGesturePropagation={stopGesturePropagation}
       onTouchEnd={handleTouchEnd}
     >
       <RNMBXMakerViewContentComponent

--- a/src/specs/RNMBXMarkerViewNativeComponent.ts
+++ b/src/specs/RNMBXMarkerViewNativeComponent.ts
@@ -18,6 +18,7 @@ export interface NativeProps extends ViewProps {
   allowOverlap: UnsafeMixed<boolean>;
   allowOverlapWithPuck: UnsafeMixed<boolean>;
   isSelected: UnsafeMixed<boolean>;
+  stopGesturePropagation: UnsafeMixed<boolean>;
 }
 
 // @ts-ignore-error - Codegen requires single cast but TypeScript prefers double cast


### PR DESCRIPTION
## Description

Fixes #4255

On Android with the new architecture (Fabric), a `MarkerView` blocks map pan/pinch: a gesture that *starts* on a marker never reaches the map, so the marker acts as a dead zone. iOS is unaffected.

Root cause: a side effect of the touch fix in #4176, which called `requestDisallowInterceptTouchEvent(true)` on every `ACTION_DOWN` to keep child `Pressable`s tappable. That also stopped the map from ever seeing the gesture — and, for pinch, from seeing the second finger's `ACTION_POINTER_DOWN`.

Fix — decide gesture ownership at touch-down from what's under the finger, instead of always grabbing:

1. Touch on a **scrollable** descendant (`ScrollView`/`FlatList`/`ViewPager`, detected via `canScrollHorizontally/Vertically`) → disallow map interception so the child keeps the gesture. The map is an ancestor and would otherwise steal the drag on its own touch-slop before the child could claim it.
2. **Anything else** → leave interception alone. Taps still reach child `Pressable`s (Mapbox uses its own touch-slop, so a tap isn't intercepted), while a pan/pinch that merely starts on the marker moves the map.

Two more things:
- A tap that lands on a `MarkerView` is absorbed by the marker rather than falling through to touchable sources (symbol/shape layers) or pins underneath it. `pointerEvents="none"`/`"box-none"` markers stay transparent.
- New **`stopGesturePropagation`** prop (Android-only): children that handle drags purely in JS (PanResponder, e.g. some sliders) never claim the *native* gesture and can be taken over by the map — a nondeterministic race. Setting `stopGesturePropagation` makes the marker keep every gesture. iOS gesture recognisers already coexist with marker content, so it's a no-op there (mirrors react-native-maps' iOS-only `stopPropagation`, inverted).

Ran `yarn generate` (docs updated). Native + JS change; no style-spec changes.

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [x] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [x] In New Architecture mode/android
- [x] I added/updated a sample (`/example` Marker View: scrollable-in-marker, feature-under-marker, and a `stopGesturePropagation` toggle)

## Screenshot OR Video

Verified on a physical Android device (New Architecture), driving the same gestures before/after:

- Drag starting on a (non-scrollable) marker — before: map frozen; after: map pans.
- Tap child `Pressable`/counter — works; tap on marker over a feature — feature underneath is not selected; the same feature just outside the marker still is.
- Native `ScrollView` inside a marker — scrolls the child, map does not pan.
- `@rneui` slider (JS PanResponder) inside a marker — races the map (nondeterministic; reproduced both a clean drag and a leak on the *same* slider). With `stopGesturePropagation`, three consecutive slider drags never pan the map.
- `pointerEvents="none"` — tap/drag still passes through and selects the feature underneath.

Pinch-zoom starting on a marker zooms the map (confirmed on device) — the marker no longer grabs on DOWN for non-scrollable content, so the map sees the whole gesture including the second finger.

## Component to reproduce the issue you're fixing

<details>
<summary>Reproducer — pan-through, tap shield, scrollable, and slider opt-in</summary>

Drag on the pink marker: on the unfixed build the map doesn't move; with the fix it pans. Tapping the marker doesn't select the red circle underneath. The horizontal strip scrolls without panning the map. The `@rneui` slider may occasionally hand the drag to the map — set `stopGesturePropagation` to make it keep the gesture every time.

```tsx
import React from 'react';
import { View, Text, Pressable, ScrollView, StyleSheet } from 'react-native';
import Mapbox, { MapView, Camera, MarkerView, ShapeSource, CircleLayer } from '@rnmapbox/maps';

const CENTER: [number, number] = [-122.4194, 37.7749];

export default function MarkerViewGestureRepro(): React.JSX.Element {
  const [mapMoved, setMapMoved] = React.useState(0);
  const [featurePressed, setFeaturePressed] = React.useState(0);

  const shape: GeoJSON.FeatureCollection = {
    type: 'FeatureCollection',
    features: [{ type: 'Feature', properties: {}, geometry: { type: 'Point', coordinates: CENTER } }],
  };

  return (
    <View style={styles.container}>
      <MapView style={styles.map} onRegionDidChange={() => setMapMoved((c) => c + 1)}>
        <Camera defaultSettings={{ centerCoordinate: CENTER, zoomLevel: 13 }} />

        <ShapeSource id="under" shape={shape} onPress={() => setFeaturePressed((c) => c + 1)}>
          <CircleLayer id="under-circle" style={{ circleRadius: 60, circleColor: 'rgba(255,0,0,0.35)' }} />
        </ShapeSource>

        <MarkerView coordinate={CENTER} anchor={{ x: 0.5, y: 0.5 }} allowOverlap>
          <Pressable style={styles.marker} onPress={() => {}}>
            <Text style={styles.markerText}>TAP</Text>
          </Pressable>
        </MarkerView>

        {/* native scrollable: scrolls without panning the map */}
        <MarkerView coordinate={CENTER} anchor={{ x: 0.5, y: 2 }} allowOverlap>
          <View style={styles.strip} collapsable={false}>
            <ScrollView horizontal>
              {Array.from({ length: 12 }).map((_, i) => (
                <View key={i} style={[styles.box, { backgroundColor: `hsl(${i * 30},70%,60%)` }]}>
                  <Text style={styles.boxText}>{i}</Text>
                </View>
              ))}
            </ScrollView>
          </View>
        </MarkerView>
      </MapView>

      <View style={styles.hud} pointerEvents="none">
        <Text>Map moved: {mapMoved}</Text>
        <Text>Feature (under marker) pressed: {featurePressed}</Text>
      </View>
    </View>
  );
}

const styles = StyleSheet.create({
  container: { flex: 1 },
  map: { flex: 1 },
  hud: { position: 'absolute', bottom: 24, left: 16, backgroundColor: 'white', padding: 8, borderRadius: 8 },
  marker: { width: 64, height: 64, borderRadius: 32, backgroundColor: '#ff2d87', borderWidth: 3, borderColor: '#fff', alignItems: 'center', justifyContent: 'center' },
  markerText: { color: '#fff', fontWeight: '800' },
  strip: { width: 180, height: 54, backgroundColor: '#fff', borderRadius: 8, borderWidth: 1, borderColor: '#333' },
  box: { width: 50, height: 50, margin: 2, borderRadius: 6, alignItems: 'center', justifyContent: 'center' },
  boxText: { color: '#fff', fontWeight: 'bold' },
});
```

</details>
