### PR TITLE
ci: scheduled check that latest GitHub release is published on npm

### DIFF
--- a/.github/workflows/check-npm-publish.yml
+++ b/.github/workflows/check-npm-publish.yml
@@ -1,0 +1,33 @@
+name: Check NPM Publish
+on:
+  schedule:
+    - cron: '30 6 * * *'
+  workflow_dispatch:
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Verify latest GitHub release is on npm
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name)
+          version=${tag#v}
+          if npm view "@rnmapbox/maps@$version" version > /dev/null 2>&1; then
+            echo "npm has @rnmapbox/maps@$version"
+            exit 0
+          fi
+          echo "::error::Release $tag exists on GitHub but @rnmapbox/maps@$version is not on npm"
+          title="npm publish missing for $tag"
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "\"$title\" in:title" --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            echo "Issue #$existing already open"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" \
+              --title "$title" \
+              --body "The latest GitHub release [\`$tag\`](${{ github.server_url }}/$GITHUB_REPOSITORY/releases/tag/$tag) is not published on npm (\`npm view @rnmapbox/maps@$version\` finds nothing). The publish workflow may have failed or never run. Detected by the scheduled Check NPM Publish workflow."
+          fi
+          exit 1


### PR DESCRIPTION
## Description

Adds a scheduled workflow (daily, plus manual dispatch) that checks the latest GitHub release is actually published on npm. If `npm view @rnmapbox/maps@<version>` finds nothing, it opens an issue (deduped by title, so repeated runs won't spam) and fails the run.

Complements #4265: the `notify-failure` job there covers the case where the publish workflow runs and fails, this catches the whole class including the workflow never firing. Dry-run against the current state correctly detects that v10.3.4 is missing from npm.

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [ ] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

CI-only change; example app checklist items are not applicable.
