### PR TITLE
fix(ci): pin npm@11 in publish workflow, file issue on publish failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,23 @@ jobs:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
           registry-url: 'https://registry.npmjs.org'
       - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
+        # npm 12 requires node >= 22.22.2, newer than our .nvmrc; npm 11.5.1+ has OIDC support
+        run: npm install -g npm@11
       - name: Install dependencies and build 🔧
         run: yarn install --immutable
       - name: Publish package on NPM 📦
         run: npm publish --provenance --access public ${{ github.event.release.prerelease && '--tag next' || ''}}
+  notify-failure:
+    runs-on: ubuntu-latest
+    needs: build
+    if: failure()
+    permissions:
+      issues: write
+    steps:
+      - name: Create issue about publish failure
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue create --repo "$GITHUB_REPOSITORY" \
+            --title "npm publish failed for ${{ github.event.release.tag_name }}" \
+            --body "The [Publish to NPM run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for release \`${{ github.event.release.tag_name }}\` failed. The package was not published to npm."


### PR DESCRIPTION
## Description

The v10.3.3 and v10.3.4 npm publishes both failed silently: the "Upgrade npm for OIDC support" step runs `npm install -g npm@latest`, and npm 12 now requires node >= 22.22.2 while `.nvmrc` pins 22.16.0, so the step fails with `EBADENGINE` (see [v10.3.4 run](https://github.com/rnmapbox/maps/actions/runs/29924017049), [v10.3.3 run](https://github.com/rnmapbox/maps/actions/runs/29222093900)). npm's `latest` dist-tag is still 10.3.2.

This pins `npm@11` (supports node >= 22.9.0 and has the OIDC/provenance support since 11.5.1), and adds a `notify-failure` job that opens a GitHub issue whenever the publish job fails, so a broken release no longer goes unnoticed.

Note: re-running the failed runs won't help since release-triggered workflows use the workflow file from the tagged commit; v10.3.3/v10.3.4 need to be re-released from a commit containing this fix (or superseded by a 10.3.5).

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

CI-only change; example app checklist items are not applicable.
