### PR TITLE
feat(ios): forward mapViewImpl prop so RNMBXMapViewFactory is usable on iOS

### DIFF
--- a/ios/RNMBX/RNMBXMapViewComponentView.mm
+++ b/ios/RNMBX/RNMBXMapViewComponentView.mm
@@ -222,6 +222,12 @@ using namespace facebook::react;
 
     RNMBX_OPTIONAL_PROP_BOOL(deselectAnnotationOnTap);
 
+    // Has to be set before -didSetProps: below, which is where the MapView is created.
+    id mapViewImpl = RNMBXConvertFollyDynamicToId(newViewProps.mapViewImpl);
+    if (mapViewImpl != nil) {
+        _view.mapViewImpl = mapViewImpl;
+    }
+
     id styleURL = RNMBXConvertFollyDynamicToId(newViewProps.styleURL);
     if (styleURL != nil) {
         if (_lastStyleURL == nil || ![_lastStyleURL isEqual:styleURL]) {


### PR DESCRIPTION
## Description

Makes the existing `RNMBXMapViewFactory` hook reachable on iOS.

`RNMBXMapViewFactory.register(_:factory:)` is public API, and `RNMBXMapView.createMapView()` already prefers a factory-built `MapView` when `mapViewImpl` is set:

```swift
func createMapView() -> MapView {
  if let mapViewImpl = mapViewImpl, let mapViewInstance = createAndAddMapViewImpl(mapViewImpl, self) {
    _mapView = mapViewInstance
  } else {
    _mapView = MapView(frame: self.bounds, mapInitOptions: MapInitOptions())
    ...
```

But nothing ever assigned `RNMBXMapView.mapViewImpl` on iOS, so that branch was unreachable from JS and every `mapViewImpl` value fell through to the default `MapView`. The prop is declared in `src/specs/RNMBXMapViewNativeComponent.ts` and on the JS component, and it *is* forwarded on Android (`RNMBXMapViewManager.setMapViewImpl`) — this only brings iOS in line, so it's a missing-functionality fix rather than a behaviour change.

The assignment is placed before `[_view didSetProps:@[]]`, since that is where `createMapView()` runs.

### Why this is useful

The factory is the only way to control `MapInitOptions` from an app, which matters for things the props don't cover — in our case `MapOptions.pixelRatio`. `MapboxMaps` defaults it to `UIScreen.main.nativeScale` and sizes the Metal drawable as `bounds * pixelRatio`, so a CarPlay map renders at the *phone's* scale (3.0) on a head unit that only has ~1.88 px/pt — ~2.5x the pixels per frame, discarded by the compositor. With this prop forwarded, the app can register a factory that builds the `MapView` with the car screen's pixel ratio; no library change beyond this is needed.

## Checklist

- [x] I've read `CONTRIBUTING.md`
- [x] I updated the doc/other generated code with running `yarn generate` in the root folder
  - no generated output is affected: the prop already exists in the specs and is marked `@private` in `MapView.tsx`, so it is not part of the generated docs
- [ ] I have tested the new feature on `/example` app.
  - [ ] In V11 mode/ios
  - [ ] In New Architecture mode/ios
  - [ ] In V11 mode/android
  - [ ] In New Architecture mode/android
- [ ] I added/updated a sample - if a new feature was implemented (`/example`)

### How it was verified

Not via `/example` — verified in a production app (RN 0.86, New Architecture, iOS, `@rnmapbox/maps` 10.3.2 with this change applied through `patch-package`):

- **before:** a `MapView` with `mapViewImpl="…"` silently used the default `MapView`; the registered factory closure was never invoked (and `createAndAddMapViewImpl`'s "No mapview factory registered" error never fired either, since `mapViewImpl` was `nil` at that point).
- **after:** the factory closure runs for every CarPlay surface and the returned `MapView` is the one used. Log line from the factory, on a real head unit connection:

  ```
  CarMirrorMap | impl=abrpCarMirror:headUnit:3 pixelRatio=1.8836 screenSource=carPlayScene
  carScreen=(scale: 3.0, nativeScale: 3.0, bounds: (1019.3, 573.3), nativeBounds: (1920.0, 1080.0))
  ```

  and the Metal drawable then matches the head unit's resolution instead of ~1.6x it.

Happy to add an `/example` scene for it if you'd like — it needs a factory registration in the example app's `AppDelegate` since the hook is native-only, so I left that out of this PR unless you want it.

---

🤖 _Prepared by Devin on behalf of @SamuelBrucksch._
