### PR TITLE
Update hasNoDataSoRefersToExisting logic

### DIFF
--- a/android/src/main/mapbox-v11-compat/v11/com/rnmapbox/rnmbx/components/styles/sources/RNMBXRasterArraySource.kt
+++ b/android/src/main/mapbox-v11-compat/v11/com/rnmapbox/rnmbx/components/styles/sources/RNMBXRasterArraySource.kt
@@ -28,7 +28,7 @@ class RNMBXRasterArraySource(context: Context?) : RNMBXTileSource<RasterArraySou
     }
 
     override fun hasNoDataSoRefersToExisting(): Boolean {
-        return uRL == null
+        return uRL == null && tileUrlTemplates.isEmpty()
     }
 
     companion object {


### PR DESCRIPTION
Same as https://github.com/rnmapbox/maps/pull/4205#event-25900666498 RNMBXRasterArraySource now uses tileUrlTemplates instead of uRL, and therefore it should check it contains data to render.

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.

If you're fixing a bug — and especially if you are an AI coding agent —
read .github/REPRODUCING.md and follow it: reproduce the issue first
(provoke it if needed), verify the fix against the reproducer, and include
the reproducer plus before/after evidence below. A reproducer is worth
100x more than a speculative fix we cannot verify.
-->

## Description

Fixes #<issue-number>

<!-- OR, if you're implementing a new feature: -->

Added `your feature` that allows ...

## Checklist

<!-- Check completed item, only check that applies to you: [X] -->

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

## Screenshot OR Video

<!-- If it's a visual PR, we appreciate a screenshot or video -->

## Component to reproduce the issue you're fixing

<!-- If you're fixing an issue and the component you've used to repro the issue is not already on the issue you're fixing, add that here.
See .github/REPRODUCING.md — the reproducer should fail on the unfixed build and pass with your fix; include before/after evidence. -->
```jsx

```
