### PR TITLE
fix(android): register compat Kotlin source dirs for AGP 8.9+ (RN 0.86)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -211,6 +211,18 @@ Please upgrade to Mapbox v11.x or use @rnmapbox/maps 10.2.x
                     }
                 }
 
+                // AGP 8.9+ (bundled with RN 0.86 / Gradle 8.x) no longer feeds
+                // extra java.srcDirs into the Kotlin compile task. The compat
+                // directories appended above (mapbox-v11-compat, rn-compat and the
+                // selected lifecycle-compat variant) contain only Kotlin sources,
+                // so without this they are silently skipped and their packages
+                // (e.g. com.rnmapbox.rnmbx.v11compat) fail to resolve. Mirror the
+                // Java source dirs onto the Kotlin source set to keep them compiled.
+                // Guarded by the same impl check as the `kotlin-android` plugin
+                // above, since only that impl registers the `kotlin` source set.
+                if (safeExtGet("RNMapboxMapsImpl", defaultMapboxMapsImpl) == "mapbox") {
+                    kotlin.srcDirs(java.srcDirs)
+                }
             }
         }
 


### PR DESCRIPTION
## Description

Fixes #4263 


On the React Native **0.86** Android toolchain, appending a directory to `java.srcDirs` in `android/build.gradle` no longer registers it as a Kotlin source root for the `compileKotlin` task. The compat directories added there — `mapbox-v11-compat/v11`, `rn-compat/rn75`, and the selected `lifecycle-compat/*` variant — contain **only** Kotlin sources, so they are silently skipped and their packages (e.g. `com.rnmapbox.rnmbx.v11compat`) fail to resolve, breaking the Android build.

**Fix:** after all the conditional `java.srcDirs +=` additions, mirror them onto the Kotlin source set:

```groovy
// Guarded by the same RNMapboxMapsImpl == "mapbox" check as the kotlin-android
// plugin, since only that impl registers the `kotlin` source set.
if (safeExtGet("RNMapboxMapsImpl", defaultMapboxMapsImpl) == "mapbox") {
    kotlin.srcDirs(java.srcDirs)
}
```

One placement covers every current and future compat dir.

### ⚠️ Speculative fix — reproduction caveat (per `.github/REPRODUCING.md`)

I want to be upfront rather than overclaim:

- I could **not** reproduce this in `/example` as-is: it's pinned to **RN 0.84.1** (Gradle 9.0.0 / AGP 8.9+) and builds fine there — including in `android-actions.yml` CI. So this is **not** a plain "AGP 8.9+" bug; the trigger is the **RN 0.86** toolchain specifically (its AGP + Kotlin Gradle Plugin combination). Reproducing in `/example` would require bumping it to RN 0.86.
- The bug **does** reproduce in a downstream app on **RN 0.86 / Gradle 8.14.3**, where the equivalent change (applied as a `yarn patch` to `android/build.gradle`) is what made the Android build succeed. Without it: unresolved references to the `v11compat` / `rncompat` packages. With it: clean compile.